### PR TITLE
More portable random number generator. Addresses Issue #1

### DIFF
--- a/include/GAMER.h
+++ b/include/GAMER.h
@@ -62,6 +62,7 @@ using namespace std;
 #include "Typedef.h"
 #include "AMR.h"
 #include "Timer.h"
+#include "RandomNumber.h"
 #include "Global.h"
 #include "Prototype.h"
 #include "PhysicalConstant.h"

--- a/include/HDF5_Typedef.h
+++ b/include/HDF5_Typedef.h
@@ -108,6 +108,7 @@ struct Makefile_t
    int SupportHDF5;
    int SupportGSL;
    int SupportGrackle;
+   int RandomNumber;
 
 #  ifdef GRAVITY
    int PotScheme;

--- a/include/Macro.h
+++ b/include/Macro.h
@@ -73,6 +73,11 @@
 #define HILBERT      1
 
 
+// random number implementation
+#define RNG_GNU_EXT  1
+#define RNG_CPP11    2
+
+
 // NCOMP_FLUID : number of active components in each cell (i.e., the "fluid" array)
 //               --> do not include passive components here, which is set by NCOMP_PASSIVE
 // NFLUX_FLUID : number of active components in the "flux" array

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -559,7 +559,7 @@ void CPU_GrackleSolver_Original( grackle_field_data *Che_FieldData, code_units C
 #ifdef STAR_FORMATION
 void SF_CreateStar( const int lv, const real TimeNew, const real dt );
 void SF_FreeRNG();
-void SF_CreateStar_AGORA( const int lv, const real TimeNew, const real dt, struct drand48_data *drand_buf,
+void SF_CreateStar_AGORA( const int lv, const real TimeNew, const real dt, RandomNumber_t *RNG,
                           const real GasDensThres, const real Efficiency, const real MinStarMass, const real MaxStarMFrac,
                           const bool DetRandom, const bool UseMetal );
 #endif

--- a/include/RandomNumber.h
+++ b/include/RandomNumber.h
@@ -43,8 +43,8 @@ struct RandomNumber_t
 // data members
 // ===================================================================================
 #  if   ( RANDOM_NUMBER == RNG_CPP11 )
-   mt19937 *RNG;
-   uniform_real_distribution <double> Distribution;
+   std::mt19937 *RNG;
+   std::uniform_real_distribution <double> Distribution;
 
 #  elif ( RANDOM_NUMBER == RNG_GNU_EXT )
    struct drand48_data *RNG;
@@ -78,7 +78,7 @@ struct RandomNumber_t
 
 //    allocate RNG
 #     if   ( RANDOM_NUMBER == RNG_CPP11 )
-      RNG = new mt19937      [N];
+      RNG = new std::mt19937 [N];
 #     elif ( RANDOM_NUMBER == RNG_GNU_EXT )
       RNG = new drand48_data [N];
 #     endif

--- a/include/RandomNumber.h
+++ b/include/RandomNumber.h
@@ -1,0 +1,175 @@
+#ifndef __RANDOM_NUMBER_H__
+#define __RANDOM_NUMBER_H__
+
+
+
+#if ( RANDOM_NUMBER == RNG_CPP11 )
+#include <random>
+
+#elif ( RANDOM_NUMBER == RNG_GNU_EXT )
+#include <stdlib.h>
+
+#else
+#error : ERROR : unsupported RANDOM_NUMBER !!
+#endif
+
+void Aux_Error( const char *File, const int Line, const char *Func, const char *Format, ... );
+
+
+
+
+//-------------------------------------------------------------------------------------------------------
+// Structure   :  RandomNumber_t
+// Description :  Data structure of the random number generator (RNG)
+//
+// Note        :  1. Adopted RNG implementation is controlled by the Makefile option "RANDOM_NUMBER"
+//                   --> Currently supported options:
+//                          RNG_CPP11  : c++11 library <random>
+//                          RNG_GNU_EXT: GNU extension drand48_r
+//                2. All implementations must be thread-safe
+//
+// Data Member :  RNG          : Random number generator
+//                Distribution : Random number distribution used by RNG_CP11
+//                N_RNG        : Total number of RNG
+//
+// Method      :  RandomNumber_t : Constructor
+//               ~RandomNumber_t : Destructor
+//                GetValue       : Return random number
+//                SetSeed        : Set random seed
+//-------------------------------------------------------------------------------------------------------
+struct RandomNumber_t
+{
+
+// data members
+// ===================================================================================
+#  if   ( RANDOM_NUMBER == RNG_CPP11 )
+   mt19937 *RNG;
+   uniform_real_distribution <double> Distribution;
+
+#  elif ( RANDOM_NUMBER == RNG_GNU_EXT )
+   struct drand48_data *RNG;
+#  endif
+
+   int N_RNG;
+
+
+   //===================================================================================
+   // Constructor :  RandomNumber_t
+   // Description :  Constructor of the structure "RandomNumber_t"
+   //
+   // Note        :  1. Allocate RNG
+   //                2. Call SetSeed() to set the random seed for each RNG
+   //
+   // Parameter   :  N : Number of RNG to be initialized
+   //                    --> Usually set equal to the number of OpenMP threads
+   //===================================================================================
+#  if   ( RANDOM_NUMBER == RNG_CPP11 )
+   RandomNumber_t( const int N ) : Distribution( 0.0, 1.0 )
+#  else
+   RandomNumber_t( const int N )
+#  endif
+   {
+
+//    check
+      if ( N <= 0 )  Aux_Error( ERROR_INFO, "N (%d) <= 0 !!\n", N );
+
+//    record the number of RNG
+      N_RNG = N;
+
+//    allocate RNG
+#     if   ( RANDOM_NUMBER == RNG_CPP11 )
+      RNG = new mt19937      [N];
+#     elif ( RANDOM_NUMBER == RNG_GNU_EXT )
+      RNG = new drand48_data [N];
+#     endif
+
+   } // METHOD : RandomNumber_t
+
+
+
+   //===================================================================================
+   // Destructor  :  ~RandomNumber_t
+   // Description :  Destructor of the structure "RandomNumber_t"
+   //
+   // Note        :  Free memory
+   //===================================================================================
+   ~RandomNumber_t()
+   {
+
+      delete [] RNG;
+
+   } // METHOD : ~RandomNumber_t
+
+
+
+   //===================================================================================
+   // Constructor :  GetValue
+   // Description :  Return a uniformly distributed random number in the specified range
+   //
+   // Note        :  1. Only return a single random number
+   //                   --> Must specify the ID of the target RNG
+   //
+   // Parameter   :  ID  : Target RNG (0 <= ID < N_RNG)
+   //                Min : Lower limit of the random number
+   //                Max : Upper limit of the random number
+   //
+   // Return      :  Random number
+   //===================================================================================
+   double GetValue( const int ID, const double Min, const double Max )
+   {
+
+//    check
+#     ifdef GAMER_DEBUG
+      if ( ID < 0  ||  ID >= N_RNG )
+         Aux_Error( ERROR_INFO, "incorrect RNG ID = %d (total number of RNG = %d) !!\n", ID, N_RNG );
+#     endif
+
+//    get a uniformly distributed random number in the range [0.0, 1.0)
+      double Random;
+#     if   ( RANDOM_NUMBER == RNG_CPP11 )
+      Random = Distribution( RNG[ID] );
+#     elif ( RANDOM_NUMBER == RNG_GNU_EXT )
+      drand48_r( RNG+ID, &Random );
+#     endif
+
+//    convert the range to [Min, Max) and return
+      return Random*(Max-Min) + Min;
+
+   } // METHOD : GetValue
+
+
+
+   //===================================================================================
+   // Constructor :  SetSeed
+   // Description :  Set random seed for the target RNG
+   //
+   // Note        :  1. Only set random seed for a single RNG
+   //                   --> Must specify the ID of the target RNG
+   //
+   // Parameter   :  ID   : Target RNG (0 <= ID < N_RNG)
+   //                Seed : Random seed
+   //===================================================================================
+   void SetSeed( const int ID, const long Seed )
+   {
+
+//    check
+#     ifdef GAMER_DEBUG
+      if ( ID < 0  ||  ID >= N_RNG )
+         Aux_Error( ERROR_INFO, "incorrect RNG ID = %d (total number of RNG = %d) !!\n", ID, N_RNG );
+#     endif
+
+//    set random seed
+#     if   ( RANDOM_NUMBER == RNG_CPP11 )
+      RNG[ID].seed( Seed );
+#     elif ( RANDOM_NUMBER == RNG_GNU_EXT )
+      srand48_r( Seed, RNG + ID );
+#     endif
+
+   } // METHOD : SetSeed
+
+
+}; // struct RandomNumber_t
+
+
+
+#endif // #ifndef __RANDOM_NUMBER_H__

--- a/src/Auxiliary/Aux_TakeNote.cpp
+++ b/src/Auxiliary/Aux_TakeNote.cpp
@@ -306,6 +306,14 @@ void Aux_TakeNote()
       fprintf( Note, "SUPPORT_GSL                     OFF\n" );
 #     endif
 
+#     if   ( RANDOM_NUMBER == RNG_GNU_EXT )
+      fprintf( Note, "RANDOM_NUMBER                   RNG_GNU_EXT\n" );
+#     elif ( RANDOM_NUMBER == RNG_CPP11 )
+      fprintf( Note, "RANDOM_NUMBER                   RNG_CPP11\n" );
+#     else
+      fprintf( Note, "RANDOM_NUMBER                   UNKNOWN\n" );
+#     endif
+
       fprintf( Note, "***********************************************************************************\n" );
       fprintf( Note, "\n\n");
 

--- a/src/Init/Init_ByRestart_HDF5.cpp
+++ b/src/Init/Init_ByRestart_HDF5.cpp
@@ -1264,6 +1264,7 @@ void Check_Makefile( const char *FileName )
    LoadField( "SupportHDF5",            &RS.SupportHDF5,            SID, TID, NonFatal, &RT.SupportHDF5,            1, NonFatal );
    LoadField( "SupportGSL",             &RS.SupportGSL,             SID, TID, NonFatal, &RT.SupportGSL,             1, NonFatal );
    LoadField( "SupportGrackle",         &RS.SupportGrackle,         SID, TID, NonFatal, &RT.SupportGrackle,         1, NonFatal );
+   LoadField( "RandomNumber",           &RS.RandomNumber,           SID, TID, NonFatal, &RT.RandomNumber,           1, NonFatal );
 
    LoadField( "NLevel",                 &RS.NLevel,                 SID, TID, NonFatal, &RT.NLevel,                 1, NonFatal );
    LoadField( "MaxPatch",               &RS.MaxPatch,               SID, TID, NonFatal, &RT.MaxPatch,               1, NonFatal );

--- a/src/Makefile
+++ b/src/Makefile
@@ -196,6 +196,11 @@ SIMU_OPTION += -DOPENMP
 # support yt inline analysis
 #SIMU_OPTION += -DSUPPORT_LIBYT
 
+# random number implementation: RNG_GNU_EXT/RNG_CPP11 (GNU extension drand48_r/c++11 <random>)
+# --> use RNG_GNU_EXT for compilers supporting GNU extensions (**not supported on some macOS**)
+#     use RNG_CPP11   for compilers supporting c++11 (**may need to add -std=c++11 to CXXFLAG**)
+SIMU_OPTION += -DRANDOM_NUMBER=RNG_GNU_EXT
+
 
 
 

--- a/src/Output/Output_DumpData_Total_HDF5.cpp
+++ b/src/Output/Output_DumpData_Total_HDF5.cpp
@@ -69,7 +69,7 @@ Procedure for outputting new variables:
 
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  Output_DumpData_Total_HDF5 (FormatVersion = 2263)
+// Function    :  Output_DumpData_Total_HDF5 (FormatVersion = 2264)
 // Description :  Output all simulation data in the HDF5 format, which can be used as a restart file
 //                or loaded by YT
 //
@@ -149,6 +149,7 @@ Procedure for outputting new variables:
 //                2261 : 2017/12/05 --> no longer define INTEL
 //                2262 : 2017/12/27 --> rename all UM variables
 //                2263 : 2017/12/27 --> remove OPT__RESTART_HEADER
+//                2264 : 2018/02/28 --> add RANDOM_NUMBER
 //-------------------------------------------------------------------------------------------------------
 void Output_DumpData_Total_HDF5( const char *FileName )
 {
@@ -1255,7 +1256,7 @@ void FillIn_KeyInfo( KeyInfo_t &KeyInfo )
 
    const time_t CalTime  = time( NULL );   // calendar time
 
-   KeyInfo.FormatVersion = 2263;
+   KeyInfo.FormatVersion = 2264;
    KeyInfo.Model         = MODEL;
    KeyInfo.NLevel        = NLEVEL;
    KeyInfo.NCompFluid    = NCOMP_FLUID;
@@ -1432,6 +1433,8 @@ void FillIn_Makefile( Makefile_t &Makefile )
 #  else
    Makefile.SupportGrackle         = 0;
 #  endif
+
+   Makefile.RandomNumber           = RANDOM_NUMBER;
 
    Makefile.NLevel                 = NLEVEL;
    Makefile.MaxPatch               = MAX_PATCH;
@@ -2171,6 +2174,7 @@ void GetCompound_Makefile( hid_t &H5_TypeID )
    H5Tinsert( H5_TypeID, "SupportHDF5",            HOFFSET(Makefile_t,SupportHDF5            ), H5T_NATIVE_INT );
    H5Tinsert( H5_TypeID, "SupportGSL",             HOFFSET(Makefile_t,SupportGSL             ), H5T_NATIVE_INT );
    H5Tinsert( H5_TypeID, "SupportGrackle",         HOFFSET(Makefile_t,SupportGrackle         ), H5T_NATIVE_INT );
+   H5Tinsert( H5_TypeID, "RandomNumber",           HOFFSET(Makefile_t,RandomNumber           ), H5T_NATIVE_INT );
 
    H5Tinsert( H5_TypeID, "NLevel",                 HOFFSET(Makefile_t,NLevel                 ), H5T_NATIVE_INT );
    H5Tinsert( H5_TypeID, "MaxPatch",               HOFFSET(Makefile_t,MaxPatch               ), H5T_NATIVE_INT );


### PR DESCRIPTION
This PR adds the header `include/RandomNumber.h` to support different RNG implementations. It currently supports (i) GNU extension `drand48_r` and (ii) C++11 library `<random>`. The purpose is to make the code more portable since GNU extension is not supported on macOS while C++11 is not supported on some old compilers.

To choose different RNG:
1. Set the Makefile option `RANDOM_NUMBER` to either `RNG_GNU_EXT` or `RNG_CPP11`
2. For `RNG_CPP11`, add `-std=c++11` to `CXXFLAG`

@jzuhone Please have a look at it. After it gets merged, we can apply it to your PR #2.