### PR TITLE
Enhanced Grackle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Mac
+.DS_Store
+
 *.o
 
 bin/**

--- a/example/test_problem/Template/Input__Parameter
+++ b/example/test_problem/Template/Input__Parameter
@@ -150,6 +150,9 @@ GRACKLE_CMB_FLOOR             1           # ...    "cmb_temperature_floor" [1]
 GRACKLE_PE_HEATING            0           # ...    "photoelectric_heating" [0]
 GRACKLE_PE_HEATING_RATE       8.5e-26     # ...    "photoelectric_heating_rate (in erg/cm^3/s)" [8.5e-26]
 GRACKLE_CLOUDY_TABLE          CloudyData_noUVB.h5  # "grackle_data_file"
+GRACKLE_THREE_BODY_RATE       4           # used Glover+08 rate
+GRACKLE_CIE_COOLING           1           # 0: off; 1:on
+GRACKLE_H2_OPA_APPROX         1           # H2 opacity from Ripamonti+04; 0:off, 1:Ripomonti+04
 CHE_GPU_NPGROUP              -1           # number of patch groups sent into the CPU/GPU Grackle solver (<=0=auto) [-1]
 
 

--- a/include/Global.h
+++ b/include/Global.h
@@ -197,7 +197,7 @@ extern bool            GRACKLE_PE_HEATING;
 extern double          GRACKLE_PE_HEATING_RATE;
 extern char            GRACKLE_CLOUDY_TABLE[MAX_STRING];
 extern int             GRACKLE_THREE_BODY_RATE;
-extern int             GRACKLE_CIE_COOLING;
+extern bool            GRACKLE_CIE_COOLING;
 extern int             GRACKLE_H2_OPA_APPROX;
 extern int             CHE_GPU_NPGROUP;
 #endif

--- a/include/Global.h
+++ b/include/Global.h
@@ -196,6 +196,9 @@ extern bool            GRACKLE_CMB_FLOOR;
 extern bool            GRACKLE_PE_HEATING;
 extern double          GRACKLE_PE_HEATING_RATE;
 extern char            GRACKLE_CLOUDY_TABLE[MAX_STRING];
+extern int             GRACKLE_THREE_BODY_RATE;
+extern int             GRACKLE_CIE_COOLING;
+extern int             GRACKLE_H2_OPA_APPROX;
 extern int             CHE_GPU_NPGROUP;
 #endif
 

--- a/include/HDF5_Typedef.h
+++ b/include/HDF5_Typedef.h
@@ -481,6 +481,9 @@ struct InputPara_t
    int    Grackle_PE_Heating;
    double Grackle_PE_HeatingRate;
    char  *Grackle_CloudyTable;
+   int    Grackle_ThreeBodyRate;
+   int    Grackle_CIE_Cooling;
+   int    Grackle_H2_OpaApprox;
    int    Che_GPU_NPGroup;
 #  endif
 

--- a/src/Auxiliary/Aux_TakeNote.cpp
+++ b/src/Auxiliary/Aux_TakeNote.cpp
@@ -748,6 +748,9 @@ void Aux_TakeNote()
       fprintf( Note, "GRACKLE_PE_HEATING              %d\n",      GRACKLE_PE_HEATING      );
       fprintf( Note, "GRACKLE_PE_HEATING_RATE         %13.7e\n",  GRACKLE_PE_HEATING_RATE );
       fprintf( Note, "GRACKLE_CLOUDY_TABLE            %s\n",      GRACKLE_CLOUDY_TABLE    );
+      fprintf( Note, "GRACKLE_THREE_BODY_RATE         %d\n",      GRACKLE_THREE_BODY_RATE );
+      fprintf( Note, "GRACKLE_CIE_COOLING             %d\n",      GRACKLE_CIE_COOLING     );
+      fprintf( Note, "GRACKLE_H2_OPA_APPROX           %d\n",      GRACKLE_H2_OPA_APPROX   );
       fprintf( Note, "CHE_GPU_NPGROUP                 %d\n",      CHE_GPU_NPGROUP         ); }
       fprintf( Note, "***********************************************************************************\n" );
       fprintf( Note, "\n\n");

--- a/src/Grackle/Grackle_Close.cpp
+++ b/src/Grackle/Grackle_Close.cpp
@@ -50,6 +50,8 @@ void Grackle_Close( const int lv, const int SaveSg, const real h_Che_Array[], co
    const int   Size1v     = NPG*Size1pg;
    const real  Gamma_m1   = GAMMA - (real)1.0;
    const real _Gamma_m1   = (real)1.0 / Gamma_m1;
+   
+   const real mass_ratio_ep   = Const_me/Const_mp;
 
    const real *Ptr_Dens0  = h_Che_Array + CheIdx_Dens *Size1v;
    const real *Ptr_sEint0 = h_Che_Array + CheIdx_sEint*Size1v;
@@ -130,7 +132,7 @@ void Grackle_Close( const int lv, const int SaveSg, const real h_Che_Array[], co
 
 //          update all chemical species
             if ( GRACKLE_PRIMORDIAL >= GRACKLE_PRI_CHE_NSPE6 ) {
-            *( fluid[Idx_e    ][0][0] + idx_p ) = Ptr_e    [idx_pg];
+            *( fluid[Idx_e    ][0][0] + idx_p ) = Ptr_e    [idx_pg] * mass_ratio_ep;
             *( fluid[Idx_HI   ][0][0] + idx_p ) = Ptr_HI   [idx_pg];
             *( fluid[Idx_HII  ][0][0] + idx_p ) = Ptr_HII  [idx_pg];
             *( fluid[Idx_HeI  ][0][0] + idx_p ) = Ptr_HeI  [idx_pg];

--- a/src/Grackle/Grackle_Init.cpp
+++ b/src/Grackle/Grackle_Init.cpp
@@ -83,15 +83,18 @@ void Grackle_Init()
 
 
 // set chemistry by accessing "grackle_data"
-   grackle_data->use_grackle                = GRACKLE_ACTIVATE;
-   grackle_data->with_radiative_cooling     = GRACKLE_COOLING;
-   grackle_data->primordial_chemistry       = GRACKLE_PRIMORDIAL;
-   grackle_data->metal_cooling              = GRACKLE_METAL;
-   grackle_data->UVbackground               = GRACKLE_UV;
-   grackle_data->cmb_temperature_floor      = GRACKLE_CMB_FLOOR;
-   grackle_data->photoelectric_heating      = GRACKLE_PE_HEATING;
-   grackle_data->photoelectric_heating_rate = GRACKLE_PE_HEATING_RATE;
-   grackle_data->grackle_data_file          = GRACKLE_CLOUDY_TABLE;
+   grackle_data->use_grackle                    = GRACKLE_ACTIVATE;
+   grackle_data->with_radiative_cooling         = GRACKLE_COOLING;
+   grackle_data->primordial_chemistry           = GRACKLE_PRIMORDIAL;
+   grackle_data->metal_cooling                  = GRACKLE_METAL;
+   grackle_data->UVbackground                   = GRACKLE_UV;
+   grackle_data->cmb_temperature_floor          = GRACKLE_CMB_FLOOR;
+   grackle_data->photoelectric_heating          = GRACKLE_PE_HEATING;
+   grackle_data->photoelectric_heating_rate     = GRACKLE_PE_HEATING_RATE;
+   grackle_data->grackle_data_file              = GRACKLE_CLOUDY_TABLE;
+   grackle_data->three_body_rate                = GRACKLE_THREE_BODY_RATE;
+   grackle_data->cie_cooling                    = GRACKLE_CIE_COOLING;
+   grackle_data->h2_optical_depth_approximation = GRACKLE_H2_OPA_APPROX;
 
 #  ifdef OPENMP
 // currently we adopt the OpenMP implementation in Grackle directly, which applies the parallelization to

--- a/src/Grackle/Grackle_Prepare.cpp
+++ b/src/Grackle/Grackle_Prepare.cpp
@@ -94,6 +94,7 @@ void Grackle_Prepare( const int lv, real h_Che_Array[], const int NPG, const int
 
    const int  Size1pg         = CUBE(PS2);
    const int  Size1v          = NPG*Size1pg;
+   const real mass_ratio_pe   = Const_mp/Const_me;
 #  ifdef DUAL_ENERGY
    const real  Gamma_m1       = GAMMA - (real)1.0;
    const real _Gamma_m1       = (real)1.0 / Gamma_m1;
@@ -190,7 +191,7 @@ void Grackle_Prepare( const int lv, real h_Che_Array[], const int NPG, const int
 
 //          6-species network
             if ( GRACKLE_PRIMORDIAL >= GRACKLE_PRI_CHE_NSPE6 ) {
-            Ptr_e    [idx_pg] = *( fluid[Idx_e    ][0][0] + idx_p );
+            Ptr_e    [idx_pg] = *( fluid[Idx_e    ][0][0] + idx_p ) * mass_ratio_pe;
             Ptr_HI   [idx_pg] = *( fluid[Idx_HI   ][0][0] + idx_p );
             Ptr_HII  [idx_pg] = *( fluid[Idx_HII  ][0][0] + idx_p );
             Ptr_HeI  [idx_pg] = *( fluid[Idx_HeI  ][0][0] + idx_p );

--- a/src/Init/Init_ByRestart_HDF5.cpp
+++ b/src/Init/Init_ByRestart_HDF5.cpp
@@ -1745,6 +1745,9 @@ void Check_InputPara( const char *FileName, const int FormatVersion )
    LoadField( "Grackle_PE_Heating",      &RS.Grackle_PE_Heating,      SID, TID, NonFatal, &RT.Grackle_PE_Heating,       1, NonFatal );
    LoadField( "Grackle_PE_HeatingRate",  &RS.Grackle_PE_HeatingRate,  SID, TID, NonFatal, &RT.Grackle_PE_HeatingRate,   1, NonFatal );
    LoadField( "Grackle_CloudyTable",     &RS.Grackle_CloudyTable,     SID, TID, NonFatal,  RT.Grackle_CloudyTable,      1, NonFatal );
+   LoadField( "Grackle_ThreeBodyRate",   &RS.Grackle_ThreeBodyRate,   SID, TID, NonFatal, &RT.Grackle_ThreeBodyRate,    1, NonFatal );
+   LoadField( "Grackle_CIE_Cooling",     &RS.Grackle_CIE_Cooling,     SID, TID, NonFatal, &RT.Grackle_CIE_Cooling,      1, NonFatal );
+   LoadField( "Grackle_H2_OpaApprox",    &RS.Grackle_H2_OpaApprox,    SID, TID, NonFatal, &RT.Grackle_H2_OpaApprox,     1, NonFatal );
    LoadField( "Che_GPU_NPGroup",         &RS.Che_GPU_NPGroup,         SID, TID, NonFatal, &RT.Che_GPU_NPGroup,          1, NonFatal );
 #  endif
 

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -184,7 +184,7 @@ void Init_Load_Parameter()
    ReadPara->Add( "GRACKLE_PE_HEATING_RATE",    &GRACKLE_PE_HEATING_RATE,         8.5e-26,         0.0,           NoMax_double   );
    ReadPara->Add( "GRACKLE_CLOUDY_TABLE",        GRACKLE_CLOUDY_TABLE,            Useless_str,     Useless_str,   Useless_str    );
    ReadPara->Add( "GRACKLE_THREE_BODY_RATE",    &GRACKLE_THREE_BODY_RATE,         0,               0,             5              );
-   ReadPara->Add( "GRACKLE_CIE_COOLING",        &GRACKLE_CIE_COOLING,             0,               0,             1              );
+   ReadPara->Add( "GRACKLE_CIE_COOLING",        &GRACKLE_CIE_COOLING,             0,               Useless_bool,  Useless_bool   );
    ReadPara->Add( "GRACKLE_H2_OPA_APPROX",      &GRACKLE_H2_OPA_APPROX,           0,               0,             1              );
 // do not check CHE_GPU_NPGROUP since it may be reset by either Init_ResetDefaultParameter() or CUAPI_Set_Default_GPU_Parameter()
    ReadPara->Add( "CHE_GPU_NPGROUP",            &CHE_GPU_NPGROUP,                -1,               NoMin_int,     NoMax_int      );

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -183,6 +183,9 @@ void Init_Load_Parameter()
    ReadPara->Add( "GRACKLE_PE_HEATING",         &GRACKLE_PE_HEATING,              false,           Useless_bool,  Useless_bool   );
    ReadPara->Add( "GRACKLE_PE_HEATING_RATE",    &GRACKLE_PE_HEATING_RATE,         8.5e-26,         0.0,           NoMax_double   );
    ReadPara->Add( "GRACKLE_CLOUDY_TABLE",        GRACKLE_CLOUDY_TABLE,            Useless_str,     Useless_str,   Useless_str    );
+   ReadPara->Add( "GRACKLE_THREE_BODY_RATE",    &GRACKLE_THREE_BODY_RATE,         1,               0,             5              );
+   ReadPara->Add( "GRACKLE_CIE_COOLING",        &GRACKLE_CIE_COOLING,             0,               0,             1              );
+   ReadPara->Add( "GRACKLE_H2_OPA_APPROX",      &GRACKLE_H2_OPA_APPROX,           1,               0,             1              );
 // do not check CHE_GPU_NPGROUP since it may be reset by either Init_ResetDefaultParameter() or CUAPI_Set_Default_GPU_Parameter()
    ReadPara->Add( "CHE_GPU_NPGROUP",            &CHE_GPU_NPGROUP,                -1,               NoMin_int,     NoMax_int      );
 #  endif

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -183,9 +183,9 @@ void Init_Load_Parameter()
    ReadPara->Add( "GRACKLE_PE_HEATING",         &GRACKLE_PE_HEATING,              false,           Useless_bool,  Useless_bool   );
    ReadPara->Add( "GRACKLE_PE_HEATING_RATE",    &GRACKLE_PE_HEATING_RATE,         8.5e-26,         0.0,           NoMax_double   );
    ReadPara->Add( "GRACKLE_CLOUDY_TABLE",        GRACKLE_CLOUDY_TABLE,            Useless_str,     Useless_str,   Useless_str    );
-   ReadPara->Add( "GRACKLE_THREE_BODY_RATE",    &GRACKLE_THREE_BODY_RATE,         1,               0,             5              );
+   ReadPara->Add( "GRACKLE_THREE_BODY_RATE",    &GRACKLE_THREE_BODY_RATE,         0,               0,             5              );
    ReadPara->Add( "GRACKLE_CIE_COOLING",        &GRACKLE_CIE_COOLING,             0,               0,             1              );
-   ReadPara->Add( "GRACKLE_H2_OPA_APPROX",      &GRACKLE_H2_OPA_APPROX,           1,               0,             1              );
+   ReadPara->Add( "GRACKLE_H2_OPA_APPROX",      &GRACKLE_H2_OPA_APPROX,           0,               0,             1              );
 // do not check CHE_GPU_NPGROUP since it may be reset by either Init_ResetDefaultParameter() or CUAPI_Set_Default_GPU_Parameter()
    ReadPara->Add( "CHE_GPU_NPGROUP",            &CHE_GPU_NPGROUP,                -1,               NoMin_int,     NoMax_int      );
 #  endif

--- a/src/Main/Main.cpp
+++ b/src/Main/Main.cpp
@@ -175,7 +175,7 @@ bool                 GRACKLE_PE_HEATING;
 double               GRACKLE_PE_HEATING_RATE;
 char                 GRACKLE_CLOUDY_TABLE[MAX_STRING];
 int                  GRACKLE_THREE_BODY_RATE;
-int                  GRACKLE_CIE_COOLING;
+bool                 GRACKLE_CIE_COOLING;
 int                  GRACKLE_H2_OPA_APPROX;
 int                  CHE_GPU_NPGROUP;
 #endif

--- a/src/Main/Main.cpp
+++ b/src/Main/Main.cpp
@@ -174,6 +174,9 @@ bool                 GRACKLE_CMB_FLOOR;
 bool                 GRACKLE_PE_HEATING;
 double               GRACKLE_PE_HEATING_RATE;
 char                 GRACKLE_CLOUDY_TABLE[MAX_STRING];
+int                  GRACKLE_THREE_BODY_RATE;
+int                  GRACKLE_CIE_COOLING;
+int                  GRACKLE_H2_OPA_APPROX;
 int                  CHE_GPU_NPGROUP;
 #endif
 

--- a/src/Output/Output_DumpData_Total_HDF5.cpp
+++ b/src/Output/Output_DumpData_Total_HDF5.cpp
@@ -2588,6 +2588,9 @@ void GetCompound_InputPara( hid_t &H5_TypeID )
    H5Tinsert( H5_TypeID, "Grackle_PE_Heating",      HOFFSET(InputPara_t,Grackle_PE_Heating     ), H5T_NATIVE_INT     );
    H5Tinsert( H5_TypeID, "Grackle_PE_HeatingRate",  HOFFSET(InputPara_t,Grackle_PE_HeatingRate ), H5T_NATIVE_DOUBLE  );
    H5Tinsert( H5_TypeID, "Grackle_CloudyTable",     HOFFSET(InputPara_t,Grackle_CloudyTable    ), H5_TypeID_VarStr   );
+   H5Tinsert( H5_TypeID, "Grackle_ThreeBodyRate",   HOFFSET(InputPara_t,Grackle_ThreeBodyRate  ), H5T_NATIVE_INT     );
+   H5Tinsert( H5_TypeID, "Grackle_CIE_Cooling",     HOFFSET(InputPara_t,Grackle_CIE_Cooling    ), H5T_NATIVE_INT     );
+   H5Tinsert( H5_TypeID, "Grackle_H2_OpaApprox",    HOFFSET(InputPara_t,Grackle_H2_OpaApprox   ), H5T_NATIVE_INT     );
    H5Tinsert( H5_TypeID, "Che_GPU_NPGroup",         HOFFSET(InputPara_t,Che_GPU_NPGroup        ), H5T_NATIVE_INT     );
 #  endif
 

--- a/src/Output/Output_DumpData_Total_HDF5.cpp
+++ b/src/Output/Output_DumpData_Total_HDF5.cpp
@@ -1897,6 +1897,9 @@ void FillIn_InputPara( InputPara_t &InputPara )
    InputPara.Grackle_PE_Heating      = GRACKLE_PE_HEATING;
    InputPara.Grackle_PE_HeatingRate  = GRACKLE_PE_HEATING_RATE;
    InputPara.Grackle_CloudyTable     = GRACKLE_CLOUDY_TABLE;
+   InputPara.Grackle_ThreeBodyRate   = GRACKLE_THREE_BODY_RATE;
+   InputPara.Grackle_CIE_Cooling     = GRACKLE_CIE_COOLING;
+   InputPara.Grackle_H2_OpaApprox    = GRACKLE_H2_OPA_APPROX;
    InputPara.Che_GPU_NPGroup         = CHE_GPU_NPGROUP;
 #  endif
 

--- a/src/Output/Output_DumpData_Total_HDF5.cpp
+++ b/src/Output/Output_DumpData_Total_HDF5.cpp
@@ -69,7 +69,7 @@ Procedure for outputting new variables:
 
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  Output_DumpData_Total_HDF5 (FormatVersion = 2310)
+// Function    :  Output_DumpData_Total_HDF5 (FormatVersion = 2311)
 // Description :  Output all simulation data in the HDF5 format, which can be used as a restart file
 //                or loaded by YT
 //
@@ -167,6 +167,7 @@ Procedure for outputting new variables:
 //                2308 : 2019/03/14 --> add OPT__RECORD_NOTE and OPT__RECORD_UNPHY
 //                2309 : 2019/05/31 --> add OPT__GRAVITY_EXTRA_MASS
 //                2310 : 2019/10/16 --> add DT__MAX
+//                2311 : 2019/12/29 --> output GRACKLE_THREE_BODY_RATE, GRACKLE_CIE_COOLING, GRACKLE_H2_OPA_APPROX
 //-------------------------------------------------------------------------------------------------------
 void Output_DumpData_Total_HDF5( const char *FileName )
 {
@@ -1231,7 +1232,7 @@ void FillIn_KeyInfo( KeyInfo_t &KeyInfo )
 
    const time_t CalTime   = time( NULL );    // calendar time
 
-   KeyInfo.FormatVersion  = 2310;
+   KeyInfo.FormatVersion  = 2311;
    KeyInfo.Model          = MODEL;
    KeyInfo.NLevel         = NLEVEL;
    KeyInfo.NCompFluid     = NCOMP_FLUID;


### PR DESCRIPTION
* Allow gamer to set grackle parameters:  three_body_rate, cie_cooling, h2_optical_depth_approximation
* Rescale electron mass: use real electron density in fluid calculation, and rescale it with m_p/m_e when passing it to grackle. It allows normalization of grackle fields. 