### PR TITLE
64-bit bitwise index

### DIFF
--- a/include/Macro.h
+++ b/include/Macro.h
@@ -196,46 +196,46 @@
 #endif
 
 // bitwise field indices
-// --> must have "_VAR_NAME = 1<<VAR_NAME" (e.g., _DENS == 1<<DENS)
+// --> must have "_VAR_NAME = 1L<<VAR_NAME" (e.g., _DENS == 1L<<DENS)
 // --> convenient for determining subsets of fields (e.g., _DENS|_ENGY)
 // --> used as function parameters (e.g., Prepare_PatchData(), Flu_FixUp(), Flu_Restrict(), Buf_GetBufferData())
-#  define _DENS               ( 1 << DENS )
-#  define _MOMX               ( 1 << MOMX )
-#  define _MOMY               ( 1 << MOMY )
-#  define _MOMZ               ( 1 << MOMZ )
-#  define _ENGY               ( 1 << ENGY )
+#  define _DENS               ( 1L << DENS )
+#  define _MOMX               ( 1L << MOMX )
+#  define _MOMY               ( 1L << MOMY )
+#  define _MOMZ               ( 1L << MOMZ )
+#  define _ENGY               ( 1L << ENGY )
 
 #if ( NCOMP_PASSIVE > 0 )
 # if   ( DUAL_ENERGY == DE_ENPY )
-#  define _ENPY               ( 1 << ENPY )
+#  define _ENPY               ( 1L << ENPY )
 # elif ( DUAL_ENERGY == DE_EINT )
-#  define _EINT               ( 1 << EINT )
+#  define _EINT               ( 1L << EINT )
 # endif
 #endif // #if ( NCOMP_PASSIVE > 0 )
 
 // bitwise flux indices
-#  define _FLUX_DENS          ( 1 << FLUX_DENS )
-#  define _FLUX_MOMX          ( 1 << FLUX_MOMX )
-#  define _FLUX_MOMY          ( 1 << FLUX_MOMY )
-#  define _FLUX_MOMZ          ( 1 << FLUX_MOMZ )
-#  define _FLUX_ENGY          ( 1 << FLUX_ENGY )
+#  define _FLUX_DENS          ( 1L << FLUX_DENS )
+#  define _FLUX_MOMX          ( 1L << FLUX_MOMX )
+#  define _FLUX_MOMY          ( 1L << FLUX_MOMY )
+#  define _FLUX_MOMZ          ( 1L << FLUX_MOMZ )
+#  define _FLUX_ENGY          ( 1L << FLUX_ENGY )
 
 #if ( NFLUX_PASSIVE > 0 )
 # if   ( DUAL_ENERGY == DE_ENPY )
-#  define _FLUX_ENPY          ( 1 << FLUX_ENPY )
+#  define _FLUX_ENPY          ( 1L << FLUX_ENPY )
 # elif ( DUAL_ENERGY == DE_EINT )
-#  define _FLUX_EINT          ( 1 << FLUX_EINT )
+#  define _FLUX_EINT          ( 1L << FLUX_EINT )
 # endif
 #endif // #if ( NFLUX_PASSIVE > 0 )
 
 // bitwise indices of derived fields
-// --> start from (1<<NCOMP_TOTAL) to distinguish from the intrinsic fields
+// --> start from (1L<<NCOMP_TOTAL) to distinguish from the intrinsic fields
 // --> remember to define NDERIVE = total number of derived fields
-#  define _VELX               ( 1 << (NCOMP_TOTAL+0) )
-#  define _VELY               ( 1 << (NCOMP_TOTAL+1) )
-#  define _VELZ               ( 1 << (NCOMP_TOTAL+2) )
-#  define _PRES               ( 1 << (NCOMP_TOTAL+3) )
-#  define _TEMP               ( 1 << (NCOMP_TOTAL+4) )
+#  define _VELX               ( 1L << (NCOMP_TOTAL+0) )
+#  define _VELY               ( 1L << (NCOMP_TOTAL+1) )
+#  define _VELZ               ( 1L << (NCOMP_TOTAL+2) )
+#  define _PRES               ( 1L << (NCOMP_TOTAL+3) )
+#  define _TEMP               ( 1L << (NCOMP_TOTAL+4) )
 #  define _DERIVED            ( _VELX | _VELY | _VELZ | _PRES | _TEMP )
 #  define NDERIVE             5
 
@@ -257,12 +257,12 @@
 #  define  FLUX_DENS          0
 
 // bitwise field indices
-#  define _DENS               ( 1 << DENS )
-#  define _REAL               ( 1 << REAL )
-#  define _IMAG               ( 1 << IMAG )
+#  define _DENS               ( 1L << DENS )
+#  define _REAL               ( 1L << REAL )
+#  define _IMAG               ( 1L << IMAG )
 
 // bitwise flux indices
-#  define _FLUX_DENS          ( 1 << FLUX_DENS )
+#  define _FLUX_DENS          ( 1L << FLUX_DENS )
 
 // bitwise indices of derived fields
 #  define _DERIVED            0
@@ -281,15 +281,15 @@
 
 // bitwise field indices used by all models
 # ifdef GRAVITY
-#  define _POTE               ( 1 << (NCOMP_TOTAL+NDERIVE) )
+#  define _POTE               ( 1L << (NCOMP_TOTAL+NDERIVE) )
 # endif
-#  define _FLUID              (  ( 1 << NCOMP_FLUID ) - 1           )
-#  define _PASSIVE            (  ( 1 << NCOMP_TOTAL ) - 1 - _FLUID  )
-#  define _TOTAL              (  ( 1 << NCOMP_TOTAL ) - 1           )
+#  define _FLUID              (  ( 1L << NCOMP_FLUID ) - 1L           )
+#  define _PASSIVE            (  ( 1L << NCOMP_TOTAL ) - 1L - _FLUID  )
+#  define _TOTAL              (  ( 1L << NCOMP_TOTAL ) - 1L           )
 
-#  define _FLUX_FLUID         (  ( 1 << NFLUX_FLUID ) - 1                )
-#  define _FLUX_PASSIVE       (  ( 1 << NFLUX_TOTAL ) - 1 - _FLUX_FLUID  )
-#  define _FLUX_TOTAL         (  ( 1 << NFLUX_TOTAL ) - 1                )
+#  define _FLUX_FLUID         (  ( 1L << NFLUX_FLUID ) - 1L                )
+#  define _FLUX_PASSIVE       (  ( 1L << NFLUX_TOTAL ) - 1L - _FLUX_FLUID  )
+#  define _FLUX_TOTAL         (  ( 1L << NFLUX_TOTAL ) - 1L                )
 
 
 
@@ -354,13 +354,13 @@
 
 
 // bitwise field indices related to particles
-// --> note that _POTE = ( 1 << (NCOMP_TOTAL+NDERIVE) )
-#  define _PAR_DENS           ( 1 << (NCOMP_TOTAL+NDERIVE+1) )
+// --> note that _POTE = ( 1L << (NCOMP_TOTAL+NDERIVE) )
+#  define _PAR_DENS           ( 1L << (NCOMP_TOTAL+NDERIVE+1) )
 
 # if ( MODEL == PAR_ONLY )
 #  define _TOTAL_DENS         ( _PAR_DENS )
 # else
-#  define _TOTAL_DENS         ( 1 << (NCOMP_TOTAL+NDERIVE+2) )
+#  define _TOTAL_DENS         ( 1L << (NCOMP_TOTAL+NDERIVE+2) )
 # endif
 
 #else // #ifdef PARTICLE
@@ -728,8 +728,8 @@
 #endif
 
 
-// macro converting an array index (e.g., DENS) to bitwise index (e.g., _DENS=(1<<DENS))
-#define BIDX( idx )     ( 1 << (idx) )
+// macro converting an array index (e.g., DENS) to bitwise index (e.g., _DENS=(1L<<DENS))
+#define BIDX( idx )     ( 1L << (idx) )
 
 
 

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -54,7 +54,7 @@ int Aux_IsFinite( const double x );
 void Buf_AllocateBufferPatch_Base( AMR_t *Tamr );
 void Buf_AllocateBufferPatch( AMR_t *Tamr, const int lv );
 void Buf_GetBufferData( const int lv, const int FluSg, const int PotSg, const GetBufMode_t GetBufMode,
-                        const int TVar, const int ParaBuffer, const UseLBFunc_t UseLBFunc );
+                        const long TVar, const int ParaBuffer, const UseLBFunc_t UseLBFunc );
 void Buf_RecordBoundaryFlag( const int lv );
 void Buf_RecordBoundaryPatch_Base();
 void Buf_RecordBoundaryPatch( const int lv );
@@ -111,11 +111,11 @@ void Flu_FixUp( const int lv );
 void Flu_Prepare( const int lv, const double PrepTime, real h_Flu_Array_F_In[], real h_Pot_Array_USG_F[],
                   double h_Corner_Array_F[][3], const int NPG, const int *PID0_List );
 void Flu_Restrict( const int FaLv, const int SonFluSg, const int FaFluSg, const int SonPotSg, const int FaPotSg,
-                   const int TVar );
+                   const long TVar );
 void Flu_BoundaryCondition_User( real *Array, const int NVar_Flu, const int ArraySizeX, const int ArraySizeY,
                                  const int ArraySizeZ, const int Idx_Start[], const int Idx_End[],
                                  const int TFluVarIdxList[], const double Time, const double dh, const double *Corner,
-                                 const int TVar, const int lv );
+                                 const long TVar, const int lv );
 void Hydro_BoundaryCondition_Outflow( real *Array, const int BC_Face, const int NVar, const int GhostSize,
                                       const int ArraySizeX, const int ArraySizeY, const int ArraySizeZ,
                                       const int Idx_Start[], const int Idx_End[] );
@@ -131,7 +131,7 @@ void InvokeSolver( const Solver_t TSolver, const int lv, const double TimeNew, c
                    const double Poi_Coeff, const int SaveSg_Flu, const int SaveSg_Pot,
                    const bool OverlapMPI, const bool Overlap_Sync );
 void Prepare_PatchData( const int lv, const double PrepTime, real *h_Input_Array,
-                        const int GhostSize, const int NPG, const int *PID0_List, int TVar,
+                        const int GhostSize, const int NPG, const int *PID0_List, long TVar,
                         const IntScheme_t IntScheme, const PrepUnit_t PrepUnit, const NSide_t NSide,
                         const bool IntPhase, const OptFluBC_t FluBC[], const OptPotBC_t PotBC,
                         const real MinDens, const real MinPres, const bool DE_Consistency );
@@ -362,7 +362,7 @@ void LB_ExchangeFlaggedBuffer( const int lv );
 void LB_FindFather( const int SonLv, const bool SearchAllSon, const int NInput, int* TargetSonPID0, const bool ResetSonID );
 void LB_FindSonNotHome( const int FaLv, const bool SearchAllFa, const int NInput, int* TargetFaPID );
 void LB_GetBufferData( const int lv, const int FluSg, const int PotSg, const GetBufMode_t GetBufMode,
-                       const int TVar, const int ParaBuf );
+                       const long TVar, const int ParaBuf );
 real*LB_GetBufferData_MemAllocate_Send( const int NSend );
 real*LB_GetBufferData_MemAllocate_Recv( const int NRecv );
 void LB_GrandsonCheck( const int lv );

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -396,7 +396,7 @@ void Hydro_Init_ByFunction_AssignData( const int lv );
 void Hydro_BoundaryCondition_Reflecting( real *Array, const int BC_Face, const int NVar_Flu, const int GhostSize,
                                          const int ArraySizeX, const int ArraySizeY, const int ArraySizeZ,
                                          const int Idx_Start[], const int Idx_End[], const int TFluVarIdxList[],
-                                         const int NVar_Der, const int TDerVarList[] );
+                                         const int NVar_Der, const long TDerVarList[] );
 bool Hydro_Flag_Vorticity( const int i, const int j, const int k, const int lv, const int PID, const double Threshold );
 
 

--- a/src/Buffer/Buf_GetBufferData.cpp
+++ b/src/Buffer/Buf_GetBufferData.cpp
@@ -46,7 +46,7 @@
 //                                  USELB_NO  : do not use the load-balance alternative function
 //-------------------------------------------------------------------------------------------------------
 void Buf_GetBufferData( const int lv, const int FluSg, const int PotSg, const GetBufMode_t GetBufMode,
-                        const int TVar, const int ParaBuf, const UseLBFunc_t UseLBFunc )
+                        const long TVar, const int ParaBuf, const UseLBFunc_t UseLBFunc )
 {
 
 // invoke the alternative load-balance function
@@ -123,7 +123,7 @@ void Buf_GetBufferData( const int lv, const int FluSg, const int PotSg, const Ge
    NVar_Flu = 0;
 
    for (int v=0; v<NFluid_Max; v++)
-      if ( TVar & (1<<v) )    TFluVarIdxList[ NVar_Flu++ ] = v;
+      if ( TVar & (1L<<v) )   TFluVarIdxList[ NVar_Flu++ ] = v;
 
    NVar_Tot = NVar_Flu;
 #  ifdef GRAVITY

--- a/src/Fluid/Flu_BoundaryCondition_User.cpp
+++ b/src/Fluid/Flu_BoundaryCondition_User.cpp
@@ -90,7 +90,7 @@ void BC_User( real fluid[], const double x, const double y, const double z, cons
 void Flu_BoundaryCondition_User( real *Array, const int NVar_Flu, const int ArraySizeX, const int ArraySizeY,
                                  const int ArraySizeZ, const int Idx_Start[], const int Idx_End[],
                                  const int TFluVarIdxList[], const double Time, const double dh, const double *Corner,
-                                 const int TVar, const int lv )
+                                 const long TVar, const int lv )
 {
 
 // check

--- a/src/Fluid/Flu_Prepare.cpp
+++ b/src/Fluid/Flu_Prepare.cpp
@@ -5,9 +5,9 @@
 
 //-------------------------------------------------------------------------------------------------------
 // Function    :  Flu_Prepare
-// Description :  Prepare the input array "Flu_Array_F_In" for the fluid solver
+// Description :  Prepare the input array Flu_Array_F_In[] for the fluid solver
 //
-// Note        :  Invoke the function "Prepare_PatchData"
+// Note        :  Invoke Prepare_PatchData()
 //
 // Parameter   :  lv                   : Target refinement level
 //                PrepTime             : Target physical time to prepare the coarse-grid data
@@ -64,8 +64,8 @@ void Flu_Prepare( const int lv, const double PrepTime, real h_Flu_Array_F_In[], 
 #  ifdef UNSPLIT_GRAVITY
 // prepare the potential array
    if ( OPT__GRAVITY_TYPE == GRAVITY_SELF  ||  OPT__GRAVITY_TYPE == GRAVITY_BOTH )
-   Prepare_PatchData( lv, PrepTime, h_Pot_Array_USG_F, USG_GHOST_SIZE, NPG, PID0_List,
-                      _POTE,         OPT__GRA_INT_SCHEME, UNIT_PATCHGROUP, NSIDE_26, IntPhase_No,
+   Prepare_PatchData( lv, PrepTime, h_Pot_Array_USG_F, USG_GHOST_SIZE, NPG, PID0_List, _POTE,
+                      OPT__GRA_INT_SCHEME, UNIT_PATCHGROUP, NSIDE_26, IntPhase_No,
                       OPT__BC_FLU, OPT__BC_POT, MinDens_No, MinPres_No, DE_Consistency_No );
 
 // prepare the corner array

--- a/src/Fluid/Flu_Restrict.cpp
+++ b/src/Fluid/Flu_Restrict.cpp
@@ -23,7 +23,7 @@
 //                           --> _FLUID, _PASSIVE, and _TOTAL apply to all models
 //-------------------------------------------------------------------------------------------------------
 void Flu_Restrict( const int FaLv, const int SonFluSg, const int FaFluSg, const int SonPotSg, const int FaPotSg,
-                   const int TVar )
+                   const long TVar )
 {
 
    const int SonLv = FaLv + 1;
@@ -82,7 +82,7 @@ void Flu_Restrict( const int FaLv, const int SonFluSg, const int FaFluSg, const 
    NVar_Flu = 0;
 
    for (int v=0; v<NCOMP_TOTAL; v++)
-      if ( TVar & (1<<v) )    TFluVarIdxList[ NVar_Flu++ ] = v;
+      if ( TVar & (1L<<v) )   TFluVarIdxList[ NVar_Flu++ ] = v;
 
 // check again
    NVar_Tot = NVar_Flu;

--- a/src/LoadBalance/LB_GetBufferData.cpp
+++ b/src/LoadBalance/LB_GetBufferData.cpp
@@ -56,7 +56,7 @@ extern Timer_t *Timer_MPI[3];
 //                ParaBuf     : Number of ghost zones to exchange (useless in DATA_RESTRICT and COARSE_FINE_FLUX )
 //-------------------------------------------------------------------------------------------------------
 void LB_GetBufferData( const int lv, const int FluSg, const int PotSg, const GetBufMode_t GetBufMode,
-                       const int TVar, const int ParaBuf )
+                       const long TVar, const int ParaBuf )
 {
 
 // check
@@ -121,7 +121,7 @@ void LB_GetBufferData( const int lv, const int FluSg, const int PotSg, const Get
    NVar_Flu = 0;
 
    for (int v=0; v<NFluid_Max; v++)
-      if ( TVar & (1<<v) )    TFluVarIdxList[ NVar_Flu++ ] = v;
+      if ( TVar & (1L<<v) )   TFluVarIdxList[ NVar_Flu++ ] = v;
 
    NVar_Tot = NVar_Flu;
 #  ifdef GRAVITY

--- a/src/LoadBalance/LB_Refine_GetNewRealPatchList.cpp
+++ b/src/LoadBalance/LB_Refine_GetNewRealPatchList.cpp
@@ -455,8 +455,8 @@ void PrepareCData( const int FaLv, const int FaPID, real *const FaData,
 
 
 // 2. fill up the ghost zones of FaData (no interpolation is required)
-   const int  NDer       = 0;
-   const int *DerVarList = NULL;
+   const int   NDer       = 0;
+   const long *DerVarList = NULL;
 
    int    Loop[3], Disp1[3], Disp2[3], I2, J2, K2, SibPID;
    int    BC_Sibling, BC_Idx_Start[3], BC_Idx_End[3];

--- a/src/Main/InterpolateGhostZone.cpp
+++ b/src/Main/InterpolateGhostZone.cpp
@@ -64,7 +64,7 @@ static int Table_01( const int SibID, const int Side, const char dim, const int 
 //-------------------------------------------------------------------------------------------------------
 void InterpolateGhostZone( const int lv, const int PID, real IntData[], const int SibID, const double PrepTime,
                            const int GhostSize, const IntScheme_t IntScheme, const int NTSib[], int *TSib[],
-                           const int TVar, const int NVar_Tot, const int NVar_Flu, const int TFluVarIdxList[],
+                           const long TVar, const int NVar_Tot, const int NVar_Flu, const int TFluVarIdxList[],
                            const int NVar_Der, const int TDerVarList[], const bool IntPhase,
                            const OptFluBC_t FluBC[], const OptPotBC_t PotBC, const int BC_Face[], const real MinPres,
                            const bool DE_Consistency )
@@ -105,7 +105,7 @@ void InterpolateGhostZone( const int lv, const int PID, real IntData[], const in
 #  endif // MODEL
 
 #  ifdef GRAVITY
-   const bool PrepPot      = ( TVar & _POTE     ) ? true : false;
+   const bool PrepPot         = ( TVar & _POTE ) ? true : false;
 #  endif
 
 #  if ( MODEL == HYDRO  ||  MODEL == MHD )

--- a/src/Main/InterpolateGhostZone.cpp
+++ b/src/Main/InterpolateGhostZone.cpp
@@ -65,7 +65,7 @@ static int Table_01( const int SibID, const int Side, const char dim, const int 
 void InterpolateGhostZone( const int lv, const int PID, real IntData[], const int SibID, const double PrepTime,
                            const int GhostSize, const IntScheme_t IntScheme, const int NTSib[], int *TSib[],
                            const long TVar, const int NVar_Tot, const int NVar_Flu, const int TFluVarIdxList[],
-                           const int NVar_Der, const int TDerVarList[], const bool IntPhase,
+                           const int NVar_Der, const long TDerVarList[], const bool IntPhase,
                            const OptFluBC_t FluBC[], const OptPotBC_t PotBC, const int BC_Face[], const real MinPres,
                            const bool DE_Consistency )
 {

--- a/src/Main/Prepare_PatchData.cpp
+++ b/src/Main/Prepare_PatchData.cpp
@@ -2,7 +2,7 @@
 
 void InterpolateGhostZone( const int lv, const int PID, real IntData[], const int SibID, const double PrepTime,
                            const int GhostSize, const IntScheme_t IntScheme, const int NTSib[], int *TSib[],
-                           const int TVar, const int NVar_Tot, const int NVar_Flu, const int TFluVarIdxList[],
+                           const long TVar, const int NVar_Tot, const int NVar_Flu, const int TFluVarIdxList[],
                            const int NVar_Der, const int TDerVarList[], const bool IntPhase,
                            const OptFluBC_t FluBC[], const OptPotBC_t PotBC, const int BC_Face[], const real MinPres,
                            const bool DE_Consistency );
@@ -116,7 +116,7 @@ bool ParDensArray_Initialized = false;
 //                                     in all patches already satisfy this consistency check
 //-------------------------------------------------------------------------------------------------------
 void Prepare_PatchData( const int lv, const double PrepTime, real *h_Input_Array,
-                        const int GhostSize, const int NPG, const int *PID0_List, int TVar,
+                        const int GhostSize, const int NPG, const int *PID0_List, long TVar,
                         const IntScheme_t IntScheme, const PrepUnit_t PrepUnit, const NSide_t NSide,
                         const bool IntPhase, const OptFluBC_t FluBC[], const OptPotBC_t PotBC,
                         const real MinDens, const real MinPres, const bool DE_Consistency )
@@ -130,7 +130,7 @@ void Prepare_PatchData( const int lv, const double PrepTime, real *h_Input_Array
 // --> to be more cautious, we apply these checks even when GAMER_DEBUG is off
 //#  ifdef GAMER_DEBUG
 
-   int AllVar = ( _TOTAL | _DERIVED );
+   long AllVar = ( _TOTAL | _DERIVED );
 #  ifdef GRAVITY
    AllVar |= _POTE;
 #  endif
@@ -138,7 +138,7 @@ void Prepare_PatchData( const int lv, const double PrepTime, real *h_Input_Array
    AllVar |= _PAR_DENS;
    AllVar |= _TOTAL_DENS;
 #  endif
-   if ( TVar & ~AllVar )   Aux_Error( ERROR_INFO, "unsupported parameter %s = %d !!\n", "TVar", TVar );
+   if ( TVar & ~AllVar )   Aux_Error( ERROR_INFO, "unsupported parameter %s = %ld !!\n", "TVar", TVar );
 
    if ( MinDens >= (real)0.0 )
    {
@@ -294,11 +294,11 @@ void Prepare_PatchData( const int lv, const double PrepTime, real *h_Input_Array
    SetTargetSibling( NTSib, TSib );
 
 // determine the components to be prepared
-// --> assuming that _VAR_NAME = 1<<VAR_NAME (e.g., _DENS == 1<<DENS)
+// --> assuming that _VAR_NAME = 1L<<VAR_NAME (e.g., _DENS == 1L<<DENS)
 // --> it also determines the order of variables stored in h_Input_Array (which is the same as patch->fluid[])
    NVar_Flu = 0;
    for (int v=0; v<NCOMP_TOTAL; v++)
-      if ( TVar & (1<<v) )    TFluVarIdxList[ NVar_Flu++ ] = v;
+      if ( TVar & (1L<<v) )   TFluVarIdxList[ NVar_Flu++ ] = v;
 
    NVar_Der = 0;
 

--- a/src/Main/Prepare_PatchData.cpp
+++ b/src/Main/Prepare_PatchData.cpp
@@ -3,7 +3,7 @@
 void InterpolateGhostZone( const int lv, const int PID, real IntData[], const int SibID, const double PrepTime,
                            const int GhostSize, const IntScheme_t IntScheme, const int NTSib[], int *TSib[],
                            const long TVar, const int NVar_Tot, const int NVar_Flu, const int TFluVarIdxList[],
-                           const int NVar_Der, const int TDerVarList[], const bool IntPhase,
+                           const int NVar_Der, const long TDerVarList[], const bool IntPhase,
                            const OptFluBC_t FluBC[], const OptPotBC_t PotBC, const int BC_Face[], const real MinPres,
                            const bool DE_Consistency );
 static void SetTargetSibling( int NTSib[], int *TSib[] );
@@ -304,7 +304,7 @@ void Prepare_PatchData( const int lv, const double PrepTime, real *h_Input_Array
 
 #  if   ( MODEL == HYDRO )
    const int NVar_Der_Max = 5;
-   int TDerVarList[NVar_Der_Max];
+   long TDerVarList[NVar_Der_Max];
 
    if ( PrepVx   )   TDerVarList[ NVar_Der ++ ] = _VELX;
    if ( PrepVy   )   TDerVarList[ NVar_Der ++ ] = _VELY;
@@ -318,7 +318,7 @@ void Prepare_PatchData( const int lv, const double PrepTime, real *h_Input_Array
 #  elif ( MODEL == ELBDM )
 // no derived variables yet
    const int NVar_Der_Max = 0;
-   int *TDerVarList = NULL;
+   long *TDerVarList = NULL;
 
 #  else
 #  error : unsupported MODEL !!

--- a/src/Model_Hydro/Hydro_BoundaryCondition_Reflecting.cpp
+++ b/src/Model_Hydro/Hydro_BoundaryCondition_Reflecting.cpp
@@ -3,22 +3,22 @@
 #if ( MODEL == HYDRO )
 
 static void BC_Reflecting_xm( real *Array, const int NVar_Flu, const int TFluVarIdxList[], const int NVar_Der,
-                              const int TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
+                              const long TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
                               const int ArraySizeZ, const int Idx_Start[], const int Idx_End[] );
 static void BC_Reflecting_xp( real *Array, const int NVar_Flu, const int TFluVarIdxList[], const int NVar_Der,
-                              const int TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
+                              const long TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
                               const int ArraySizeZ, const int Idx_Start[], const int Idx_End[] );
 static void BC_Reflecting_ym( real *Array, const int NVar_Flu, const int TFluVarIdxList[], const int NVar_Der,
-                              const int TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
+                              const long TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
                               const int ArraySizeZ, const int Idx_Start[], const int Idx_End[] );
 static void BC_Reflecting_yp( real *Array, const int NVar_Flu, const int TFluVarIdxList[], const int NVar_Der,
-                              const int TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
+                              const long TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
                               const int ArraySizeZ, const int Idx_Start[], const int Idx_End[] );
 static void BC_Reflecting_zm( real *Array, const int NVar_Flu, const int TFluVarIdxList[], const int NVar_Der,
-                              const int TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
+                              const long TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
                               const int ArraySizeZ, const int Idx_Start[], const int Idx_End[] );
 static void BC_Reflecting_zp( real *Array, const int NVar_Flu, const int TFluVarIdxList[], const int NVar_Der,
-                              const int TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
+                              const long TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
                               const int ArraySizeZ, const int Idx_Start[], const int Idx_End[] );
 
 
@@ -47,7 +47,7 @@ static void BC_Reflecting_zp( real *Array, const int NVar_Flu, const int TFluVar
 void Hydro_BoundaryCondition_Reflecting( real *Array, const int BC_Face, const int NVar_Flu, const int GhostSize,
                                          const int ArraySizeX, const int ArraySizeY, const int ArraySizeZ,
                                          const int Idx_Start[], const int Idx_End[], const int TFluVarIdxList[],
-                                         const int NVar_Der, const int TDerVarList[] )
+                                         const int NVar_Der, const long TDerVarList[] )
 {
 
 // check the index range
@@ -137,7 +137,7 @@ void Hydro_BoundaryCondition_Reflecting( real *Array, const int BC_Face, const i
 // Return      :  Array
 //-------------------------------------------------------------------------------------------------------
 void BC_Reflecting_xm( real *Array, const int NVar_Flu, const int TFluVarIdxList[], const int NVar_Der,
-                       const int TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
+                       const long TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
                        const int ArraySizeZ, const int Idx_Start[], const int Idx_End[] )
 {
 
@@ -227,7 +227,7 @@ void BC_Reflecting_xm( real *Array, const int NVar_Flu, const int TFluVarIdxList
 // Return      :  Array
 //-------------------------------------------------------------------------------------------------------
 void BC_Reflecting_xp( real *Array, const int NVar_Flu, const int TFluVarIdxList[], const int NVar_Der,
-                       const int TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
+                       const long TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
                        const int ArraySizeZ, const int Idx_Start[], const int Idx_End[] )
 {
 
@@ -317,7 +317,7 @@ void BC_Reflecting_xp( real *Array, const int NVar_Flu, const int TFluVarIdxList
 // Return      :  Array
 //-------------------------------------------------------------------------------------------------------
 void BC_Reflecting_ym( real *Array, const int NVar_Flu, const int TFluVarIdxList[], const int NVar_Der,
-                       const int TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
+                       const long TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
                        const int ArraySizeZ, const int Idx_Start[], const int Idx_End[] )
 {
 
@@ -407,7 +407,7 @@ void BC_Reflecting_ym( real *Array, const int NVar_Flu, const int TFluVarIdxList
 // Return      :  Array
 //-------------------------------------------------------------------------------------------------------
 void BC_Reflecting_yp( real *Array, const int NVar_Flu, const int TFluVarIdxList[], const int NVar_Der,
-                       const int TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
+                       const long TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
                        const int ArraySizeZ, const int Idx_Start[], const int Idx_End[] )
 {
 
@@ -497,7 +497,7 @@ void BC_Reflecting_yp( real *Array, const int NVar_Flu, const int TFluVarIdxList
 // Return      :  Array
 //-------------------------------------------------------------------------------------------------------
 void BC_Reflecting_zm( real *Array, const int NVar_Flu, const int TFluVarIdxList[], const int NVar_Der,
-                       const int TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
+                       const long TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
                        const int ArraySizeZ, const int Idx_Start[], const int Idx_End[] )
 {
 
@@ -587,7 +587,7 @@ void BC_Reflecting_zm( real *Array, const int NVar_Flu, const int TFluVarIdxList
 // Return      :  Array
 //-------------------------------------------------------------------------------------------------------
 void BC_Reflecting_zp( real *Array, const int NVar_Flu, const int TFluVarIdxList[], const int NVar_Der,
-                       const int TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
+                       const long TDerVarList[], const int GhostSize, const int ArraySizeX, const int ArraySizeY,
                        const int ArraySizeZ, const int Idx_Start[], const int Idx_End[] )
 {
 

--- a/src/Refine/Flag_Real.cpp
+++ b/src/Refine/Flag_Real.cpp
@@ -79,7 +79,8 @@ void Flag_Real( const int lv, const UseLBFunc_t UseLBFunc )
 
 
 // set the variables for the Lohner's error estimator
-   int  Lohner_NVar=0, Lohner_TVar=0, Lohner_Stride;
+   int  Lohner_NVar=0, Lohner_Stride;
+   long Lohner_TVar=0;
    real MinDens=-1.0, MinPres=-1.0;    // default is to turn off minimum density/pressure checks
 
 #  if   ( MODEL == HYDRO  ||  MODEL == MHD )

--- a/src/Refine/Refine.cpp
+++ b/src/Refine/Refine.cpp
@@ -94,8 +94,8 @@ void Refine( const int lv, const UseLBFunc_t UseLBFunc )
 
 
 // determine the priority of different boundary faces (z>y>x) to set the corner cells properly for the non-periodic B.C.
-   const int  NDer       = 0;
-   const int *DerVarList = NULL;
+   const int   NDer       = 0;
+   const long *DerVarList = NULL;
 
    int BC_Face[26], BC_Face_tmp[3], FluVarIdxList[NCOMP_TOTAL];
 

--- a/tool/analysis/gamer_extract_profile/GAMER_Functions/InterpolateGhostZone.cpp
+++ b/tool/analysis/gamer_extract_profile/GAMER_Functions/InterpolateGhostZone.cpp
@@ -44,7 +44,7 @@ static int Table_01( const int SibID, const int Side, const char dim, const int 
 //                IntPhase       : true --> Perform interpolation on rho/phase instead of real/imag parts in ELBDM
 //-------------------------------------------------------------------------------------------------------
 void InterpolateGhostZone( const int lv, const int PID, real IntData[], const int SibID, const int GhostSize, 
-                           const IntScheme_t IntScheme, const int NTSib[], int *TSib[], const int TVar, const int NVar_Tot,
+                           const IntScheme_t IntScheme, const int NTSib[], int *TSib[], const long TVar, const int NVar_Tot,
                            const int NVar_Flu, const int TFluVarIdxList[], const bool IntPhase )
 {
 

--- a/tool/analysis/gamer_extract_profile/GAMER_Functions/Prepare_PatchData.cpp
+++ b/tool/analysis/gamer_extract_profile/GAMER_Functions/Prepare_PatchData.cpp
@@ -1,7 +1,7 @@
 #include "ExtractProfile.h"
 
 void InterpolateGhostZone( const int lv, const int PID, real IntData[], const int SibID, const int GhostSize, 
-                           const IntScheme_t IntScheme, const int NTSib[], int *TSib[], const int TVar, const int NVar_Tot,
+                           const IntScheme_t IntScheme, const int NTSib[], int *TSib[], const long TVar, const int NVar_Tot,
                            const int NVar_Flu, const int TFluVarIdxList[], const bool IntPhase );
 static void SetTargetSibling( int NTSib[], int *TSib[] );
 static int Table_01( const int SibID, const char dim, const int Count, const int GhostSize );
@@ -51,7 +51,7 @@ static int Table_02( const int lv, const int PID, const int Side );
 //                                      --> TVar must contain _REAL and _IMAG
 //-------------------------------------------------------------------------------------------------------
 void Prepare_PatchData( const int lv, real *h_Input_Array, const int GhostSize, const int NPG, const int *PID0_List, 
-                        const int TVar, const IntScheme_t IntScheme, const NSide_t NSide, const bool IntPhase )
+                        const long TVar, const IntScheme_t IntScheme, const NSide_t NSide, const bool IntPhase )
 {
 
 // check
@@ -85,7 +85,7 @@ void Prepare_PatchData( const int lv, real *h_Input_Array, const int GhostSize, 
 // determine the components to be prepared
    NVar_Flu = 0;
    for (int v=0; v<NCOMP_TOTAL; v++)
-      if ( TVar & (1<<v) )    TFluVarIdxList[ NVar_Flu++ ] = v;
+      if ( TVar & (1L<<v) )   TFluVarIdxList[ NVar_Flu++ ] = v;
 
    NVar_Tot = NVar_Flu;
 

--- a/tool/analysis/gamer_extract_profile/Header/Prototype.h
+++ b/tool/analysis/gamer_extract_profile/Header/Prototype.h
@@ -32,7 +32,7 @@ void Aux_Error( const char *File, const int Line, const char *Func, const char *
 void Aux_Message( FILE *Type, const char *Format, ... );
 bool Aux_CheckFileExist( const char *FileName );
 void Prepare_PatchData( const int lv, real *h_Input_Array, const int GhostSize, const int NPG, const int *PID0_List, 
-                        const int TVar, const IntScheme_t IntScheme, const NSide_t NSide, const bool IntPhase );
+                        const long TVar, const IntScheme_t IntScheme, const NSide_t NSide, const bool IntPhase );
 void Int_Table( const IntScheme_t IntScheme, int &NSide, int &NGhost );
 void Interpolate( real CData [], const int CSize[3], const int CStart[3], const int CRange[3],
                   real FData [], const int FSize[3], const int FStart[3], 

--- a/tool/analysis/gamer_extract_profile/Header/TypeDef.h
+++ b/tool/analysis/gamer_extract_profile/Header/TypeDef.h
@@ -62,11 +62,11 @@ typedef float  real;
 #  define MOMZ             3
 #  define ENGY             4
 
-#  define _DENS            ( 1 << (DENS) )
-#  define _MOMX            ( 1 << (MOMX) )
-#  define _MOMY            ( 1 << (MOMY) )
-#  define _MOMZ            ( 1 << (MOMZ) )
-#  define _ENGY            ( 1 << (ENGY) )
+#  define _DENS            ( 1L << (DENS) )
+#  define _MOMX            ( 1L << (MOMX) )
+#  define _MOMY            ( 1L << (MOMY) )
+#  define _MOMZ            ( 1L << (MOMZ) )
+#  define _ENGY            ( 1L << (ENGY) )
 
 #elif ( MODEL == MHD )
 #  warning : WAIT MHD !!!
@@ -78,9 +78,9 @@ typedef float  real;
 #  define REAL             1
 #  define IMAG             2
 
-#  define _DENS            ( 1 << (DENS) )
-#  define _REAL            ( 1 << (REAL) )
-#  define _IMAG            ( 1 << (IMAG) )
+#  define _DENS            ( 1L << (DENS) )
+#  define _REAL            ( 1L << (REAL) )
+#  define _IMAG            ( 1L << (IMAG) )
 
 #else
 #  error : ERROR : unsupported MODEL !!
@@ -90,11 +90,11 @@ typedef float  real;
 
 
 // symbolic constants used by all models
-#  define _FLUID           (  ( 1 << NCOMP_FLUID ) - 1           )
-#  define _PASSIVE         (  ( 1 << NCOMP_TOTAL ) - 1 - _FLUID  )
-#  define _TOTAL           (  ( 1 << NCOMP_TOTAL ) - 1           )
-#  define _POTE            ( 1 << NCOMP_TOTAL   )
-#  define _PAR_DENS        ( 1 << NCOMP_TOTAL+1 )
+#  define _FLUID           (  ( 1L << NCOMP_FLUID ) - 1L           )
+#  define _PASSIVE         (  ( 1L << NCOMP_TOTAL ) - 1L - _FLUID  )
+#  define _TOTAL           (  ( 1L << NCOMP_TOTAL ) - 1L           )
+#  define _POTE            ( 1L << (NCOMP_TOTAL  ) )
+#  define _PAR_DENS        ( 1L << (NCOMP_TOTAL+1) )
 
 
 // 3D to 1D array indices transformation

--- a/tool/analysis/gamer_extract_profile/Main.cpp
+++ b/tool/analysis/gamer_extract_profile/Main.cpp
@@ -276,7 +276,8 @@ void GetRMS()
    const int NPG       = 1;
    const NSide_t NSide = NSIDE_26;
 
-   int    ShellID, Var, i, j, k, im, jm, km, ip, jp, kp, TVar, POTE, PAR_DENS, NextIdx;
+   int    ShellID, Var, i, j, k, im, jm, km, ip, jp, kp, POTE, PAR_DENS, NextIdx;
+   long   TVar;
    double Radius, scale, dv;
    double x, x1, x2, y, y1, y2, z, z1, z2;   // (x,y,z) : relative coordinates to the vector "Center"
    real   pass[NCOMP_PASSIVE];
@@ -540,7 +541,8 @@ void ShellAverage()
    const int NPG       = 1;
    const NSide_t NSide = NSIDE_26;
 
-   int    ShellID, Var, i, j, k, im, jm, km, ip, jp, kp, TVar, POTE, PAR_DENS, NextIdx;
+   int    ShellID, Var, i, j, k, im, jm, km, ip, jp, kp, POTE, PAR_DENS, NextIdx;
+   long   TVar;
    double Radius, scale, dv;
    double x, x1, x2, y, y1, y2, z, z1, z2;   // (x,y,z) : relative coordinates to the vector "Center"
    real   pass[NCOMP_PASSIVE];


### PR DESCRIPTION
Declare all bitwise index variables (e.g., `_DENS`) as `long` instead of `int`. Verified by running a Plummer collision test with 40 passive scalars. This resolves #17.
@wt-liao Can you take a look?