### PR TITLE
Scatter particle IC

### DIFF
--- a/include/Macro.h
+++ b/include/Macro.h
@@ -489,6 +489,9 @@
 #  define _PAR_ACCZ           ( 1L << PAR_ACCZ )
 # endif
 #  define _PAR_TIME           ( 1L << PAR_TIME )
+#  define _PAR_POS            ( _PAR_POSX | _PAR_POSY | _PAR_POSZ )
+#  define _PAR_VEL            ( _PAR_VELX | _PAR_VELY | _PAR_VELZ )
+#  define _PAR_ACC            ( _PAR_ACCX | _PAR_ACCY | _PAR_ACCZ )
 #  define _PAR_TOTAL          (  ( 1L << PAR_NATT_TOTAL ) - 1L )
 
 // grid fields related to particles
@@ -849,6 +852,14 @@
 
 // maximum length for strings
 #define MAX_STRING         512
+
+
+// MPI floating-point data type
+#ifdef FLOAT8
+#  define MPI_GAMER_REAL MPI_DOUBLE
+#else
+#  define MPI_GAMER_REAL MPI_FLOAT
+#endif
 
 
 

--- a/include/Par_EquilibriumIC.h
+++ b/include/Par_EquilibriumIC.h
@@ -40,7 +40,7 @@ typedef struct Physical_Parameter{
    double*  Cloud_Center;
    double*  Cloud_BulkVel;
    double   Cloud_Einasto_Power_Factor;
-   double   Cloud_Par_Num;
+   long     Cloud_Par_Num;
 
    int      Cloud_MassProfNBin;
 }PhysP;

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -611,6 +611,8 @@ void Par_PredictPos( const long NPar, const long *ParList, real *ParPosX, real *
                      const double TargetTime );
 void Par_Init_Attribute();
 void Par_AddParticleAfterInit( const long NNewPar, real *NewParAtt[PAR_NATT_TOTAL] );
+void Par_ScatterParticleData( const long NPar_ThisRank, const long NPar_AllRank, const long AttBitIdx,
+                              real *Data_Send[PAR_NATT_TOTAL], real *Data_Recv[PAR_NATT_TOTAL] );
 FieldIdx_t AddParticleAttribute( const char *InputLabel );
 FieldIdx_t GetParticleAttributeIndex( const char *InputLabel, const Check_t Check );
 #ifdef LOAD_BALANCE

--- a/src/Makefile
+++ b/src/Makefile
@@ -566,7 +566,8 @@ CPU_FILE    += Par_Init_ByFunction.cpp  Par_Output_TextFile.cpp  Par_FindHomePat
                Par_PassParticle2Sibling.cpp  Par_CountParticleInDescendant.cpp  Par_Aux_GetConservedQuantity.cpp \
                Par_Aux_InitCheck.cpp  Par_Aux_Record_ParticleCount.cpp  Par_PassParticle2Son_MultiPatch.cpp \
                Par_Synchronize.cpp  Par_PredictPos.cpp  Par_Init_ByFile.cpp  Par_Init_Attribute.cpp \
-               Par_AddParticleAfterInit.cpp  Par_PassParticle2Son_SinglePatch.cpp  Par_EquilibriumIC.cpp
+               Par_AddParticleAfterInit.cpp  Par_PassParticle2Son_SinglePatch.cpp  Par_EquilibriumIC.cpp \
+               Par_ScatterParticleData.cpp
 
 vpath %.cu     Particle/GPU
 vpath %.cpp    Particle/CPU  Particle

--- a/src/Particle/Par_EquilibriumIC.cpp
+++ b/src/Particle/Par_EquilibriumIC.cpp
@@ -301,13 +301,13 @@ void Par_EquilibriumIC::Init()
 // Parameter   :  Mass_AllRank : An array of all particles' masses
 //                Pos_AllRank  : An array of all particles' position vectors
 //                Vel_AllRank  : An array of all particles' velocity vectors
-//                Par_Idx      : Starting index of particles in this cloud
+//                Par_Idx0     : Starting index of particles in this cloud
 //
 // Return      :  Mass_AllRank
 //                Pos_AllRank
 //                Vel_AllRank
 //-------------------------------------------------------------------------------------------------------
-void Par_EquilibriumIC::Par_SetEquilibriumIC( real *Mass_AllRank, real *Pos_AllRank[3], real *Vel_AllRank[3], const long Par_Idx )
+void Par_EquilibriumIC::Par_SetEquilibriumIC( real *Mass_AllRank, real *Pos_AllRank[3], real *Vel_AllRank[3], const long Par_Idx0 )
 {
 
    double *Table_MassProf_r = NULL;
@@ -333,7 +333,7 @@ void Par_EquilibriumIC::Par_SetEquilibriumIC( real *Mass_AllRank, real *Pos_AllR
    }
 
    // set particle attributes
-   for (long p = Par_Idx; p<Par_Idx + params.Cloud_Par_Num; p++)
+   for (long p=Par_Idx0; p<Par_Idx0+params.Cloud_Par_Num; p++)
    {
       // mass
       Mass_AllRank[p] = ParM;

--- a/src/Particle/Par_EquilibriumIC.cpp
+++ b/src/Particle/Par_EquilibriumIC.cpp
@@ -116,11 +116,11 @@ void Par_EquilibriumIC::Load_Physical_Params( const FP filename_para, const int 
    delete ReadPara;
 
    // Convert Cloud_Par_Num_Ratio to Cloud_Par_Num
-   params.Cloud_Par_Num = int(ratio*NPar_AllRank);
+   params.Cloud_Par_Num = long(ratio*NPar_AllRank);
 
    // Check whether user forgot to fill in Cloud_Par_Num_Ratio
    if(params.Cloud_Par_Num==0){
-      Aux_Error( ERROR_INFO, "Cloud_Par_Num_Ratio is 0! There are no particles in this cloud!!");
+      Aux_Error( ERROR_INFO, "Cloud_Par_Num_Ratio is 0! There is no particle in this cloud!!" );
    }
 
    // (1-2) set the default values

--- a/src/Particle/Par_ScatterParticleData.cpp
+++ b/src/Particle/Par_ScatterParticleData.cpp
@@ -1,0 +1,64 @@
+#include "GAMER.h"
+
+#ifdef PARTICLE
+
+
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  Par_ScatterParticleData
+// Description :  Scatter particle data from the root rank to all ranks
+//
+// Note        :  1. Typically called by a particle initial condition routine like Par_Init_ByFunction_*()
+//                2. Do not put this file in "Particle/LoadBalance" since we still need to copy data from
+//                   Data_Send[] to Data_Recv[] in the serial mode
+//
+// Parameter   :  NPar_ThisRank : Number of particles to be received by this MPI rank
+//                NPar_AllRank  : Total number of particles in all MPI ranks
+//                AttBitIdx     : Bitwise indices of the target particle attributes (e.g., _PAR_MASS | _PAR_VELX)
+//                                --> A user-defined attribute with an integer index AttIntIdx returned by
+//                                    AddParticleAttribute() can be converted to a bitwise index by BIDX(AttIntIdx)
+//                Data_Send     : Pointer array for all particle attributes to be sent
+//                                --> Dimension = [PAR_NATT_TOTAL][NPar_AllRank]
+//                                --> Target particle attributes are set by "AttBitIdx"
+//                Data_Recv     : Pointer array for all particle attributes to be received
+//
+// Return      :  Data_Recv
+//-------------------------------------------------------------------------------------------------------
+void Par_ScatterParticleData( const long NPar_ThisRank, const long NPar_AllRank, const long AttBitIdx,
+                              real *Data_Send[PAR_NATT_TOTAL], real *Data_Recv[PAR_NATT_TOTAL] )
+{
+
+// check integer overflow in MPI
+   if ( NPar_AllRank > (long)__INT_MAX__ )
+      Aux_Error( ERROR_INFO, "Total number of particles (%ld) exceeds the maximum integer (%ld) --> MPI will likely fail !!\n",
+                 NPar_AllRank, (long)__INT_MAX__ );
+
+
+// get the number of particles in each rank and set the corresponding offsets
+   int NSend[MPI_NRank], SendDisp[MPI_NRank];
+   int NPar_ThisRank_int = NPar_ThisRank;    // (i) convert to "int" and (ii) remove the "const" declaration
+                                             // --> (ii) is necessary for OpenMPI version < 1.7
+
+   MPI_Gather( &NPar_ThisRank_int, 1, MPI_INT, NSend, 1, MPI_INT, 0, MPI_COMM_WORLD );
+
+   if ( MPI_Rank == 0 )
+   {
+      SendDisp[0] = 0;
+      for (int r=1; r<MPI_NRank; r++)  SendDisp[r] = SendDisp[r-1] + NSend[r-1];
+   }
+
+
+// send particle attributes (one at a time) from the root rank to all ranks
+   for (int v=0; v<PAR_NATT_TOTAL; v++)
+   {
+      if ( AttBitIdx & (1L<<v) )    MPI_Scatterv( Data_Send[v], NSend, SendDisp, MPI_GAMER_REAL,
+                                                  Data_Recv[v], NPar_ThisRank,   MPI_GAMER_REAL,
+                                                  0, MPI_COMM_WORLD );
+   }
+
+} // FUNCTION : Par_ScatterParticleData
+
+
+
+#endif // #ifdef PARTICLE

--- a/src/TestProblem/Hydro/Plummer/Par_Init_ByFunction_Plummer.cpp
+++ b/src/TestProblem/Hydro/Plummer/Par_Init_ByFunction_Plummer.cpp
@@ -65,9 +65,8 @@ void Par_Init_ByFunction_Plummer( const long NPar_ThisRank, const long NPar_AllR
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ...\n", __FUNCTION__ );
 
 
-   real *Mass_AllRank   = NULL;
-   real *Pos_AllRank[3] = { NULL, NULL, NULL };
-   real *Vel_AllRank[3] = { NULL, NULL, NULL };
+   real *ParData_AllRank[PAR_NATT_TOTAL];
+   for (int v=0; v<PAR_NATT_TOTAL; v++)   ParData_AllRank[v] = NULL;
 
 // only the master rank will construct the initial condition
    if ( MPI_Rank == 0 )
@@ -81,12 +80,13 @@ void Par_Init_ByFunction_Plummer( const long NPar_ThisRank, const long NPar_AllR
       double  TotM, ParM, dr, RanM, RanR, EstM, ErrM, ErrM_Max=-1.0, RanVec[3];
       double  Vmax, RanV, RanProb, Prob;
 
-      Mass_AllRank = new real [NPar_AllRank];
-      for (int d=0; d<3; d++)
-      {
-         Pos_AllRank[d] = new real [NPar_AllRank];
-         Vel_AllRank[d] = new real [NPar_AllRank];
-      }
+      ParData_AllRank[PAR_MASS] = new real [NPar_AllRank];
+      ParData_AllRank[PAR_POSX] = new real [NPar_AllRank];
+      ParData_AllRank[PAR_POSY] = new real [NPar_AllRank];
+      ParData_AllRank[PAR_POSZ] = new real [NPar_AllRank];
+      ParData_AllRank[PAR_VELX] = new real [NPar_AllRank];
+      ParData_AllRank[PAR_VELY] = new real [NPar_AllRank];
+      ParData_AllRank[PAR_VELZ] = new real [NPar_AllRank];
 
 
 //    initialize the random number generator
@@ -121,7 +121,7 @@ void Par_Init_ByFunction_Plummer( const long NPar_ThisRank, const long NPar_AllR
       for (long p=0; p<NPar_AllRank; p++)
       {
 //       mass
-         Mass_AllRank[p] = ParM;
+         ParData_AllRank[PAR_MASS][p] = ParM;
 
 
 //       position
@@ -136,17 +136,17 @@ void Par_Init_ByFunction_Plummer( const long NPar_ThisRank, const long NPar_AllR
 
 //       randomly set the position vector with a given radius
          RanVec_FixRadius( RanR, RanVec );
-         for (int d=0; d<3; d++)    Pos_AllRank[d][p] = RanVec[d] + Plummer_Center[d];
+         for (int d=0; d<3; d++)    ParData_AllRank[PAR_POSX+d][p] = RanVec[d] + Plummer_Center[d];
 
 //       set position offset for the Plummer collision test
          if ( Plummer_Collision )
-         for (int d=0; d<3; d++)    Pos_AllRank[d][p] += Coll_Offset*( (p<NPar_AllRank/2)?-1.0:+1.0 );
+         for (int d=0; d<3; d++)    ParData_AllRank[PAR_POSX+d][p] += Coll_Offset*( (p<NPar_AllRank/2)?-1.0:+1.0 );
 
 //       check periodicity
          for (int d=0; d<3; d++)
          {
             if ( OPT__BC_FLU[d*2] == BC_FLU_PERIODIC )
-               Pos_AllRank[d][p] = FMOD( Pos_AllRank[d][p]+(real)amr->BoxSize[d], (real)amr->BoxSize[d] );
+               ParData_AllRank[PAR_POSX+d][p] = FMOD( ParData_AllRank[PAR_POSX+d][p]+(real)amr->BoxSize[d], (real)amr->BoxSize[d] );
          }
 
 
@@ -165,7 +165,7 @@ void Par_Init_ByFunction_Plummer( const long NPar_ThisRank, const long NPar_AllR
 
 //       randomly set the velocity vector with the given amplitude (RanV*Vmax)
          RanVec_FixRadius( RanV*Vmax, RanVec );
-         for (int d=0; d<3; d++)    Vel_AllRank[d][p] = RanVec[d] + Plummer_BulkVel[d];
+         for (int d=0; d<3; d++)    ParData_AllRank[PAR_VELX+d][p] = RanVec[d] + Plummer_BulkVel[d];
 
       } // for (long p=0; p<NPar_AllRank; p++)
 
@@ -186,59 +186,15 @@ void Par_Init_ByFunction_Plummer( const long NPar_ThisRank, const long NPar_AllR
    for (long p=0; p<NPar_ThisRank; p++)   ParTime[p] = Time[0];
 
 
-// get the number of particles in each rank and set the corresponding offsets
-   if ( NPar_AllRank > (long)__INT_MAX__ )
-      Aux_Error( ERROR_INFO, "NPar_Active_AllRank (%ld) exceeds the maximum integer (%ld) --> MPI will likely fail !!\n",
-                 NPar_AllRank, (long)__INT_MAX__ );
-
-   int NSend[MPI_NRank], SendDisp[MPI_NRank];
-   int NPar_ThisRank_int = NPar_ThisRank;    // (i) convert to "int" and (ii) remove the "const" declaration
-                                             // --> (ii) is necessary for OpenMPI version < 1.7
-
-   MPI_Gather( &NPar_ThisRank_int, 1, MPI_INT, NSend, 1, MPI_INT, 0, MPI_COMM_WORLD );
-
-   if ( MPI_Rank == 0 )
-   {
-      SendDisp[0] = 0;
-      for (int r=1; r<MPI_NRank; r++)  SendDisp[r] = SendDisp[r-1] + NSend[r-1];
-   }
-
-
 // send particle attributes from the master rank to all ranks
-   real *Mass   =   ParMass;
-   real *Pos[3] = { ParPosX, ParPosY, ParPosZ };
-   real *Vel[3] = { ParVelX, ParVelY, ParVelZ };
-
-#  ifdef FLOAT8
-   MPI_Scatterv( Mass_AllRank, NSend, SendDisp, MPI_DOUBLE, Mass, NPar_ThisRank, MPI_DOUBLE, 0, MPI_COMM_WORLD );
-
-   for (int d=0; d<3; d++)
-   {
-      MPI_Scatterv( Pos_AllRank[d], NSend, SendDisp, MPI_DOUBLE, Pos[d], NPar_ThisRank, MPI_DOUBLE, 0, MPI_COMM_WORLD );
-      MPI_Scatterv( Vel_AllRank[d], NSend, SendDisp, MPI_DOUBLE, Vel[d], NPar_ThisRank, MPI_DOUBLE, 0, MPI_COMM_WORLD );
-   }
-
-#  else
-   MPI_Scatterv( Mass_AllRank, NSend, SendDisp, MPI_FLOAT,  Mass, NPar_ThisRank, MPI_FLOAT,  0, MPI_COMM_WORLD );
-
-   for (int d=0; d<3; d++)
-   {
-      MPI_Scatterv( Pos_AllRank[d], NSend, SendDisp, MPI_FLOAT,  Pos[d], NPar_ThisRank, MPI_FLOAT,  0, MPI_COMM_WORLD );
-      MPI_Scatterv( Vel_AllRank[d], NSend, SendDisp, MPI_FLOAT,  Vel[d], NPar_ThisRank, MPI_FLOAT,  0, MPI_COMM_WORLD );
-   }
-#  endif
+   Par_ScatterParticleData( NPar_ThisRank, NPar_AllRank, _PAR_MASS|_PAR_POS|_PAR_VEL, ParData_AllRank, AllAttribute );
 
 
+// free resource
    if ( MPI_Rank == 0 )
    {
       delete RNG;
-      delete [] Mass_AllRank;
-
-      for (int d=0; d<3; d++)
-      {
-         delete [] Pos_AllRank[d];
-         delete [] Vel_AllRank[d];
-      }
+      for (int v=0; v<PAR_NATT_TOTAL; v++)   delete [] ParData_AllRank[v];
    }
 
 

--- a/src/TestProblem/Hydro/Plummer/Par_Init_ByFunction_Plummer.cpp
+++ b/src/TestProblem/Hydro/Plummer/Par_Init_ByFunction_Plummer.cpp
@@ -182,12 +182,12 @@ void Par_Init_ByFunction_Plummer( const long NPar_ThisRank, const long NPar_AllR
    } // if ( MPI_Rank == 0 )
 
 
-// synchronize all particles to the physical time on the base level
-   for (long p=0; p<NPar_ThisRank; p++)   ParTime[p] = Time[0];
-
-
 // send particle attributes from the master rank to all ranks
    Par_ScatterParticleData( NPar_ThisRank, NPar_AllRank, _PAR_MASS|_PAR_POS|_PAR_VEL, ParData_AllRank, AllAttribute );
+
+
+// synchronize all particles to the physical time on the base level
+   for (long p=0; p<NPar_ThisRank; p++)   ParTime[p] = Time[0];
 
 
 // free resource


### PR DESCRIPTION
- Add `Par_ScatterParticleData()` to scatter the particle initial condition from the root rank
  - Apply to the test problems `Plummer` and `ParticleEquilibriumIC`
- Minor fix/update
  - Declare `Cloud_Par_Num` as `long`
  - Define `PAR_POS/VEL/ACC` and `MPI_GAMER_REAL` in `Macro.h`