### PR TITLE
Better handling for variable-length array pointers

### DIFF
--- a/src/Fluid/Flu_BoundaryCondition_User.cpp
+++ b/src/Fluid/Flu_BoundaryCondition_User.cpp
@@ -158,7 +158,8 @@ void Flu_BoundaryCondition_User( real *Array, const int NVar_Flu, const int Arra
 
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 
 // set the boundary values

--- a/src/Fluid/Flu_DerivedField_BuiltIn.cpp
+++ b/src/Fluid/Flu_DerivedField_BuiltIn.cpp
@@ -58,8 +58,10 @@ void Flu_DerivedField_DivVel( real Out[], const real FluIn[], const real MagIn[]
 
 
 // 1D arrays -> 3D arrays
-   real (*FluIn3D)[NCellInZ ][NCellInY ][NCellInX ] = ( real (*)[NCellInZ ][NCellInY ][NCellInX ] )FluIn;
-   real (*Out3D  )[NCellOutZ][NCellOutY][NCellOutX] = ( real (*)[NCellOutZ][NCellOutY][NCellOutX] )Out;
+   typedef real (*vla_in)[NCellInZ ][NCellInY ][NCellInX ];
+   typedef real (*vla_out)[NCellOutZ][NCellOutY][NCellOutX];
+   vla_in FluIn3D = ( vla_in )FluIn;
+   vla_out Out3D = ( vla_out )Out;
 
 
 // fill in the output array
@@ -138,11 +140,13 @@ void Flu_DerivedField_Mach( real Out[], const real FluIn[], const real MagIn[], 
 
 
 // 1D arrays -> 3D arrays
-   real (*FluIn3D)[NCellInZ ][NCellInY ][NCellInX ] = ( real (*)[NCellInZ ][NCellInY ][NCellInX ] )FluIn;
+   typedef real (*vla_in)[NCellInZ ][NCellInY ][NCellInX ];
+   vla_in FluIn3D = ( vla_in )FluIn;
 #  ifdef MHD
-   real (*MagIn3D)[NCellInZ ][NCellInY ][NCellInX ] = ( real (*)[NCellInZ ][NCellInY ][NCellInX ] )MagIn;
+   vla_in MagIn3D = ( vla_in )MagIn;
 #  endif
-   real (*Out3D  )[NCellOutZ][NCellOutY][NCellOutX] = ( real (*)[NCellOutZ][NCellOutY][NCellOutX] )Out;
+   typedef real (*vla_out)[NCellOutZ][NCellOutY][NCellOutX];
+   vla_out Out3D = ( vla_out )Out;
 
 
 // fill in the output array

--- a/src/Fluid/Flu_DerivedField_User.cpp
+++ b/src/Fluid/Flu_DerivedField_User.cpp
@@ -65,11 +65,13 @@ void Flu_DerivedField_User_Template( real Out[], const real FluIn[], const real 
 
 
 // 1D arrays -> 3D arrays
-   real (*FluIn3D)[NCellInZ ][NCellInY ][NCellInX ] = ( real (*)[NCellInZ ][NCellInY ][NCellInX ] )FluIn;
+   typedef real (*vla_in)[NCellInZ ][NCellInY ][NCellInX ];
+   vla_in FluIn3D = ( vla_in )FluIn;
 #  ifdef MHD
-   real (*MagIn3D)[NCellInZ ][NCellInY ][NCellInX ] = ( real (*)[NCellInZ ][NCellInY ][NCellInX ] )MagIn;
+   vla_in MagIn3D = ( vla_in )MagIn;
 #  endif
-   real (*Out3D  )[NCellOutZ][NCellOutY][NCellOutX] = ( real (*)[NCellOutZ][NCellOutY][NCellOutX] )Out;
+   typedef real (*vla_out)[NCellOutZ][NCellOutY][NCellOutX];
+   vla_out Out3D = ( vla_out )Out;
 
 
 // fill in the output array

--- a/src/Model_Hydro/Hydro_BoundaryCondition_Outflow.cpp
+++ b/src/Model_Hydro/Hydro_BoundaryCondition_Outflow.cpp
@@ -104,7 +104,8 @@ void BC_Outflow_xm( real *Array, const int NVar, const int GhostSize, const int 
    const int i_ref = GhostSize;  // reference i index
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 // set the boundary values
    for (int v=0; v<NVar; v++)
@@ -134,7 +135,8 @@ void BC_Outflow_xp( real *Array, const int NVar, const int GhostSize, const int 
    const int i_ref = ArraySizeX - GhostSize - 1;    // reference i index
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 // set the boundary values
    for (int v=0; v<NVar; v++)
@@ -164,7 +166,8 @@ void BC_Outflow_ym( real *Array, const int NVar, const int GhostSize, const int 
    const int j_ref = GhostSize;  // reference j index
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 // set the boundary values
    for (int v=0; v<NVar; v++)
@@ -194,7 +197,8 @@ void BC_Outflow_yp( real *Array, const int NVar, const int GhostSize, const int 
    const int j_ref = ArraySizeY - GhostSize - 1;    // reference j index
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 // set the boundary values
    for (int v=0; v<NVar; v++)
@@ -224,7 +228,8 @@ void BC_Outflow_zm( real *Array, const int NVar, const int GhostSize, const int 
    const int k_ref = GhostSize;  // reference k index
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 // set the boundary values
    for (int v=0; v<NVar; v++)
@@ -254,7 +259,8 @@ void BC_Outflow_zp( real *Array, const int NVar, const int GhostSize, const int 
    const int k_ref = ArraySizeZ - GhostSize - 1;    // reference k index
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 // set the boundary values
    for (int v=0; v<NVar; v++)

--- a/src/Model_Hydro/Hydro_BoundaryCondition_Reflecting.cpp
+++ b/src/Model_Hydro/Hydro_BoundaryCondition_Reflecting.cpp
@@ -137,7 +137,8 @@ void BC_Reflecting_xm( real *Array, const int NVar_Flu, const int TFluVarIdxList
    int TFluVarIdx, ii;
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 
 // set the boundary values
@@ -219,7 +220,8 @@ void BC_Reflecting_xp( real *Array, const int NVar_Flu, const int TFluVarIdxList
    int TFluVarIdx, ii;
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 
 // set the boundary values
@@ -301,7 +303,8 @@ void BC_Reflecting_ym( real *Array, const int NVar_Flu, const int TFluVarIdxList
    int TFluVarIdx, jj;
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 
 // set the boundary values
@@ -383,7 +386,8 @@ void BC_Reflecting_yp( real *Array, const int NVar_Flu, const int TFluVarIdxList
    int TFluVarIdx, jj;
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 
 // set the boundary values
@@ -465,7 +469,8 @@ void BC_Reflecting_zm( real *Array, const int NVar_Flu, const int TFluVarIdxList
    int TFluVarIdx, kk;
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 
 // set the boundary values
@@ -547,7 +552,8 @@ void BC_Reflecting_zp( real *Array, const int NVar_Flu, const int TFluVarIdxList
    int TFluVarIdx, kk;
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 
 // set the boundary values

--- a/src/Model_Hydro/MHD_BoundaryCondition_Outflow.cpp
+++ b/src/Model_Hydro/MHD_BoundaryCondition_Outflow.cpp
@@ -125,7 +125,8 @@ void BC_Outflow_xm( real **Array, const int NVar, const int TVarIdxList[], const
       {
          case MAGX:
          {
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2]; k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1]; j++)
@@ -137,7 +138,8 @@ void BC_Outflow_xm( real **Array, const int NVar, const int TVarIdxList[], const
 
          case MAGY:
          {
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1]+1; j++)
@@ -149,7 +151,8 @@ void BC_Outflow_xm( real **Array, const int NVar, const int TVarIdxList[], const
 
          case MAGZ:
          {
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2]+1; k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -191,7 +194,8 @@ void BC_Outflow_xp( real **Array, const int NVar, const int TVarIdxList[], const
       {
          case MAGX:
          {
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (int k=Idx_Start[2];   k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1];   j<=Idx_End[1];   j++)
@@ -203,7 +207,8 @@ void BC_Outflow_xp( real **Array, const int NVar, const int TVarIdxList[], const
 
          case MAGY:
          {
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1]+1; j++)
@@ -215,7 +220,8 @@ void BC_Outflow_xp( real **Array, const int NVar, const int TVarIdxList[], const
 
          case MAGZ:
          {
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2]+1; k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -256,7 +262,8 @@ void BC_Outflow_ym( real **Array, const int NVar, const int TVarIdxList[], const
       {
          case MAGX:
          {
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -268,7 +275,8 @@ void BC_Outflow_ym( real **Array, const int NVar, const int TVarIdxList[], const
 
          case MAGY:
          {
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2]; k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1]; j++)
@@ -280,7 +288,8 @@ void BC_Outflow_ym( real **Array, const int NVar, const int TVarIdxList[], const
 
          case MAGZ:
          {
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2]+1; k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -322,7 +331,8 @@ void BC_Outflow_yp( real **Array, const int NVar, const int TVarIdxList[], const
       {
          case MAGX:
          {
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -334,7 +344,8 @@ void BC_Outflow_yp( real **Array, const int NVar, const int TVarIdxList[], const
 
          case MAGY:
          {
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (int k=Idx_Start[2];   k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]+1; j<=Idx_End[1]+1; j++)
@@ -346,7 +357,8 @@ void BC_Outflow_yp( real **Array, const int NVar, const int TVarIdxList[], const
 
          case MAGZ:
          {
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2]+1; k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -387,7 +399,8 @@ void BC_Outflow_zm( real **Array, const int NVar, const int TVarIdxList[], const
       {
          case MAGX:
          {
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -399,7 +412,8 @@ void BC_Outflow_zm( real **Array, const int NVar, const int TVarIdxList[], const
 
          case MAGY:
          {
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1]+1; j++)
@@ -411,7 +425,8 @@ void BC_Outflow_zm( real **Array, const int NVar, const int TVarIdxList[], const
 
          case MAGZ:
          {
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2]; k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1]; j++)
@@ -453,7 +468,8 @@ void BC_Outflow_zp( real **Array, const int NVar, const int TVarIdxList[], const
       {
          case MAGX:
          {
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -465,7 +481,8 @@ void BC_Outflow_zp( real **Array, const int NVar, const int TVarIdxList[], const
 
          case MAGY:
          {
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1]+1; j++)
@@ -477,7 +494,8 @@ void BC_Outflow_zp( real **Array, const int NVar, const int TVarIdxList[], const
 
          case MAGZ:
          {
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (int k=Idx_Start[2]+1; k<=Idx_End[2]+1; k++)
             for (int j=Idx_Start[1];   j<=Idx_End[1];   j++)

--- a/src/Model_Hydro/MHD_BoundaryCondition_Reflecting.cpp
+++ b/src/Model_Hydro/MHD_BoundaryCondition_Reflecting.cpp
@@ -126,7 +126,8 @@ void BC_Reflecting_xm( real **Array, const int NVar, const int TVarIdxList[], co
       {
          case MAGX:
          {
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2]; k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1]; j++)
@@ -138,7 +139,8 @@ void BC_Reflecting_xm( real **Array, const int NVar, const int TVarIdxList[], co
 
          case MAGY:
          {
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1]+1; j++)
@@ -150,7 +152,8 @@ void BC_Reflecting_xm( real **Array, const int NVar, const int TVarIdxList[], co
 
          case MAGZ:
          {
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2]+1; k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -192,7 +195,8 @@ void BC_Reflecting_xp( real **Array, const int NVar, const int TVarIdxList[], co
       {
          case MAGX:
          {
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (int k=Idx_Start[2];   k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1];   j<=Idx_End[1];   j++)
@@ -204,7 +208,8 @@ void BC_Reflecting_xp( real **Array, const int NVar, const int TVarIdxList[], co
 
          case MAGY:
          {
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1]+1; j++)
@@ -216,7 +221,8 @@ void BC_Reflecting_xp( real **Array, const int NVar, const int TVarIdxList[], co
 
          case MAGZ:
          {
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2]+1; k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -258,7 +264,8 @@ void BC_Reflecting_ym( real **Array, const int NVar, const int TVarIdxList[], co
       {
          case MAGX:
          {
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -270,7 +277,8 @@ void BC_Reflecting_ym( real **Array, const int NVar, const int TVarIdxList[], co
 
          case MAGY:
          {
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2]; k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1]; j++)
@@ -282,7 +290,8 @@ void BC_Reflecting_ym( real **Array, const int NVar, const int TVarIdxList[], co
 
          case MAGZ:
          {
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2]+1; k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -324,7 +333,8 @@ void BC_Reflecting_yp( real **Array, const int NVar, const int TVarIdxList[], co
       {
          case MAGX:
          {
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -336,7 +346,8 @@ void BC_Reflecting_yp( real **Array, const int NVar, const int TVarIdxList[], co
 
          case MAGY:
          {
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (int k=Idx_Start[2];   k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]+1; j<=Idx_End[1]+1; j++)
@@ -348,7 +359,8 @@ void BC_Reflecting_yp( real **Array, const int NVar, const int TVarIdxList[], co
 
          case MAGZ:
          {
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2]+1; k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -390,7 +402,8 @@ void BC_Reflecting_zm( real **Array, const int NVar, const int TVarIdxList[], co
       {
          case MAGX:
          {
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -402,7 +415,8 @@ void BC_Reflecting_zm( real **Array, const int NVar, const int TVarIdxList[], co
 
          case MAGY:
          {
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1]+1; j++)
@@ -414,7 +428,8 @@ void BC_Reflecting_zm( real **Array, const int NVar, const int TVarIdxList[], co
 
          case MAGZ:
          {
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2]; k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1]; j++)
@@ -456,7 +471,8 @@ void BC_Reflecting_zp( real **Array, const int NVar, const int TVarIdxList[], co
       {
          case MAGX:
          {
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1];   j++)
@@ -468,7 +484,8 @@ void BC_Reflecting_zp( real **Array, const int NVar, const int TVarIdxList[], co
 
          case MAGY:
          {
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (int k=Idx_Start[2]; k<=Idx_End[2];   k++)
             for (int j=Idx_Start[1]; j<=Idx_End[1]+1; j++)
@@ -480,7 +497,8 @@ void BC_Reflecting_zp( real **Array, const int NVar, const int TVarIdxList[], co
 
          case MAGZ:
          {
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (int k=Idx_Start[2]+1; k<=Idx_End[2]+1; k++)
             for (int j=Idx_Start[1];   j<=Idx_End[1];   j++)

--- a/src/Model_Hydro/MHD_BoundaryCondition_User.cpp
+++ b/src/Model_Hydro/MHD_BoundaryCondition_User.cpp
@@ -161,7 +161,8 @@ void BC_User_xm( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1];
             xyz0_FC[2] = xyz0_CC[2];
 
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (k=Idx_Start[2], z=xyz0_FC[2]; k<=Idx_End[2]; k++, z+=dh)
             for (j=Idx_Start[1], y=xyz0_FC[1]; j<=Idx_End[1]; j++, y+=dh)
@@ -180,7 +181,8 @@ void BC_User_xm( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1] - 0.5*dh;
             xyz0_FC[2] = xyz0_CC[2];
 
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (k=Idx_Start[2], z=xyz0_FC[2]; k<=Idx_End[2];   k++, z+=dh)
             for (j=Idx_Start[1], y=xyz0_FC[1]; j<=Idx_End[1]+1; j++, y+=dh)
@@ -199,7 +201,8 @@ void BC_User_xm( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1];
             xyz0_FC[2] = xyz0_CC[2] - 0.5*dh;
 
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (k=Idx_Start[2], z=xyz0_FC[2]; k<=Idx_End[2]+1; k++, z+=dh)
             for (j=Idx_Start[1], y=xyz0_FC[1]; j<=Idx_End[1];   j++, y+=dh)
@@ -254,7 +257,8 @@ void BC_User_xp( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1];
             xyz0_FC[2] = xyz0_CC[2];
 
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (k=Idx_Start[2],   z=xyz0_FC[2]; k<=Idx_End[2];   k++, z+=dh)
             for (j=Idx_Start[1],   y=xyz0_FC[1]; j<=Idx_End[1];   j++, y+=dh)
@@ -273,7 +277,8 @@ void BC_User_xp( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1] - 0.5*dh;
             xyz0_FC[2] = xyz0_CC[2];
 
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (k=Idx_Start[2], z=xyz0_FC[2]; k<=Idx_End[2];   k++, z+=dh)
             for (j=Idx_Start[1], y=xyz0_FC[1]; j<=Idx_End[1]+1; j++, y+=dh)
@@ -292,7 +297,8 @@ void BC_User_xp( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1];
             xyz0_FC[2] = xyz0_CC[2] - 0.5*dh;
 
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (k=Idx_Start[2], z=xyz0_FC[2]; k<=Idx_End[2]+1; k++, z+=dh)
             for (j=Idx_Start[1], y=xyz0_FC[1]; j<=Idx_End[1];   j++, y+=dh)
@@ -347,7 +353,8 @@ void BC_User_ym( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1];
             xyz0_FC[2] = xyz0_CC[2];
 
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (k=Idx_Start[2], z=xyz0_FC[2]; k<=Idx_End[2];   k++, z+=dh)
             for (j=Idx_Start[1], y=xyz0_FC[1]; j<=Idx_End[1];   j++, y+=dh)
@@ -366,7 +373,8 @@ void BC_User_ym( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1] - 0.5*dh;
             xyz0_FC[2] = xyz0_CC[2];
 
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (k=Idx_Start[2], z=xyz0_FC[2]; k<=Idx_End[2]; k++, z+=dh)
             for (j=Idx_Start[1], y=xyz0_FC[1]; j<=Idx_End[1]; j++, y+=dh)
@@ -385,7 +393,8 @@ void BC_User_ym( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1];
             xyz0_FC[2] = xyz0_CC[2] - 0.5*dh;
 
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (k=Idx_Start[2], z=xyz0_FC[2]; k<=Idx_End[2]+1; k++, z+=dh)
             for (j=Idx_Start[1], y=xyz0_FC[1]; j<=Idx_End[1];   j++, y+=dh)
@@ -440,7 +449,8 @@ void BC_User_yp( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1];
             xyz0_FC[2] = xyz0_CC[2];
 
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (k=Idx_Start[2], z=xyz0_FC[2]; k<=Idx_End[2];   k++, z+=dh)
             for (j=Idx_Start[1], y=xyz0_FC[1]; j<=Idx_End[1];   j++, y+=dh)
@@ -459,7 +469,8 @@ void BC_User_yp( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1] + 0.5*dh;
             xyz0_FC[2] = xyz0_CC[2];
 
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (k=Idx_Start[2],   z=xyz0_FC[2]; k<=Idx_End[2];   k++, z+=dh)
             for (j=Idx_Start[1]+1, y=xyz0_FC[1]; j<=Idx_End[1]+1; j++, y+=dh)
@@ -478,7 +489,8 @@ void BC_User_yp( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1];
             xyz0_FC[2] = xyz0_CC[2] - 0.5*dh;
 
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (k=Idx_Start[2], z=xyz0_FC[2]; k<=Idx_End[2]+1; k++, z+=dh)
             for (j=Idx_Start[1], y=xyz0_FC[1]; j<=Idx_End[1];   j++, y+=dh)
@@ -533,7 +545,8 @@ void BC_User_zm( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1];
             xyz0_FC[2] = xyz0_CC[2];
 
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (k=Idx_Start[2], z=xyz0_FC[2]; k<=Idx_End[2];   k++, z+=dh)
             for (j=Idx_Start[1], y=xyz0_FC[1]; j<=Idx_End[1];   j++, y+=dh)
@@ -552,7 +565,8 @@ void BC_User_zm( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1] - 0.5*dh;
             xyz0_FC[2] = xyz0_CC[2];
 
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (k=Idx_Start[2], z=xyz0_FC[2]; k<=Idx_End[2];   k++, z+=dh)
             for (j=Idx_Start[1], y=xyz0_FC[1]; j<=Idx_End[1]+1; j++, y+=dh)
@@ -571,7 +585,8 @@ void BC_User_zm( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1];
             xyz0_FC[2] = xyz0_CC[2] - 0.5*dh;
 
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (k=Idx_Start[2], z=xyz0_FC[2]; k<=Idx_End[2]; k++, z+=dh)
             for (j=Idx_Start[1], y=xyz0_FC[1]; j<=Idx_End[1]; j++, y+=dh)
@@ -626,7 +641,8 @@ void BC_User_zp( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1];
             xyz0_FC[2] = xyz0_CC[2];
 
-            real (*MagX)[ArraySizeY][ArraySizeX+1] = ( real (*)[ArraySizeY][ArraySizeX+1] )Array[MAGX];
+            typedef real (*vlax)[ArraySizeY][ArraySizeX+1];
+            vlax MagX = ( vlax )Array[MAGX];
 
             for (k=Idx_Start[2], z=xyz0_FC[2]; k<=Idx_End[2];   k++, z+=dh)
             for (j=Idx_Start[1], y=xyz0_FC[1]; j<=Idx_End[1];   j++, y+=dh)
@@ -645,7 +661,8 @@ void BC_User_zp( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1] - 0.5*dh;
             xyz0_FC[2] = xyz0_CC[2];
 
-            real (*MagY)[ArraySizeY+1][ArraySizeX] = ( real (*)[ArraySizeY+1][ArraySizeX] )Array[MAGY];
+            typedef real (*vlay)[ArraySizeY+1][ArraySizeX];
+            vlay MagY = ( vlay )Array[MAGY];
 
             for (k=Idx_Start[2], z=xyz0_FC[2]; k<=Idx_End[2];   k++, z+=dh)
             for (j=Idx_Start[1], y=xyz0_FC[1]; j<=Idx_End[1]+1; j++, y+=dh)
@@ -664,7 +681,8 @@ void BC_User_zp( real **Array, const int NVar, const int TVarIdxList[], const in
             xyz0_FC[1] = xyz0_CC[1];
             xyz0_FC[2] = xyz0_CC[2] + 0.5*dh;
 
-            real (*MagZ)[ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeY][ArraySizeX] )Array[MAGZ];
+            typedef real (*vlaz)[ArraySizeY][ArraySizeX];
+            vlaz MagZ = ( vlaz )Array[MAGZ];
 
             for (k=Idx_Start[2]+1, z=xyz0_FC[2]; k<=Idx_End[2]+1; k++, z+=dh)
             for (j=Idx_Start[1],   y=xyz0_FC[1]; j<=Idx_End[1];   j++, y+=dh)

--- a/src/Particle/Par_Aux_GetConservedQuantity.cpp
+++ b/src/Particle/Par_Aux_GetConservedQuantity.cpp
@@ -147,7 +147,8 @@ void Par_Aux_GetConservedQuantity( double &Mass_Total, double &MomX_Total, doubl
       long   ParID;
 
       real *Pot = new real [ 8*CUBE(PotSize) ];    // 8: number of patches per patch group
-      real (*Pot3D)[PotSize][PotSize][PotSize] = ( real (*)[PotSize][PotSize][PotSize] )Pot;
+      typedef real (*vla)[PotSize][PotSize][PotSize];
+      vla Pot3D = ( vla )Pot;
 
 
 //    use static schedule to give the same reduction result everytime

--- a/src/Particle/Par_MassAssignment.cpp
+++ b/src/Particle/Par_MassAssignment.cpp
@@ -165,7 +165,8 @@ void Par_MassAssignment( const long *ParList, const long NPar, const ParInterp_t
    const double _dh3      = CUBE(_dh);
    const double Ghost_Phy = amr->Par->GhostSize*dh;
 
-   real (*Rho3D)[RhoSize][RhoSize] = ( real (*)[RhoSize][RhoSize] )Rho;
+   typedef real (*vla)[RhoSize][RhoSize];
+   vla Rho3D = ( vla )Rho;
 
    int  idx[3];      // array index for Rho
    real ParDens;     // mass density of the cloud

--- a/src/Particle/Par_UpdateParticle.cpp
+++ b/src/Particle/Par_UpdateParticle.cpp
@@ -173,8 +173,10 @@ void Par_UpdateParticle( const int lv, const double TimeNew, const double TimeOl
    real *Pot = new real [ 8*CUBE(PotSize) ];    // 8: number of patches per patch group
    real *Acc = new real [ 3*CUBE(AccSize) ];    // 3: three dimension
 
-   real (*Pot3D)[PotSize][PotSize][PotSize] = ( real (*)[PotSize][PotSize][PotSize] )Pot;
-   real (*Acc3D)[AccSize][AccSize][AccSize] = ( real (*)[AccSize][AccSize][AccSize] )Acc;
+   typedef real (*vla_pot)[PotSize][PotSize][PotSize];
+   typedef real (*vla_acc)[AccSize][AccSize][AccSize];
+   vla_pot Pot3D = ( vla_pot )Pot;
+   vla_acc Acc3D = ( vla_acc )Acc;
 
    bool GotYou;
    long ParID;

--- a/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_MG.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_MG.cpp
@@ -386,8 +386,9 @@ void Smoothing( real *Sol_1D, const real *RHS_1D, const real dh, const int NGrid
    int ip, jp, kp, im, jm, km;
 
 // typecasting to 3D arrays
-         real (*Sol)[NGrid][NGrid] = ( real(*)[NGrid][NGrid] )Sol_1D;
-   const real (*RHS)[NGrid][NGrid] = ( real(*)[NGrid][NGrid] )RHS_1D;
+   typedef real (*vla)[NGrid][NGrid];
+         vla Sol = ( vla )Sol_1D;
+   const vla RHS = ( vla )RHS_1D;
 
 
 // odd-even ordering
@@ -453,9 +454,10 @@ void ComputeDefect( const real *Sol_1D, const real *RHS_1D, real *Def_1D, const 
    int ip, jp, kp, im, jm, km;
 
 // typecasting to 3D arrays
-   const real (*Sol)[NGrid][NGrid] = ( real(*)[NGrid][NGrid] )Sol_1D;
-   const real (*RHS)[NGrid][NGrid] = ( real(*)[NGrid][NGrid] )RHS_1D;
-         real (*Def)[NGrid][NGrid] = ( real(*)[NGrid][NGrid] )Def_1D;
+   typedef real (*vla)[NGrid][NGrid];
+   const vla Sol = ( vla )Sol_1D;
+   const vla RHS = ( vla )RHS_1D;
+         vla Def = ( vla )Def_1D;
 
 
    for (int k=1; k<NGrid-1; k++)
@@ -523,8 +525,10 @@ void Restrict( const real *FData_1D, real *CData_1D, const int NGrid_F, const in
    const real Ratio = real(NGrid_F-1) / real(NGrid_C-1);
 
 // typecasting to 3D arrays
-   const real (*FData)[NGrid_F][NGrid_F] = ( real(*)[NGrid_F][NGrid_F] )FData_1D;
-         real (*CData)[NGrid_C][NGrid_C] = ( real(*)[NGrid_C][NGrid_C] )CData_1D;
+   typedef real (*vlaf)[NGrid_F][NGrid_F];
+   typedef real (*vlac)[NGrid_C][NGrid_C];
+   const vlaf FData = ( vlaf )FData_1D;
+         vlac CData = ( vlac )CData_1D;
 
    int  iim, ii, iip, jjm, jj, jjp, kkm, kk, kkp;
    real x, y, z, Coeff[3][3]; // Coeff[x/y/z][left/center/right]
@@ -625,8 +629,11 @@ void Prolongate_and_Correct( const real *CData_1D, real *FData_1D, const int NGr
    const real Ratio = real(NGrid_C-1) / real(NGrid_F-1);
 
 // typecasting to 3D arrays
-   const real (*CData)[NGrid_C][NGrid_C] = ( real(*)[NGrid_C][NGrid_C] )CData_1D;
-         real (*FData)[NGrid_F][NGrid_F] = ( real(*)[NGrid_F][NGrid_F] )FData_1D;
+
+   typedef real (*vlaf)[NGrid_F][NGrid_F];
+   typedef real (*vlac)[NGrid_C][NGrid_C];
+         vlaf FData = ( vlaf )FData_1D;
+   const vlac CData = ( vlac )CData_1D;
 
    int  ii, iip, jj, jjp, kk, kkp;
    real x, y, z, Coeff[3][2]; // Coeff[x/y/z][left/right]

--- a/src/SelfGravity/Poi_BoundaryCondition_Extrapolation.cpp
+++ b/src/SelfGravity/Poi_BoundaryCondition_Extrapolation.cpp
@@ -161,7 +161,8 @@ void BC_Extrapolation_xm( real *Array, const int NVar, const int GhostSize, cons
    const int i_ref = GhostSize;  // reference i index
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 // set the boundary values
    for (int v=0; v<NVar; v++)
@@ -199,7 +200,8 @@ void BC_Extrapolation_xp( real *Array, const int NVar, const int GhostSize, cons
    const int i_ref = ArraySizeX - GhostSize - 1;   // reference i index
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 // set the boundary values
    for (int v=0; v<NVar; v++)
@@ -237,7 +239,8 @@ void BC_Extrapolation_ym( real *Array, const int NVar, const int GhostSize, cons
    const int j_ref = GhostSize;  // reference j index
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 // set the boundary values
    for (int v=0; v<NVar; v++)
@@ -275,7 +278,8 @@ void BC_Extrapolation_yp( real *Array, const int NVar, const int GhostSize, cons
    const int j_ref = ArraySizeY - GhostSize - 1;   // reference j index
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 // set the boundary values
    for (int v=0; v<NVar; v++)
@@ -313,7 +317,8 @@ void BC_Extrapolation_zm( real *Array, const int NVar, const int GhostSize, cons
    const int k_ref = GhostSize;  // reference k index
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 // set the boundary values
    for (int v=0; v<NVar; v++)
@@ -351,7 +356,8 @@ void BC_Extrapolation_zp( real *Array, const int NVar, const int GhostSize, cons
    const int k_ref = ArraySizeZ - GhostSize - 1;   // reference k index
 
 // 1D array -> 3D array
-   real (*Array3D)[ArraySizeZ][ArraySizeY][ArraySizeX] = ( real (*)[ArraySizeZ][ArraySizeY][ArraySizeX] )Array;
+   typedef real (*vla)[ArraySizeZ][ArraySizeY][ArraySizeX];
+   vla Array3D = ( vla )Array;
 
 // set the boundary values
    for (int v=0; v<NVar; v++)


### PR DESCRIPTION
This PR changes a number of places throughout the code where a 1D array was pointed to by a 3D array using array sizes not defined at compile time. This is ok with compilers like gcc but not with clang. 

@hyschive I may have missed some other places where we do this. Also, could you test yourself?