### PR TITLE
Add libyt Example to MHD_OrszagTangVortex

### DIFF
--- a/example/test_problem/Hydro/MHD_OrszagTangVortex/Input__Parameter
+++ b/example/test_problem/Hydro/MHD_OrszagTangVortex/Input__Parameter
@@ -191,3 +191,8 @@ OPT__CK_NEGATIVE              0           # check the negative values: (0=off, 1
 OPT__CK_MEMFREE               1.0         # check the free memory in GB (0=off, >0=threshold) [1.0]
 OPT__CK_INTERFACE_B           1           # check the consistency of patch interface B field [0] ##MHD ONLY##
 OPT__CK_DIVERGENCE_B          1           # check the divergence-free constraint on B field (0=off, 1=on, 2=on+verbose) [0] ##MHD ONLY##
+
+
+# YT inline analysis
+YT_SCRIPT                     inline_script # inline python script name, exclude ".py" extension
+YT_VERBOSE                    3             # log level (0=off, 1=info, 2=warning, 3=debug)

--- a/example/test_problem/Hydro/MHD_OrszagTangVortex/Input__Parameter
+++ b/example/test_problem/Hydro/MHD_OrszagTangVortex/Input__Parameter
@@ -195,4 +195,4 @@ OPT__CK_DIVERGENCE_B          1           # check the divergence-free constraint
 
 # YT inline analysis
 YT_SCRIPT                     inline_script # inline python script name, exclude ".py" extension
-YT_VERBOSE                    3             # log level (0=off, 1=info, 2=warning, 3=debug)
+YT_VERBOSE                    1             # log level (0=off, 1=info, 2=warning, 3=debug)

--- a/example/test_problem/Hydro/MHD_OrszagTangVortex/inline_script.py
+++ b/example/test_problem/Hydro/MHD_OrszagTangVortex/inline_script.py
@@ -1,0 +1,15 @@
+import yt
+
+yt.enable_parallelism()
+
+def yt_inline():
+    ds = yt.frontends.libyt.libytDataset()
+    slc = yt.OffAxisSlicePlot(ds, [1, 1, 0], [("gas", "density")], center="c")
+    slc.annotate_cquiver(("gas", "cutting_plane_velocity_x"), ("gas", "cutting_plane_velocity_y"), factor=10, plot_args={"color":"orange"}, )
+
+    # Currently, saving annotate_cquiver will only work when it is outside of yt.is_root() clause like this.
+    slc.save()
+
+def yt_inline_inputArg( field ):
+    pass
+


### PR DESCRIPTION
# Add libyt Example to MHD_OrszagTangVortex
Add a concrete example.
- [How to run.](https://gist.github.com/cindytsai/cfc6c6fd3a759de5ead646ff1cb5374e#test-run-gamer-example-mhd_orszagtangvortex)