### PR TITLE
Rename dual-energy objects

### DIFF
--- a/include/Field.h
+++ b/include/Field.h
@@ -26,10 +26,8 @@ SET_GLOBAL( FieldIdx_t Idx_Engy,          Idx_Undefined );
 #ifdef COSMIC_RAY
 SET_GLOBAL( FieldIdx_t Idx_CRay,          Idx_Undefined );
 #endif
-#if   ( DUAL_ENERGY == DE_ENPY )
-SET_GLOBAL( FieldIdx_t Idx_Enpy,          Idx_Undefined );
-#elif ( DUAL_ENERGY == DE_EINT )
-SET_GLOBAL( FieldIdx_t Idx_Eint,          Idx_Undefined );
+#ifdef DUAL_ENERGY
+SET_GLOBAL( FieldIdx_t Idx_Dual,          Idx_Undefined );
 #endif
 
 // Grackle fields

--- a/include/Macro.h
+++ b/include/Macro.h
@@ -134,7 +134,7 @@
 // add built-in scalars
 #if ( MODEL == HYDRO )
 
-// entropy (or internal energy) for the dual-energy formalism
+// dual-energy variable
 # ifdef DUAL_ENERGY
 #  define NCOMP_PASSIVE_BUILTIN0    1
 # else
@@ -227,16 +227,13 @@
 #if ( NCOMP_PASSIVE > 0 )
 
 // always put the built-in variables at the END of the field list
-// --> so that their indices (e.g., ENPY/EINT/CRAY) can be determined during compilation
+// --> so that their indices (e.g., DUAL/CRAY) can be determined during compilation
 // --> convenient (and probably also more efficient) for the fluid solver
 #  define PASSIVE_NEXT_IDX0   ( NCOMP_TOTAL - 1   )
 
-# if   ( DUAL_ENERGY == DE_ENPY )
-#  define ENPY                ( PASSIVE_NEXT_IDX0 )
-#  define PASSIVE_NEXT_IDX1   ( ENPY - 1          )
-# elif ( DUAL_ENERGY == DE_EINT )
-#  define EINT                ( PASSIVE_NEXT_IDX0 )
-#  define PASSIVE_NEXT_IDX1   ( EINT - 1          )
+# ifdef DUAL_ENERGY
+#  define DUAL                ( PASSIVE_NEXT_IDX0 )
+#  define PASSIVE_NEXT_IDX1   ( DUAL - 1          )
 # else
 #  define PASSIVE_NEXT_IDX1   ( PASSIVE_NEXT_IDX0 )
 # endif
@@ -270,12 +267,9 @@
 // always put the built-in variables at the END of the list
 #  define FLUX_NEXT_IDX0   ( NFLUX_TOTAL - 1 )
 
-# if   ( DUAL_ENERGY == DE_ENPY )
-#  define FLUX_ENPY        ( FLUX_NEXT_IDX0  )
-#  define FLUX_NEXT_IDX1   ( FLUX_ENPY - 1   )
-# elif ( DUAL_ENERGY == DE_EINT )
-#  define FLUX_EINT        ( FLUX_NEXT_IDX0  )
-#  define FLUX_NEXT_IDX1   ( FLUX_EINT - 1   )
+# ifdef DUAL_ENERGY
+#  define FLUX_DUAL        ( FLUX_NEXT_IDX0  )
+#  define FLUX_NEXT_IDX1   ( FLUX_DUAL - 1   )
 # else
 #  define FLUX_NEXT_IDX1   ( FLUX_NEXT_IDX0  )
 # endif
@@ -301,10 +295,8 @@
 
 #if ( NCOMP_PASSIVE > 0 )
 
-# if   ( DUAL_ENERGY == DE_ENPY )
-#  define _ENPY               ( 1L << ENPY )
-# elif ( DUAL_ENERGY == DE_EINT )
-#  define _EINT               ( 1L << EINT )
+# ifdef DUAL_ENERGY
+#  define _DUAL               ( 1L << DUAL )
 # endif
 
 # ifdef COSMIC_RAY
@@ -332,10 +324,8 @@
 
 #if ( NFLUX_PASSIVE > 0 )
 
-# if   ( DUAL_ENERGY == DE_ENPY )
-#  define _FLUX_ENPY          ( 1L << FLUX_ENPY )
-# elif ( DUAL_ENERGY == DE_EINT )
-#  define _FLUX_EINT          ( 1L << FLUX_EINT )
+# ifdef DUAL_ENERGY
+#  define _FLUX_DUAL          ( 1L << FLUX_DUAL )
 # endif
 
 # ifdef COSMIC_RAY
@@ -347,8 +337,6 @@
 // bitwise indices of derived fields
 // --> start from (1L<<NCOMP_TOTAL) to distinguish from the intrinsic fields
 // --> remember to define NDERIVE = total number of derived fields
-// _EINT_DER is a derived field for distinguishing from _EINT
-// --> the latter is an intrinsic field when adopting DUAL_ENERGY == DE_EINT
 #  define _VELX               ( 1L << (NCOMP_TOTAL+ 0) )
 #  define _VELY               ( 1L << (NCOMP_TOTAL+ 1) )
 #  define _VELZ               ( 1L << (NCOMP_TOTAL+ 2) )
@@ -356,12 +344,12 @@
 #  define _PRES               ( 1L << (NCOMP_TOTAL+ 4) )
 #  define _TEMP               ( 1L << (NCOMP_TOTAL+ 5) )
 #  define _ENTR               ( 1L << (NCOMP_TOTAL+ 6) )
-#  define _EINT_DER           ( 1L << (NCOMP_TOTAL+ 7) )
+#  define _EINT               ( 1L << (NCOMP_TOTAL+ 7) )
 #  define _MAGX_CC            ( 1L << (NCOMP_TOTAL+ 8) )
 #  define _MAGY_CC            ( 1L << (NCOMP_TOTAL+ 9) )
 #  define _MAGZ_CC            ( 1L << (NCOMP_TOTAL+10) )
 #  define _MAG_ENGY_CC        ( 1L << (NCOMP_TOTAL+11) )
-#  define _DERIVED            ( _VELX | _VELY | _VELZ | _VELR | _PRES | _TEMP | _ENTR | _EINT_DER | _MAGX_CC | _MAGY_CC | _MAGZ_CC | _MAG_ENGY_CC )
+#  define _DERIVED            ( _VELX | _VELY | _VELZ | _VELR | _PRES | _TEMP | _ENTR | _EINT | _MAGX_CC | _MAGY_CC | _MAGZ_CC | _MAG_ENGY_CC )
 #  define NDERIVE             12
 
 

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -114,14 +114,12 @@ void Hydro_DualEnergyFix( const real Dens, const real MomX, const real MomY, con
                           real &Etot, real &Dual, char &DE_Status, const real Gamma_m1, const real _Gamma_m1,
                           const bool CheckMinPres, const real MinPres, const real DualEnergySwitch,
                           const real Emag );
-#if ( DUAL_ENERGY == DE_ENPY )
 real Hydro_Con2Dual( const real Dens, const real MomX, const real MomY, const real MomZ, const real Engy,
                      const real Emag, const EoS_DE2P_t EoS_DensEint2Pres, const double EoS_AuxArray_Flt[],
                      const int EoS_AuxArray_Int[], const real *const EoS_Table[EOS_NTABLE_MAX] );
 real Hydro_DensPres2Dual( const real Dens, const real Pres, const real Gamma_m1 );
 real Hydro_DensDual2Pres( const real Dens, const real Dual, const real Gamma_m1,
                           const bool CheckMinPres, const real MinPres );
-#endif
 #endif
 real Hydro_CheckMinEintInEngy( const real Dens, const real MomX, const real MomY, const real MomZ, const real InEngy,
                                const real MinEint, const real Emag );

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -111,16 +111,16 @@ bool Hydro_CheckUnphysical( const CheckUnphysical_t Mode, const real Fields[], c
 void Hydro_NormalizePassive( const real GasDens, real Passive[], const int NNorm, const int NormIdx[] );
 #ifdef DUAL_ENERGY
 void Hydro_DualEnergyFix( const real Dens, const real MomX, const real MomY, const real MomZ,
-                          real &Etot, real &Enpy, char &DE_Status, const real Gamma_m1, const real _Gamma_m1,
+                          real &Etot, real &Dual, char &DE_Status, const real Gamma_m1, const real _Gamma_m1,
                           const bool CheckMinPres, const real MinPres, const real DualEnergySwitch,
                           const real Emag );
 #if ( DUAL_ENERGY == DE_ENPY )
-real Hydro_Con2Entropy( const real Dens, const real MomX, const real MomY, const real MomZ, const real Engy,
-                        const real Emag, const EoS_DE2P_t EoS_DensEint2Pres, const double EoS_AuxArray_Flt[],
-                        const int EoS_AuxArray_Int[], const real *const EoS_Table[EOS_NTABLE_MAX] );
-real Hydro_DensPres2Entropy( const real Dens, const real Pres, const real Gamma_m1 );
-real Hydro_DensEntropy2Pres( const real Dens, const real Enpy, const real Gamma_m1,
-                             const bool CheckMinPres, const real MinPres );
+real Hydro_Con2Dual( const real Dens, const real MomX, const real MomY, const real MomZ, const real Engy,
+                     const real Emag, const EoS_DE2P_t EoS_DensEint2Pres, const double EoS_AuxArray_Flt[],
+                     const int EoS_AuxArray_Int[], const real *const EoS_Table[EOS_NTABLE_MAX] );
+real Hydro_DensPres2Dual( const real Dens, const real Pres, const real Gamma_m1 );
+real Hydro_DensDual2Pres( const real Dens, const real Dual, const real Gamma_m1,
+                          const bool CheckMinPres, const real MinPres );
 #endif
 #endif
 real Hydro_CheckMinEintInEngy( const real Dens, const real MomX, const real MomY, const real MomZ, const real InEngy,

--- a/src/Auxiliary/Aux_ComputeProfile.cpp
+++ b/src/Auxiliary/Aux_ComputeProfile.cpp
@@ -41,8 +41,8 @@ extern void SetTempIntPara( const int lv, const int Sg_Current, const double Pre
 //                                        Data[empty_bin]=Weight[empty_bin]=NCell[empty_bin]=0
 //                TVarBitIdx  : Bitwise indices of target variables for computing the profiles
 //                              --> Supported indices (defined in Macro.h):
-//                                     HYDRO : _DENS, _MOMX, _MOMY, _MOMZ, _ENGY, _VELR, _PRES, _EINT_DER
-//                                             [, _ENPY, _EINT, _POTE]
+//                                     HYDRO : _DENS, _MOMX, _MOMY, _MOMZ, _ENGY, _VELR, _PRES, _EINT
+//                                             [, _DUAL, _POTE]
 //                                     ELBDM : _DENS, _REAL, _IMAG [, _POTE]
 //                              --> For a passive scalar with an integer field index FieldIdx returned by AddField(),
 //                                  one can convert it to a bitwise field index by BIDX(FieldIdx)
@@ -461,7 +461,7 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
                            }
                            break;
 
-                           case _EINT_DER:
+                           case _EINT:
                            {
                               const real Weight = dv;
                               const real Dens   = FluidPtr[DENS][k][j][i];

--- a/src/Auxiliary/Aux_ComputeProfile.cpp
+++ b/src/Auxiliary/Aux_ComputeProfile.cpp
@@ -471,9 +471,9 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
 
 #                             if   ( DUAL_ENERGY == DE_ENPY )
                               const bool CheckMinPres_No = false;
-                              const real Enpy = FluidPtr[ENPY][k][j][i];
-                              const real Pres = Hydro_DensEntropy2Pres( Dens, Enpy, EoS_AuxArray_Flt[1],
-                                                                        CheckMinPres_No, NULL_REAL );
+                              const real Enpy = FluidPtr[DUAL][k][j][i];
+                              const real Pres = Hydro_DensDual2Pres( Dens, Enpy, EoS_AuxArray_Flt[1],
+                                                                     CheckMinPres_No, NULL_REAL );
                               const real Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, Passive, EoS_AuxArray_Flt,
                                                                           EoS_AuxArray_Int, h_EoS_Table );
 #                             elif ( DUAL_ENERGY == DE_EINT )

--- a/src/Fluid/Flu_Close.cpp
+++ b/src/Fluid/Flu_Close.cpp
@@ -741,7 +741,7 @@ void CorrectUnphysical( const int lv, const int NPG, const int *PID0_List,
 //             --> we do NOT apply the minimum pressure check in Hydro_DualEnergyFix() here
 //                 --> otherwise the pressure floor might disable the 1st-order-flux correction
 #              ifdef DUAL_ENERGY
-               Hydro_DualEnergyFix( Update[DENS], Update[MOMX], Update[MOMY], Update[MOMZ], Update[ENGY], Update[ENPY],
+               Hydro_DualEnergyFix( Update[DENS], Update[MOMX], Update[MOMY], Update[MOMZ], Update[ENGY], Update[DUAL],
                                     h_DE_Array_F_Out[TID][idx_out], EoS_AuxArray_Flt[1], EoS_AuxArray_Flt[2],
                                     CorrPres_No, NULL_REAL, DUAL_ENERGY_SWITCH, Emag_Out );
 #              endif
@@ -884,7 +884,7 @@ void CorrectUnphysical( const int lv, const int NPG, const int *PID0_List,
 //          --> we apply the minimum pressure check in Hydro_DualEnergyFix() here only when AutoReduceDt_Continue is false
 //              --> otherwise AUTO_REDUCE_DT may not be triggered due to this pressure floor
 #           ifdef DUAL_ENERGY
-            Hydro_DualEnergyFix( Update[DENS], Update[MOMX], Update[MOMY], Update[MOMZ], Update[ENGY], Update[ENPY],
+            Hydro_DualEnergyFix( Update[DENS], Update[MOMX], Update[MOMY], Update[MOMZ], Update[ENGY], Update[DUAL],
                                  h_DE_Array_F_Out[TID][idx_out], EoS_AuxArray_Flt[1], EoS_AuxArray_Flt[2],
                                  (!AutoReduceDt_Continue && OPT__LAST_RESORT_FLOOR) ? CorrPres_Yes : CorrPres_No,
                                  MIN_PRES, DUAL_ENERGY_SWITCH, Emag_Out );
@@ -957,7 +957,7 @@ void CorrectUnphysical( const int lv, const int NPG, const int *PID0_List,
                   fprintf( File, "               (%14s, %14s, %14s, %14s, %14s, %14s",
                            FieldLabel[DENS], FieldLabel[MOMX], FieldLabel[MOMY], FieldLabel[MOMZ], FieldLabel[ENGY], "Eint" );
 #                 if ( DUAL_ENERGY == DE_ENPY )
-                  fprintf( File, ", %14s", FieldLabel[ENPY] );
+                  fprintf( File, ", %14s", FieldLabel[DUAL] );
 #                 endif
                   fprintf( File, ")\n" );
 
@@ -966,7 +966,7 @@ void CorrectUnphysical( const int lv, const int NPG, const int *PID0_List,
                            Hydro_Con2Eint(In[DENS], In[MOMX], In[MOMY], In[MOMZ], In[ENGY],
                                           CheckMinEint_No, NULL_REAL, Emag_In) );
 #                 if ( DUAL_ENERGY == DE_ENPY )
-                  fprintf( File, ", %14.7e", In[ENPY] );
+                  fprintf( File, ", %14.7e", In[DUAL] );
 #                 endif
                   fprintf( File, ")\n" );
 
@@ -975,7 +975,7 @@ void CorrectUnphysical( const int lv, const int NPG, const int *PID0_List,
                            Hydro_Con2Eint(Out[DENS], Out[MOMX], Out[MOMY], Out[MOMZ], Out[ENGY],
                                           CheckMinEint_No, NULL_REAL, Emag_Out) );
 #                 if ( DUAL_ENERGY == DE_ENPY )
-                  fprintf( File, ", %14.7e", Out[ENPY] );
+                  fprintf( File, ", %14.7e", Out[DUAL] );
 #                 endif
                   fprintf( File, ")\n" );
 
@@ -984,7 +984,7 @@ void CorrectUnphysical( const int lv, const int NPG, const int *PID0_List,
                            Hydro_Con2Eint(Update[DENS], Update[MOMX], Update[MOMY], Update[MOMZ], Update[ENGY],
                                           CheckMinEint_No, NULL_REAL, Emag_Update) );
 #                 if ( DUAL_ENERGY == DE_ENPY )
-                  fprintf( File, ", %14.7e", Update[ENPY] );
+                  fprintf( File, ", %14.7e", Update[DUAL] );
 #                 endif
                   fprintf( File, ")\n" );
 

--- a/src/Fluid/Flu_Close.cpp
+++ b/src/Fluid/Flu_Close.cpp
@@ -403,16 +403,13 @@ bool Unphysical( const real Fluid[], const int CheckMode, const real Emag )
          (
 //          when adopting the dual-energy formalism, do NOT calculate pressure from "Etot-Ekin" since it would suffer
 //          from large round-off errors
-//          --> currently we use TINY_NUMBER as entropy floor and hence here we use 2.0*TINY_NUMBER to
-//              validate entropy
-//          --> in general, MIN_PRES > 0.0 should be sufficient for detecting unphysical entropy
-//          --> however, the additional check "Fluid[ENPY] < (real)2.0*TINY_NUMBER" is necessary when MIN_PRES == 0.0
-#           if   ( DUAL_ENERGY == DE_ENPY )
-            Hydro_DensEntropy2Pres( Fluid[DENS], Fluid[ENPY], EoS_AuxArray_Flt[1], NoFloor, NULL_REAL ) < (real)MIN_PRES  ||
-            Fluid[ENPY] < (real)2.0*TINY_NUMBER
-
-#           elif ( DUAL_ENERGY == DE_EINT )
-#           error : DE_EINT is NOT supported yet !!
+//          --> currently we use TINY_NUMBER as the dual-energy floor and hence here we use 2.0*TINY_NUMBER to
+//              validate the dual-energy variable
+//          --> in general, MIN_PRES > 0.0 should be sufficient for detecting unphysical dual-energy variable
+//          --> however, the additional check "Fluid[DUAL] < (real)2.0*TINY_NUMBER" is necessary when MIN_PRES == 0.0
+#           ifdef DUAL_ENERGY
+            Hydro_DensDual2Pres( Fluid[DENS], Fluid[DUAL], EoS_AuxArray_Flt[1], NoFloor, NULL_REAL ) < (real)MIN_PRES  ||
+            Fluid[DUAL] < (real)2.0*TINY_NUMBER
 
 #           else // without DUAL_ENERGY
             Hydro_Con2Eint( Fluid[DENS], Fluid[MOMX], Fluid[MOMY], Fluid[MOMZ], Fluid[ENGY],

--- a/src/Fluid/Flu_FixUp_Flux.cpp
+++ b/src/Fluid/Flu_FixUp_Flux.cpp
@@ -232,7 +232,7 @@ void Flu_FixUp_Flux( const int lv )
 #                   endif
 #                   if   ( DUAL_ENERGY == DE_ENPY )
                     ||  ( (*DE_StatusPtr1D == DE_UPDATED_BY_DUAL || *DE_StatusPtr1D == DE_UPDATED_BY_MIN_PRES)
-                           && CorrVal[ENPY] <= (real)2.0*TINY_NUMBER )
+                           && CorrVal[DUAL] <= (real)2.0*TINY_NUMBER )
 
 #                   elif ( DUAL_ENERGY == DE_EINT )
 #                   error : DE_EINT is NOT supported yet !!

--- a/src/Fluid/Flu_FixUp_Flux.cpp
+++ b/src/Fluid/Flu_FixUp_Flux.cpp
@@ -183,10 +183,10 @@ void Flu_FixUp_Flux( const int lv )
                const real Emag = NULL_REAL;
 #              endif
 
-//             when adopting the dual-energy formalism, we must determine to use Hydro_Con2Eint() or Hydro_DensEntropy2Pres()
+//             when adopting the dual-energy formalism, we must determine to use Hydro_Con2Eint() or Hydro_DensDual2Pres()
 //             since the fluid variables stored in CorrVal[] may not be fully consistent
 //             --> because they have not been corrected by Hydro_DualEnergyFix()
-//             --> also note that currently we adopt Hydro_DensEntropy2Pres() for DE_UPDATED_BY_MIN_PRES
+//             --> also note that currently we adopt Hydro_DensDual2Pres() for DE_UPDATED_BY_MIN_PRES
 //             --> consistency among all dual-energy related variables will be ensured after determining Eint
 #              if ( DUAL_ENERGY == DE_ENPY )
                if ( *DE_StatusPtr1D == DE_UPDATED_BY_ETOT  ||  *DE_StatusPtr1D == DE_UPDATED_BY_ETOT_GRA )
@@ -202,7 +202,7 @@ void Flu_FixUp_Flux( const int lv )
                {
                   const bool CheckMinPres_No = false;
                   real Pres;
-                  Pres = Hydro_DensEntropy2Pres( ForEint[DENS], ForEint[ENPY], EoS_AuxArray_Flt[1], CheckMinPres_No, NULL_REAL );
+                  Pres = Hydro_DensDual2Pres( ForEint[DENS], ForEint[DUAL], EoS_AuxArray_Flt[1], CheckMinPres_No, NULL_REAL );
 //                DE_ENPY only supports EOS_GAMMA, which does not involve passive scalars
                   Eint = EoS_DensPres2Eint_CPUPtr( ForEint[DENS], Pres, NULL, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
                }
@@ -276,10 +276,10 @@ void Flu_FixUp_Flux( const int lv )
                   CorrVal[ENGY] = Hydro_ConEint2Etot( CorrVal[DENS], CorrVal[MOMX], CorrVal[MOMY], CorrVal[MOMZ], Eint, Emag );
 #                 if   ( DUAL_ENERGY == DE_ENPY )
 //                DE_ENPY only supports EOS_GAMMA, which does not involve passive scalars
-                  CorrVal[ENPY] = Hydro_DensPres2Entropy( CorrVal[DENS],
-                                                          EoS_DensEint2Pres_CPUPtr(CorrVal[DENS],Eint,NULL,
-                                                          EoS_AuxArray_Flt,EoS_AuxArray_Int,h_EoS_Table),
-                                                          EoS_AuxArray_Flt[1] );
+                  CorrVal[DUAL] = Hydro_DensPres2Dual( CorrVal[DENS],
+                                                       EoS_DensEint2Pres_CPUPtr(CorrVal[DENS],Eint,NULL,
+                                                       EoS_AuxArray_Flt,EoS_AuxArray_Int,h_EoS_Table),
+                                                       EoS_AuxArray_Flt[1] );
 #                 elif ( DUAL_ENERGY == DE_EINT )
 #                 error : DE_EINT is NOT supported yet !!
 #                 endif // DUAL_ENERGY

--- a/src/Fluid/Flu_FixUp_Restrict.cpp
+++ b/src/Fluid/Flu_FixUp_Restrict.cpp
@@ -320,7 +320,7 @@ void Flu_FixUp_Restrict( const int FaLv, const int SonFluSg, const int FaFluSg, 
 //       --> we achieve that by setting the dual-energy switch to an extremely larger number and ignore
 //           the runtime parameter DUAL_ENERGY_SWITCH here
          const bool CheckMinPres_Yes = true;
-         const real UseEnpy2FixEngy  = HUGE_NUMBER;
+         const real UseDual2FixEngy  = HUGE_NUMBER;
          char dummy;    // we do not record the dual-energy status here
 
          Hydro_DualEnergyFix( amr->patch[FaFluSg][FaLv][FaPID]->fluid[DENS][k][j][i],
@@ -330,7 +330,7 @@ void Flu_FixUp_Restrict( const int FaLv, const int SonFluSg, const int FaFluSg, 
                               amr->patch[FaFluSg][FaLv][FaPID]->fluid[ENGY][k][j][i],
                               amr->patch[FaFluSg][FaLv][FaPID]->fluid[DUAL][k][j][i],
                               dummy, EoS_AuxArray_Flt[1], EoS_AuxArray_Flt[2], CheckMinPres_Yes, MIN_PRES,
-                              UseEnpy2FixEngy, Emag );
+                              UseDual2FixEngy, Emag );
 
 #        else // #ifdef DUAL_ENERGY
 

--- a/src/Fluid/Flu_FixUp_Restrict.cpp
+++ b/src/Fluid/Flu_FixUp_Restrict.cpp
@@ -328,7 +328,7 @@ void Flu_FixUp_Restrict( const int FaLv, const int SonFluSg, const int FaFluSg, 
                               amr->patch[FaFluSg][FaLv][FaPID]->fluid[MOMY][k][j][i],
                               amr->patch[FaFluSg][FaLv][FaPID]->fluid[MOMZ][k][j][i],
                               amr->patch[FaFluSg][FaLv][FaPID]->fluid[ENGY][k][j][i],
-                              amr->patch[FaFluSg][FaLv][FaPID]->fluid[ENPY][k][j][i],
+                              amr->patch[FaFluSg][FaLv][FaPID]->fluid[DUAL][k][j][i],
                               dummy, EoS_AuxArray_Flt[1], EoS_AuxArray_Flt[2], CheckMinPres_Yes, MIN_PRES,
                               UseEnpy2FixEngy, Emag );
 

--- a/src/Fluid/Flu_ResetByUser.cpp
+++ b/src/Fluid/Flu_ResetByUser.cpp
@@ -151,11 +151,9 @@ void Flu_ResetByUser_API_Default( const int lv, const int FluSg, const double Ti
                                                     MIN_EINT, Emag );
 
 //          calculate the dual-energy variable (entropy or internal energy)
-#           if   ( DUAL_ENERGY == DE_ENPY )
-            fluid[ENPY] = Hydro_Con2Entropy( fluid[DENS], fluid[MOMX], fluid[MOMY], fluid[MOMZ], fluid[ENGY], Emag,
-                                             EoS_DensEint2Pres_CPUPtr, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
-#           elif ( DUAL_ENERGY == DE_EINT )
-#           error : DE_EINT is NOT supported yet !!
+#           ifdef DUAL_ENERGY
+            fluid[DUAL] = Hydro_Con2Dual( fluid[DENS], fluid[MOMX], fluid[MOMY], fluid[MOMZ], fluid[ENGY], Emag,
+                                          EoS_DensEint2Pres_CPUPtr, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
 #           endif
 
 //          floor and normalize passive scalars

--- a/src/Grackle/Grackle_Close.cpp
+++ b/src/Grackle/Grackle_Close.cpp
@@ -128,7 +128,7 @@ void Grackle_Close( const int lv, const int SaveSg, const real h_Che_Array[], co
 #           if   ( DUAL_ENERGY == DE_ENPY )
 //          DE_ENPY only works with EOS_GAMMA, which does not involve passive scalars
             Pres = EoS_DensEint2Pres_CPUPtr( Dens, Eint, NULL, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
-            *( fluid[ENPY     ][0][0] + idx_p ) = Hydro_DensPres2Entropy( Dens, Pres, EoS_AuxArray_Flt[1] );
+            *( fluid[DUAL     ][0][0] + idx_p ) = Hydro_DensPres2Dual( Dens, Pres, EoS_AuxArray_Flt[1] );
 
 #           elif ( DUAL_ENERGY == DE_EINT )
 #           error : DE_EINT is NOT supported yet !!

--- a/src/Grackle/Grackle_Prepare.cpp
+++ b/src/Grackle/Grackle_Prepare.cpp
@@ -177,7 +177,7 @@ void Grackle_Prepare( const int lv, real h_Che_Array[], const int NPG, const int
 #           ifdef DUAL_ENERGY
 
 #           if   ( DUAL_ENERGY == DE_ENPY )
-            Pres = Hydro_DensEntropy2Pres( Dens, *(fluid[ENPY][0][0]+idx_p), EoS_AuxArray_Flt[1], CheckMinPres_No, NULL_REAL );
+            Pres = Hydro_DensDual2Pres( Dens, *(fluid[DUAL][0][0]+idx_p), EoS_AuxArray_Flt[1], CheckMinPres_No, NULL_REAL );
 //          EOS_GAMMA does not involve passive scalars
             Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
 #           elif ( DUAL_ENERGY == DE_EINT )

--- a/src/Init/Init_ByFile.cpp
+++ b/src/Init/Init_ByFile.cpp
@@ -660,11 +660,9 @@ void Init_ByFile_Default( real fluid_out[], const real fluid_in[], const int nva
    const real Emag = NULL_REAL;
 #  endif
 
-#  if   ( DUAL_ENERGY == DE_ENPY )
-   fluid_out[ENPY] = Hydro_Con2Entropy( fluid_in[DENS], fluid_in[MOMX], fluid_in[MOMY], fluid_in[MOMZ], fluid_in[ENGY], Emag,
-                                        EoS_DensEint2Pres_CPUPtr, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
-#  elif ( DUAL_ENERGY == DE_EINT )
-#  error : DE_EINT is NOT supported yet !!
+#  ifdef DUAL_ENERGY
+   fluid_out[DUAL] = Hydro_Con2Dual( fluid_in[DENS], fluid_in[MOMX], fluid_in[MOMY], fluid_in[MOMZ], fluid_in[ENGY], Emag,
+                                     EoS_DensEint2Pres_CPUPtr, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
 #  endif
 
 // calculate the density field for ELBDM

--- a/src/Init/Init_ByFile.cpp
+++ b/src/Init/Init_ByFile.cpp
@@ -636,10 +636,8 @@ void Init_ByFile_Default( real fluid_out[], const real fluid_in[], const int nva
    {
 //    skip the dual-energy field for HYDRO
 #     if   ( MODEL == HYDRO )
-#     if   ( DUAL_ENERGY == DE_ENPY )
-      if ( v_out == ENPY )    v_out ++;
-#     elif ( DUAL_ENERGY == DE_EINT )
-      if ( v_out == EINT )    v_out ++;
+#     ifdef DUAL_ENERGY
+      if ( v_out == DUAL )    v_out ++;
 #     endif
 
 //    skip the density field for ELBDM

--- a/src/Init/Init_Field.cpp
+++ b/src/Init/Init_Field.cpp
@@ -108,19 +108,16 @@ void Init_Field()
 
 
 // 4. must put all built-in scalars at the END of the field list and with the same order as their
-//    corresponding symbolic constants (e.g., ENPY/EINT/CRAY) defined in Macro.h
-//    --> as we still rely on these constants (e.g., DENS, ENPY) in the fluid solvers
+//    corresponding symbolic constants (e.g., DUAL/CRAY) defined in Macro.h
+//    --> as we still rely on these constants (e.g., DENS, DUAL) in the fluid solvers
 #  ifdef COSMIC_RAY
-   Idx_CRay    = AddField( "CRay",     NORMALIZE_NO, INTERP_FRAC_NO );
+   Idx_CRay = AddField( "CRay", NORMALIZE_NO, INTERP_FRAC_NO );
    if ( Idx_CRay != CRAY )    Aux_Error( ERROR_INFO, "inconsistent Idx_CRay (%d != %d) !!\n", Idx_CRay, CRAY );
 #  endif
 
-#  if   ( DUAL_ENERGY == DE_ENPY )
-   Idx_Enpy    = AddField( "Entropy",  NORMALIZE_NO, INTERP_FRAC_NO );
-   if ( Idx_Enpy != ENPY )    Aux_Error( ERROR_INFO, "inconsistent Idx_Enpy (%d != %d) !!\n", Idx_Enpy, ENPY );
-#  elif ( DUAL_ENERGY == DE_EINT )
-   Idx_Eint    = AddField( "Eint",     NORMALIZE_NO, INTERP_FRAC_NO );
-   if ( Idx_Eint != EINT )    Aux_Error( ERROR_INFO, "inconsistent Idx_Eint (%d != %d) !!\n", Idx_Eint, EINT );
+#  ifdef DUAL_ENERGY
+   Idx_Dual = AddField( "Dual", NORMALIZE_NO, INTERP_FRAC_NO );
+   if ( Idx_Dual != DUAL )    Aux_Error( ERROR_INFO, "inconsistent Idx_Dual (%d != %d) !!\n", Idx_Dual, DUAL );
 #  endif
 
 

--- a/src/LoadBalance/LB_Refine_AllocateNewPatch.cpp
+++ b/src/LoadBalance/LB_Refine_AllocateNewPatch.cpp
@@ -1011,13 +1011,13 @@ int AllocateSonPatch( const int FaLv, const int *Cr, const int PScale, const int
 //        the runtime parameter DUAL_ENERGY_SWITCH here
 #     ifdef DUAL_ENERGY
       const bool CheckMinPres_Yes = true;
-      const real UseEnpy2FixEngy  = HUGE_NUMBER;
+      const real UseDual2FixEngy  = HUGE_NUMBER;
       char dummy;    // we do not record the dual-energy status here
 
       Hydro_DualEnergyFix( FData_Flu[DENS][k][j][i], FData_Flu[MOMX][k][j][i], FData_Flu[MOMY][k][j][i],
                            FData_Flu[MOMZ][k][j][i], FData_Flu[ENGY][k][j][i], FData_Flu[DUAL][k][j][i],
                            dummy, EoS_AuxArray_Flt[1], EoS_AuxArray_Flt[2], CheckMinPres_Yes, MIN_PRES,
-                           UseEnpy2FixEngy, Emag );
+                           UseDual2FixEngy, Emag );
 
 #     else // #ifdef DUAL_ENERGY
 

--- a/src/LoadBalance/LB_Refine_AllocateNewPatch.cpp
+++ b/src/LoadBalance/LB_Refine_AllocateNewPatch.cpp
@@ -1015,7 +1015,7 @@ int AllocateSonPatch( const int FaLv, const int *Cr, const int PScale, const int
       char dummy;    // we do not record the dual-energy status here
 
       Hydro_DualEnergyFix( FData_Flu[DENS][k][j][i], FData_Flu[MOMX][k][j][i], FData_Flu[MOMY][k][j][i],
-                           FData_Flu[MOMZ][k][j][i], FData_Flu[ENGY][k][j][i], FData_Flu[ENPY][k][j][i],
+                           FData_Flu[MOMZ][k][j][i], FData_Flu[ENGY][k][j][i], FData_Flu[DUAL][k][j][i],
                            dummy, EoS_AuxArray_Flt[1], EoS_AuxArray_Flt[2], CheckMinPres_Yes, MIN_PRES,
                            UseEnpy2FixEngy, Emag );
 

--- a/src/Main/InterpolateGhostZone.cpp
+++ b/src/Main/InterpolateGhostZone.cpp
@@ -1396,7 +1396,7 @@ void InterpolateGhostZone( const int lv, const int PID, real IntData_CC[], real 
       real *FData_MomY = IntData_CC + MOMY*FSize3D_CC;
       real *FData_MomZ = IntData_CC + MOMZ*FSize3D_CC;
       real *FData_Engy = IntData_CC + ENGY*FSize3D_CC;
-      real *FData_Enpy = IntData_CC + ENPY*FSize3D_CC;
+      real *FData_Dual = IntData_CC + DUAL*FSize3D_CC;
 
       char dummy;    // we do not record the dual-energy status here
 
@@ -1416,7 +1416,7 @@ void InterpolateGhostZone( const int lv, const int PID, real IntData_CC[], real 
 //       here we ALWAYS use the dual-energy variable to correct the total energy density
 //       --> we achieve that by setting the dual-energy switch to an extremely larger number and ignore
 //           the runtime parameter DUAL_ENERGY_SWITCH here
-         Hydro_DualEnergyFix( FData_Dens[t], FData_MomX[t], FData_MomY[t], FData_MomZ[t], FData_Engy[t], FData_Enpy[t],
+         Hydro_DualEnergyFix( FData_Dens[t], FData_MomX[t], FData_MomY[t], FData_MomZ[t], FData_Engy[t], FData_Dual[t],
                               dummy, EoS_AuxArray_Flt[1], EoS_AuxArray_Flt[2], (MinPres>=(real)0.0), MinPres,
                               UseEnpy2FixEngy, Emag );
       }

--- a/src/Main/InterpolateGhostZone.cpp
+++ b/src/Main/InterpolateGhostZone.cpp
@@ -1388,7 +1388,7 @@ void InterpolateGhostZone( const int lv, const int PID, real IntData_CC[], real 
                                      IntData_FC + FSize3D_FC[0] + FSize3D_FC[1] };
       const int  size_ij         = FSize_CC[0]*FSize_CC[1];
 #     endif
-      const real UseEnpy2FixEngy = HUGE_NUMBER;
+      const real UseDual2FixEngy = HUGE_NUMBER;
 
 //    assuming that the order of variables stored in IntData_CC[] is the same as patch->fluid[]
       real *FData_Dens = IntData_CC + DENS*FSize3D_CC;
@@ -1418,7 +1418,7 @@ void InterpolateGhostZone( const int lv, const int PID, real IntData_CC[], real 
 //           the runtime parameter DUAL_ENERGY_SWITCH here
          Hydro_DualEnergyFix( FData_Dens[t], FData_MomX[t], FData_MomY[t], FData_MomZ[t], FData_Engy[t], FData_Dual[t],
                               dummy, EoS_AuxArray_Flt[1], EoS_AuxArray_Flt[2], (MinPres>=(real)0.0), MinPres,
-                              UseEnpy2FixEngy, Emag );
+                              UseDual2FixEngy, Emag );
       }
    } // if (  DE_Consistency  &&  ( TVarCC & _TOTAL ) == _TOTAL  &&  TVarFC == _MAG )
 #  endif // if ( MODEL == HYDRO  &&  defined DUAL_ENERGY )

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_DualEnergy.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_DualEnergy.cpp
@@ -10,12 +10,12 @@
 
 
 // internal functions
-#if ( DUAL_ENERGY == DE_ENPY  &&  defined __CUDACC__ )
+#ifdef __CUDACC__
 GPU_DEVICE
-static real Hydro_DensPres2Entropy( const real Dens, const real Pres, const real Gamma_m1 );
+static real Hydro_DensPres2Dual( const real Dens, const real Pres, const real Gamma_m1 );
 GPU_DEVICE
-static real Hydro_DensEntropy2Pres( const real Dens, const real Enpy, const real Gamma_m1,
-                                    const bool CheckMinPres, const real MinPres );
+static real Hydro_DensDual2Pres( const real Dens, const real Dual, const real Gamma_m1,
+                                 const bool CheckMinPres, const real MinPres );
 #endif
 
 
@@ -27,20 +27,25 @@ static real Hydro_DensEntropy2Pres( const real Dens, const real Enpy, const real
 //
 // Note        :  1. Invoked by Hydro_FullStepUpdate(), InterpolateGhostZon(), ...
 //                2. A floor value "MinPres" is applied to the corrected pressure if CheckMinPres is on
-//                3  A floor value "TINY_NUMBER" is applied to the input entropy as well
-//                4. Call-by-reference for "Etot, Enpy, and DE_Status"
+//                3  A floor value "TINY_NUMBER" is applied to the input dual-energy variable as well
+//                4. Call-by-reference for "Etot, Dual, and DE_Status"
+//                5. The dual-energy variable is determined by DUAL_ENERGY, which can be either
+//                   DE_ENPY (entropy) or DE_EINT (internal energy)
+//                   --> DE_ENPY: entropy = pressure / density^(Gamma-1)
+//                       DE_EINT: internal_energy = pressure / (Gamma-1)
+//                   --> Note that the entropy here is a monotonic function of entropy per volume
+//                       instead of the real thermodynamic entropy (see Eqs. 48 and 49 in the Arepo code paper)
 //                5. Fluid variables returned by this function are guaranteed to be consistent with each other
-//                   --> They must satisfy "entropy = pressure / density^(Gamma-1)", where pressure is calculated
-//                       by (Etot - Ekin - Emag)*(Gamma-1.0)
-//                   --> It doesn't matter we use entropy to correct Eint or vice versa, and it also holds even when
-//                       the floor value is applied to pressure
+//                   --> It doesn't matter we use the dual-energy variable to correct Eint or vice versa,
+//                       and it also holds even when the floor value is applied to pressure
+//                6. Only support the Gamma-law EoS for now
 //
 // Parameter   :  Dens             : Mass density
 //                MomX/Y/Z         : Momentum density
 //                Etot             : Total energy density
-//                Enpy             : Entropy
+//                Dual             : Dual-energy variable
 //                DE_Status        : Assigned to (DE_UPDATED_BY_ETOT / DE_UPDATED_BY_DUAL / DE_UPDATED_BY_MIN_PRES)
-//                                   to indicate whether this cell is updated by the total energy, dual energy variable,
+//                                   to indicate whether this cell is updated by the total energy, dual-energy variable,
 //                                   or pressure floor (MinPres)
 //                Gamma_m1         : Adiabatic index - 1.0
 //                _Gamma_m1        : 1.0/Gamma_m1
@@ -49,14 +54,14 @@ static real Hydro_DensEntropy2Pres( const real Dens, const real Enpy, const real
 //                                       for which we don't want to enable this option
 //                MinPres          : Minimum allowed pressure
 //                DualEnergySwitch : if ( Eint/(Ekin+Emag) < DualEnergySwitch ) ==> correct Eint and Etot
-//                                   else                                       ==> correct Enpy
+//                                   else                                       ==> correct Dual
 //                Emag             : Magnetic energy density (0.5*B^2) --> for MHD only
 //
-// Return      :  Etot, Enpy, DE_Status
+// Return      :  Etot, Dual, DE_Status
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE
 void Hydro_DualEnergyFix( const real Dens, const real MomX, const real MomY, const real MomZ,
-                          real &Etot, real &Enpy, char &DE_Status, const real Gamma_m1, const real _Gamma_m1,
+                          real &Etot, real &Dual, char &DE_Status, const real Gamma_m1, const real _Gamma_m1,
                           const bool CheckMinPres, const real MinPres, const real DualEnergySwitch,
                           const real Emag )
 {
@@ -64,8 +69,8 @@ void Hydro_DualEnergyFix( const real Dens, const real MomX, const real MomY, con
    const bool CheckMinPres_No = false;
    const bool CheckMinEint_No = false;
 
-// apply entropy floor
-   Enpy = FMAX( Enpy, TINY_NUMBER );
+// apply the dual-energy floor
+   Dual = FMAX( Dual, TINY_NUMBER );
 
 
 // calculate energies
@@ -77,28 +82,22 @@ void Hydro_DualEnergyFix( const real Dens, const real MomX, const real MomY, con
    Enth = Etot - Eint;
 
 
-// determine whether or not to use the dual-energy variable (entropy or internal energy) to correct the total energy density
+// determine whether or not to use the dual-energy variable to correct the total energy density
    if ( Eint/Enth < DualEnergySwitch )
    {
 //    correct total energy
 //    --> we will apply pressure floor later
-#     if   ( DUAL_ENERGY == DE_ENPY )
-      Pres = Hydro_DensEntropy2Pres( Dens, Enpy, Gamma_m1, CheckMinPres_No, NULL_REAL );
-      Eint = Pres*_Gamma_m1;
-
-#     elif ( DUAL_ENERGY == DE_EINT )
-#     error : DE_EINT is NOT supported yet !!
-#     endif
-
+      Pres      = Hydro_DensDual2Pres( Dens, Dual, Gamma_m1, CheckMinPres_No, NULL_REAL );
+      Eint      = Pres*_Gamma_m1;
       Etot      = Enth + Eint;
       DE_Status = DE_UPDATED_BY_DUAL;
    }
 
    else
    {
-//    correct entropy
+//    correct dual-energy variable
       Pres      = Eint*Gamma_m1;
-      Enpy      = Hydro_DensPres2Entropy( Dens, Pres, Gamma_m1 );
+      Dual      = Hydro_DensPres2Dual( Dens, Pres, Gamma_m1 );
       DE_Status = DE_UPDATED_BY_ETOT;
    } // if ( Eint/Enth < DualEnergySwitch ) ... else ...
 
@@ -109,9 +108,9 @@ void Hydro_DualEnergyFix( const real Dens, const real MomX, const real MomY, con
       Pres = MinPres;
       Eint = Pres*_Gamma_m1;
 
-//    ensure that both energy and entropy are consistent with the pressure floor
+//    ensure that both energy and dual-energy variable are consistent with the pressure floor
       Etot      = Enth + Eint;
-      Enpy      = Hydro_DensPres2Entropy( Dens, Pres, Gamma_m1 );
+      Dual      = Hydro_DensPres2Dual( Dens, Pres, Gamma_m1 );
       DE_Status = DE_UPDATED_BY_MIN_PRES;
    }
 
@@ -119,19 +118,17 @@ void Hydro_DualEnergyFix( const real Dens, const real MomX, const real MomY, con
 
 
 
-#if ( DUAL_ENERGY == DE_ENPY )
-
-// Hydro_Con2Entropy() is used by CPU only
+// Hydro_Con2Dual() is used by CPU only
 #ifndef __CUDACC__
 //-------------------------------------------------------------------------------------------------------
-// Function    :  Hydro_Con2Entropy
-// Description :  Evaluate the gas entropy from the input fluid variables
-//                --> Here entropy is defined as "pressure / density^(Gamma-1)" (i.e., entropy per volume)
+// Function    :  Hydro_Con2Dual
+// Description :  Evaluate the dual-energy variable from the input fluid variables
 //
 // Note        :  1. Used by the dual-energy formalism
 //                2. Invoked by Hydro_Init_ByFunction_AssignData(), Gra_Close(), Init_ByFile(), ...
 //                3. Currently this function does NOT apply pressure floor when calling Hydro_Con2Pres()
-//                   --> However, note that Hydro_DensPres2Entropy() does apply a floor value (TINY_NUMBER) for entropy
+//                   --> However, note that Hydro_DensPres2Dual() does apply a floor value (TINY_NUMBER) to the
+//                       dual-energy variable
 //
 // Parameter   :  Dens              : Mass density
 //                MomX/Y/Z          : Momentum density
@@ -141,38 +138,37 @@ void Hydro_DualEnergyFix( const real Dens, const real MomX, const real MomY, con
 //                EoS_AuxArray_*    : Auxiliary arrays for EoS_DensEint2Pres()
 //                EoS_Table         : EoS tables
 //
-// Return      :  Enpy
+// Return      :  Dual
 //-------------------------------------------------------------------------------------------------------
-real Hydro_Con2Entropy( const real Dens, const real MomX, const real MomY, const real MomZ, const real Engy,
-                        const real Emag, const EoS_DE2P_t EoS_DensEint2Pres, const double EoS_AuxArray_Flt[],
-                        const int EoS_AuxArray_Int[], const real *const EoS_Table[EOS_NTABLE_MAX] )
+real Hydro_Con2Dual( const real Dens, const real MomX, const real MomY, const real MomZ, const real Engy,
+                     const real Emag, const EoS_DE2P_t EoS_DensEint2Pres, const double EoS_AuxArray_Flt[],
+                     const int EoS_AuxArray_Int[], const real *const EoS_Table[EOS_NTABLE_MAX] )
 {
 
 // currently this function does NOT apply pressure floor when calling Hydro_Con2Pres()
    const bool CheckMinPres_No = false;
 
-   real Pres, Enpy;
+   real Pres, Dual;
 
-// calculate pressure and convert it to entropy
+// calculate pressure and convert it to the dual-energy variable
 // --> note that DE_ENPY only works with EOS_GAMMA, which does not involve passive scalars
    Pres = Hydro_Con2Pres( Dens, MomX, MomY, MomZ, Engy, NULL, CheckMinPres_No, NULL_REAL, Emag,
                           EoS_DensEint2Pres, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL );
-   Enpy = Hydro_DensPres2Entropy( Dens, Pres, EoS_AuxArray_Flt[1] );
+   Dual = Hydro_DensPres2Dual( Dens, Pres, EoS_AuxArray_Flt[1] );
 
-   return Enpy;
+   return Dual;
 
-} // FUNCTION : Hydro_Con2Entropy
+} // FUNCTION : Hydro_Con2Dual
 #endif // ifndef __CUDACC__
 
 
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  Hydro_DensPres2Entropy
-// Description :  Evaluate the gas entropy from the input density and pressure
-//                --> Here entropy is defined as "pressure / density^(Gamma-1)" (i.e., entropy per volume)
+// Function    :  Hydro_DensPres2Dual
+// Description :  Evaluate the dual-energy variable from the input density and pressure
 //
 // Note        :  1. Used by the dual-energy formalism
-//                2. Invoked by Hydro_Con2Entropy() and Hydro_DualEnergyFix()
+//                2. Invoked by Hydro_Con2Dual() and Hydro_DualEnergyFix()
 //                   --> This function is invoked by both CPU and GPU codes
 //                3. A floor value (TINY_NUMBER) is applied to the returned value
 //
@@ -180,30 +176,33 @@ real Hydro_Con2Entropy( const real Dens, const real MomX, const real MomY, const
 //                Pres     : Pressure
 //                Gamma_m1 : Adiabatic index - 1.0
 //
-// Return      :  Enpy
+// Return      :  Dual
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE
-real Hydro_DensPres2Entropy( const real Dens, const real Pres, const real Gamma_m1 )
+real Hydro_DensPres2Dual( const real Dens, const real Pres, const real Gamma_m1 )
 {
 
-   real Enpy;
+   real Dual;
 
-// calculate entropy
-   Enpy = Pres*POW( Dens, -Gamma_m1 );
+// calculate the dual-energy variable
+#  if   ( DUAL_ENERGY == DE_ENPY )
+   Dual = Pres*POW( Dens, -Gamma_m1 );
+#  elif ( DUAL_ENERGY == DE_EINT )
+#  error : DE_EINT is NOT supported yet !!
+#  endif
 
 // apply a floor value
-   Enpy = FMAX( Enpy, TINY_NUMBER );
+   Dual = FMAX( Dual, TINY_NUMBER );
 
-   return Enpy;
+   return Dual;
 
-} // FUNCTION : Hydro_DensPres2Entropy
+} // FUNCTION : Hydro_DensPres2Dual
 
 
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  Hydro_DensEntropy2Pres
-// Description :  Evaluate the gas pressure from the input density and entropy
-//                --> Here entropy is defined as "pressure / density^(Gamma-1)" (i.e., entropy per volume)
+// Function    :  Hydro_DensDual2Pres
+// Description :  Evaluate the gas pressure from the input density and dual-energy variable
 //
 // Note        :  1. Used by the dual-energy formalism
 //                2. Invoked by Hydro_DualEnergyFix(), Flu_Close(), Hydro_Aux_Check_Negative(), and Flu_FixUp()
@@ -211,7 +210,7 @@ real Hydro_DensPres2Entropy( const real Dens, const real Pres, const real Gamma_
 //                3. A floor value "MinPres" is applied to the returned pressure if CheckMinPres is on
 //
 // Parameter   :  Dens         : Mass density
-//                Enpy         : Enpy
+//                Dual         : Dual-energy variable
 //                Gamma_m1     : Adiabatic index - 1.0
 //                CheckMinPres : Return Hydro_CheckMinPres()
 //                               --> In some cases we actually want to check if pressure becomes unphysical,
@@ -221,23 +220,25 @@ real Hydro_DensPres2Entropy( const real Dens, const real Pres, const real Gamma_
 // Return      :  Pres
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE
-real Hydro_DensEntropy2Pres( const real Dens, const real Enpy, const real Gamma_m1,
-                             const bool CheckMinPres, const real MinPres )
+real Hydro_DensDual2Pres( const real Dens, const real Dual, const real Gamma_m1,
+                          const bool CheckMinPres, const real MinPres )
 {
 
    real Pres;
 
 // calculate pressure
-   Pres = Enpy*POW( Dens, Gamma_m1 );
+#  if   ( DUAL_ENERGY == DE_ENPY )
+   Pres = Dual*POW( Dens, Gamma_m1 );
+#  elif ( DUAL_ENERGY == DE_EINT )
+#  error : DE_EINT is NOT supported yet !!
+#  endif
 
 // apply a floor value
    if ( CheckMinPres )  Pres = Hydro_CheckMinPres( Pres, MinPres );
 
    return Pres;
 
-} // FUNCTION : Hydro_DensEntropy2Pres
-
-#endif // #if ( DUAL_ENERGY == DE_ENPY )
+} // FUNCTION : Hydro_DensDual2Pres
 
 
 

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_DualEnergy.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_DualEnergy.cpp
@@ -35,10 +35,10 @@ static real Hydro_DensDual2Pres( const real Dens, const real Dual, const real Ga
 //                       DE_EINT: internal_energy = pressure / (Gamma-1)
 //                   --> Note that the entropy here is a monotonic function of entropy per volume
 //                       instead of the real thermodynamic entropy (see Eqs. 48 and 49 in the Arepo code paper)
-//                5. Fluid variables returned by this function are guaranteed to be consistent with each other
+//                6. Fluid variables returned by this function are guaranteed to be consistent with each other
 //                   --> It doesn't matter we use the dual-energy variable to correct Eint or vice versa,
 //                       and it also holds even when the floor value is applied to pressure
-//                6. Only support the Gamma-law EoS for now
+//                7. Only support the Gamma-law EoS for now
 //
 // Parameter   :  Dens             : Mass density
 //                MomX/Y/Z         : Momentum density

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_FluUtility.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_FluUtility.cpp
@@ -943,6 +943,11 @@ real Hydro_Con2Temp( const real Dens, const real MomX, const real MomY, const re
 // Description :  Evaluate the fluid entropy
 //
 // Note        :  1. Invoke the EoS routine EoS_DensEint2Entr() to support different EoS
+//                2. We regard the entropy used in the EoS routines and that used in the dual-energy formalism
+//                   as two completely separate fields
+//                   --> The former is referred to as Entr/ENTR and manipulated by the EoS API, while the latter is
+//                       usually referred to as Enpy/Dual/DUAL and manipulated by the routines in CPU_Shared_DualEnergy.cpp
+//                   --> This routine, Hydro_Con2Entr(), belongs to the former
 //
 // Parameter   :  Dens              : Mass density
 //                MomX/Y/Z          : Momentum density

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_FullStepUpdate.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_FullStepUpdate.cpp
@@ -157,7 +157,7 @@ void Hydro_FullStepUpdate( const real g_Input[][ CUBE(FLU_NXT) ], real g_Output[
 //    Output_1Cell[DENS] = FMAX( Output_1Cell[DENS], MinDens );
 
       Hydro_DualEnergyFix( Output_1Cell[DENS], Output_1Cell[MOMX], Output_1Cell[MOMY], Output_1Cell[MOMZ],
-                           Output_1Cell[ENGY], Output_1Cell[ENPY], g_DE_Status[idx_out],
+                           Output_1Cell[ENGY], Output_1Cell[DUAL], g_DE_Status[idx_out],
                            EoS->AuxArrayDevPtr_Flt[1], EoS->AuxArrayDevPtr_Flt[2], CheckMinPres_No, NULL_REAL,
                            DualEnergySwitch, Emag );
 #     endif // #ifdef DUAL_ENERGY

--- a/src/Model_Hydro/Hydro_Aux_Check_Negative.cpp
+++ b/src/Model_Hydro/Hydro_Aux_Check_Negative.cpp
@@ -106,7 +106,7 @@ void Hydro_Aux_Check_Negative( const int lv, const int Mode, const char *comment
             if ( Mode == 2  ||  Mode == 3 )
             {
 #              if ( DUAL_ENERGY == DE_ENPY )
-               if ( Pres <= PresCheck  ||  Fluid[ENPY] < EnpyCheck )
+               if ( Pres <= PresCheck  ||  Fluid[DUAL] < EnpyCheck )
 #              else
                if ( Pres <= PresCheck )
 #              endif

--- a/src/Model_Hydro/Hydro_Aux_Check_Negative.cpp
+++ b/src/Model_Hydro/Hydro_Aux_Check_Negative.cpp
@@ -35,6 +35,10 @@ void Hydro_Aux_Check_Negative( const int lv, const int Mode, const char *comment
    if ( lv < 0  ||  lv >= NLEVEL )  Aux_Error( ERROR_INFO, "incorrect parameter %s = %d !!\n", "lv", lv );
    if ( Mode < 1  ||  Mode > 3 )    Aux_Error( ERROR_INFO, "incorrect parameter %s = %d !!\n", "Mode", Mode );
 
+#  if ( DUAL_ENERGY == DE_EINT )
+#  error : DE_EINT is NOT supported yet !!
+#  endif
+
 
    const bool CheckMinPres_No = false;
 
@@ -62,7 +66,7 @@ void Hydro_Aux_Check_Negative( const int lv, const int Mode, const char *comment
             for (int v=0; v<NCOMP_TOTAL; v++)   Fluid[v] = amr->patch[ amr->FluSg[lv] ][lv][PID]->fluid[v][k][j][i];
 
 #           if ( DUAL_ENERGY == DE_ENPY )
-            Pres = Hydro_DensEntropy2Pres( Fluid[DENS], Fluid[ENPY], EoS_AuxArray_Flt[1], CheckMinPres_No, NULL_REAL );
+            Pres = Hydro_DensDual2Pres( Fluid[DENS], Fluid[DUAL], EoS_AuxArray_Flt[1], CheckMinPres_No, NULL_REAL );
 #           else
 #           ifdef MHD
             const real Emag = MHD_GetCellCenteredBEnergyInPatch( lv, PID, i, j, k, amr->MagSg[lv] );

--- a/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
+++ b/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
@@ -275,11 +275,9 @@ void Hydro_Init_ByFunction_AssignData( const int lv )
                                                  MIN_EINT, Emag );
 
 //       calculate the dual-energy variable (entropy or internal energy)
-#        if   ( DUAL_ENERGY == DE_ENPY )
-         fluid[ENPY] = Hydro_Con2Entropy( fluid[DENS], fluid[MOMX], fluid[MOMY], fluid[MOMZ], fluid[ENGY], Emag,
-                                          EoS_DensEint2Pres_CPUPtr, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
-#        elif ( DUAL_ENERGY == DE_EINT )
-#        error : DE_EINT is NOT supported yet !!
+#        ifdef DUAL_ENERGY
+         fluid[DUAL] = Hydro_Con2Dual( fluid[DENS], fluid[MOMX], fluid[MOMY], fluid[MOMZ], fluid[ENGY], Emag,
+                                       EoS_DensEint2Pres_CPUPtr, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
 #        endif
 
 //       floor and normalize passive scalars

--- a/src/Refine/Flag_Real.cpp
+++ b/src/Refine/Flag_Real.cpp
@@ -269,8 +269,8 @@ void Flag_Real( const int lv, const UseLBFunc_t UseLBFunc )
 #                    ifdef DUAL_ENERGY
 
 #                    if   ( DUAL_ENERGY == DE_ENPY )
-                     Pres[k][j][i] = Hydro_DensEntropy2Pres( Fluid[DENS][k][j][i], Fluid[ENPY][k][j][i],
-                                                             EoS_AuxArray_Flt[1], CheckMinPres_Yes, MIN_PRES );
+                     Pres[k][j][i] = Hydro_DensDual2Pres( Fluid[DENS][k][j][i], Fluid[DUAL][k][j][i],
+                                                          EoS_AuxArray_Flt[1], CheckMinPres_Yes, MIN_PRES );
 #                    elif ( DUAL_ENERGY == DE_EINT )
 #                    error : DE_EINT is NOT supported yet !!
 #                    endif

--- a/src/Refine/Refine.cpp
+++ b/src/Refine/Refine.cpp
@@ -801,7 +801,7 @@ void Refine( const int lv, const UseLBFunc_t UseLBFunc )
             char dummy;    // we do not record the dual-energy status here
 
             Hydro_DualEnergyFix( Flu_FData[DENS][k][j][i], Flu_FData[MOMX][k][j][i], Flu_FData[MOMY][k][j][i],
-                                 Flu_FData[MOMZ][k][j][i], Flu_FData[ENGY][k][j][i], Flu_FData[ENPY][k][j][i],
+                                 Flu_FData[MOMZ][k][j][i], Flu_FData[ENGY][k][j][i], Flu_FData[DUAL][k][j][i],
                                  dummy, EoS_AuxArray_Flt[1], EoS_AuxArray_Flt[2], CheckMinPres_Yes, MIN_PRES,
                                  UseEnpy2FixEngy, Emag );
 

--- a/src/Refine/Refine.cpp
+++ b/src/Refine/Refine.cpp
@@ -797,13 +797,13 @@ void Refine( const int lv, const UseLBFunc_t UseLBFunc )
 //              the runtime parameter DUAL_ENERGY_SWITCH here
 #           ifdef DUAL_ENERGY
             const bool CheckMinPres_Yes = true;
-            const real UseEnpy2FixEngy  = HUGE_NUMBER;
+            const real UseDual2FixEngy  = HUGE_NUMBER;
             char dummy;    // we do not record the dual-energy status here
 
             Hydro_DualEnergyFix( Flu_FData[DENS][k][j][i], Flu_FData[MOMX][k][j][i], Flu_FData[MOMY][k][j][i],
                                  Flu_FData[MOMZ][k][j][i], Flu_FData[ENGY][k][j][i], Flu_FData[DUAL][k][j][i],
                                  dummy, EoS_AuxArray_Flt[1], EoS_AuxArray_Flt[2], CheckMinPres_Yes, MIN_PRES,
-                                 UseEnpy2FixEngy, Emag );
+                                 UseDual2FixEngy, Emag );
 
 #           else // #ifdef DUAL_ENERGY
 

--- a/src/SelfGravity/Gra_Close.cpp
+++ b/src/SelfGravity/Gra_Close.cpp
@@ -69,16 +69,14 @@ void Gra_Close( const int lv, const int SaveSg, const real h_Flu_Array_G[][GRA_N
                const real Emag = NULL_REAL;
 #              endif
 
-#              if   ( DUAL_ENERGY == DE_ENPY )
-               amr->patch[SaveSg][lv][PID]->fluid[ENPY][k][j][i]
-                  = Hydro_Con2Entropy( amr->patch[SaveSg][lv][PID]->fluid[DENS][k][j][i],
-                                       amr->patch[SaveSg][lv][PID]->fluid[MOMX][k][j][i],
-                                       amr->patch[SaveSg][lv][PID]->fluid[MOMY][k][j][i],
-                                       amr->patch[SaveSg][lv][PID]->fluid[MOMZ][k][j][i],
-                                       amr->patch[SaveSg][lv][PID]->fluid[ENGY][k][j][i],
-                                       Emag, EoS_DensEint2Pres_CPUPtr, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
-#              elif ( DUAL_ENERGY == DE_EINT )
-#              error : DE_EINT is NOT supported yet !!
+#              ifdef DUAL_ENERGY
+               amr->patch[SaveSg][lv][PID]->fluid[DUAL][k][j][i]
+                  = Hydro_Con2Dual( amr->patch[SaveSg][lv][PID]->fluid[DENS][k][j][i],
+                                    amr->patch[SaveSg][lv][PID]->fluid[MOMX][k][j][i],
+                                    amr->patch[SaveSg][lv][PID]->fluid[MOMY][k][j][i],
+                                    amr->patch[SaveSg][lv][PID]->fluid[MOMZ][k][j][i],
+                                    amr->patch[SaveSg][lv][PID]->fluid[ENGY][k][j][i],
+                                    Emag, EoS_DensEint2Pres_CPUPtr, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
 #              endif
             }
 #           endif // #ifdef UNSPLIT_GRAVITY

--- a/src/SourceTerms/Deleptonization/CPU_Src_Deleptonization.cpp
+++ b/src/SourceTerms/Deleptonization/CPU_Src_Deleptonization.cpp
@@ -173,7 +173,7 @@ void Src_WorkBeforeMajorFunc_Deleptonization( const int lv, const double TimeNew
    const bool        LogBin         = true;
    const double      LogBinRatio    = 1.25;
    const bool        RemoveEmptyBin = true;
-   const long        TVar[]         = { _DENS, _MOMX, _ENGY, _PRES, _VELR, _EINT_DER };
+   const long        TVar[]         = { _DENS, _MOMX, _ENGY, _PRES, _VELR, _EINT };
    const int         NProf          = SRC_DLEP_PROF_NVAR;
    const int         SingleLv       = -1;
    const int         MaxLv          = -1;

--- a/src/TestProblem/Hydro/Bondi/Flu_ResetByUser_Bondi.cpp
+++ b/src/TestProblem/Hydro/Bondi/Flu_ResetByUser_Bondi.cpp
@@ -155,12 +155,10 @@ void Flu_ResetByUser_API_Bondi( const int lv, const int FluSg, const double Time
             fluid[ENGY] = Hydro_CheckMinEintInEngy( fluid[DENS], fluid[MOMX], fluid[MOMY], fluid[MOMZ], fluid[ENGY],
                                                     (real)MIN_EINT, Emag );
 
-//          calculate the dual-energy variable (entropy or internal energy)
-#           if   ( DUAL_ENERGY == DE_ENPY )
-            fluid[ENPY] = Hydro_Con2Entropy( fluid[DENS], fluid[MOMX], fluid[MOMY], fluid[MOMZ], fluid[ENGY], Emag,
-                                             EoS_DensEint2Pres_CPUPtr, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
-#           elif ( DUAL_ENERGY == DE_EINT )
-#           error : DE_EINT is NOT supported yet !!
+//          calculate the dual-energy variable
+#           ifdef DUAL_ENERGY
+            fluid[DUAL] = Hydro_Con2Dual( fluid[DENS], fluid[MOMX], fluid[MOMY], fluid[MOMZ], fluid[ENGY], Emag,
+                                          EoS_DensEint2Pres_CPUPtr, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
 #           endif
 
 //          floor and normalize passive scalars

--- a/test_problem_deprecated/Model_ParticleOnly/TwoParOrbit/Flu_ResetByUser.cpp
+++ b/test_problem_deprecated/Model_ParticleOnly/TwoParOrbit/Flu_ResetByUser.cpp
@@ -93,7 +93,7 @@ void Flu_ResetByUser( const int lv, const int FluSg, const double TTime )
 
 //          calculate the dual-energy variable (entropy or internal energy)
 #           if   ( DUAL_ENERGY == DE_ENPY )
-            fluid[ENPY] = CPU_Fluid2Entropy( fluid[DENS], fluid[MOMX], fluid[MOMY], fluid[MOMZ], fluid[ENGY], Gamma_m1 );
+            fluid[DUAL] = CPU_Fluid2Entropy( fluid[DENS], fluid[MOMX], fluid[MOMY], fluid[MOMZ], fluid[ENGY], Gamma_m1 );
 #           elif ( DUAL_ENERGY == DE_EINT )
 #           error : DE_EINT is NOT supported yet !!
 #           endif


### PR DESCRIPTION
Rename the dual-energy variables, constants, and functions to better distinguish them from the gas entropy in the EoS module.
- `ENPY` and `EINT` &#8594; `DUAL` (similar for `Enpy`, `Entropy`, etc)
- `_EINT_DER` &#8594; `_EINT`

This will also make it easier to support `DUAL_ENERGY = DE_EINT` in the future.