### PR TITLE
Fix minor issues with particles

### DIFF
--- a/example/test_problem/Hydro/ParticleTest/Input__Parameter
+++ b/example/test_problem/Hydro/ParticleTest/Input__Parameter
@@ -20,7 +20,7 @@ NX0_TOT_X                     32          # number of base-level cells along x
 NX0_TOT_Y                     32          # number of base-level cells along y
 NX0_TOT_Z                     32          # number of base-level cells along z
 OMP_NTHREAD                  -1           # number of OpenMP threads (<=0=auto -> omp_get_max_threads) [-1] ##OPENMP ONLY##
-END_T                        -1         # end physical time (<0=auto -> must be set by test problems or restart) [-1.0]
+END_T                        -1           # end physical time (<0=auto -> must be set by test problems or restart) [-1.0]
 END_STEP                     -1           # end step (<0=auto -> must be set by test problems or restart) [-1]
 
 
@@ -198,7 +198,7 @@ OPT__OUTPUT_DIVMAG            0           # output |divergence(B)*dh/|B|| [0] ##
 OPT__OUTPUT_USER_FIELD        0           # output user-defined derived fields [0] -> edit "Flu_DerivedField_User.cpp"
 OPT__OUTPUT_MODE              2           # (1=const step, 2=const dt, 3=dump table) -> edit "Input__DumpTable" for 3
 OUTPUT_STEP                   5           # output data every OUTPUT_STEP step ##OPT__OUTPUT_MODE==1 ONLY##
-OUTPUT_DT                     100.0      # output data every OUTPUT_DT time interval ##OPT__OUTPUT_MODE==2 ONLY##
+OUTPUT_DT                  100.0          # output data every OUTPUT_DT time interval ##OPT__OUTPUT_MODE==2 ONLY##
 OUTPUT_PART_X                0.5          # x coordinate for OPT__OUTPUT_PART [-1.0]
 OUTPUT_PART_Y                0.5          # y coordinate for OPT__OUTPUT_PART [-1.0]
 OUTPUT_PART_Z                0.5          # z coordinate for OPT__OUTPUT_PART [-1.0]
@@ -228,6 +228,6 @@ OPT__CK_FINITE                0           # check if all variables are finite [0
 OPT__CK_PATCH_ALLOCATE        0           # check if all patches are properly allocated [0]
 OPT__CK_FLUX_ALLOCATE         0           # check if all flux arrays are properly allocated ##HYDRO and ELBDM ONLY## [0]
 OPT__CK_NEGATIVE              0           # check the negative values: (0=off, 1=density, 2=pressure and entropy, 3=both) [0] ##HYDRO ONLY##
-OPT__CK_MEMFREE               0         # check the free memory in GB (0=off, >0=threshold) [1.0]
+OPT__CK_MEMFREE               0           # check the free memory in GB (0=off, >0=threshold) [1.0]
 OPT__CK_PARTICLE              0           # check the particle allocation [0]
 

--- a/src/Fluid/Flu_CorrAfterAllSync.cpp
+++ b/src/Fluid/Flu_CorrAfterAllSync.cpp
@@ -47,25 +47,22 @@ void Flu_CorrAfterAllSync()
 
 // 1. synchronize all particles
 #  if ( defined PARTICLE  &&  defined STORE_PAR_ACC )
-   if ( ! OPT__FREEZE_PAR )
+   if ( OPT__VERBOSE  &&  MPI_Rank == 0 )
+      Aux_Message( stdout, "      synchronize particles                 ... " );
+
+   if (  Par_Synchronize( Time[0], PAR_SYNC_FORCE ) != 0  )
+      Aux_Error( ERROR_INFO, "particle synchronization failed !!\n" );
+
+// particles may cross patch boundaries after synchronization
+   const bool TimingSendPar_No = false;
+
+   for (int lv=0; lv<NLEVEL; lv++)
    {
-      if ( OPT__VERBOSE  &&  MPI_Rank == 0 )
-         Aux_Message( stdout, "      synchronize particles                 ... " );
+      Par_PassParticle2Sibling( lv, TimingSendPar_No );
+      Par_PassParticle2Son_MultiPatch( lv, PAR_PASS2SON_EVOLVE, TimingSendPar_No, NULL_INT, NULL );
+   }
 
-      if (  Par_Synchronize( Time[0], PAR_SYNC_FORCE ) != 0  )
-         Aux_Error( ERROR_INFO, "particle synchronization failed !!\n" );
-
-//    particles may cross patch boundaries after synchronization
-      const bool TimingSendPar_No = false;
-
-      for (int lv=0; lv<NLEVEL; lv++)
-      {
-         Par_PassParticle2Sibling( lv, TimingSendPar_No );
-         Par_PassParticle2Son_MultiPatch( lv, PAR_PASS2SON_EVOLVE, TimingSendPar_No, NULL_INT, NULL );
-      }
-
-      if ( OPT__VERBOSE  &&  MPI_Rank == 0 )    Aux_Message( stdout, "done\n" );
-   } // if ( ! OPT__FREEZE_PAR )
+   if ( OPT__VERBOSE  &&  MPI_Rank == 0 )    Aux_Message( stdout, "done\n" );
 #  endif
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -41,9 +41,6 @@ SIMU_OPTION += -DMODEL=HYDRO
 # enable particles
 #SIMU_OPTION += -DPARTICLE
 
-# enable tracer particles
-#SIMU_OPTION += -DTRACER
-
 # support Grackle, a chemistry and radiative cooling library
 # --> must set NCOMP_PASSIVE_USER according to the primordial chemistry network set by GRACKLE_PRIMORDIAL
 # --> please enable OpenMP when compiling Grackle (by "make omp-on")
@@ -138,6 +135,9 @@ endif # GRAVITY
 # (b-4) particle options
 # ------------------------------------------------------------------------------------
 ifeq "$(filter -DPARTICLE, $(SIMU_OPTION))" "-DPARTICLE"
+# enable tracer particles
+#SIMU_OPTION += -DTRACER
+
 # store particle acceleration (recommended)
 SIMU_OPTION += -DSTORE_PAR_ACC
 

--- a/src/Output/Output_DumpData.cpp
+++ b/src/Output/Output_DumpData.cpp
@@ -179,6 +179,20 @@ void Output_DumpData( const int Stage )
    if ( OPT__MANUAL_CONTROL )    Output_DumpManually( OutputData_RunTime );
 
 
+// set the acceleration of tracer particles to zero to make the output deterministic
+#  if ( defined TRACER  &&  defined STORE_PAR_ACC )
+   for (long p=0; p<amr->Par->NPar_AcPlusInac; p++)
+   {
+      if ( amr->Par->Type[p] == PTYPE_TRACER )
+      {
+         amr->Par->AccX[p] = (real)0.0;
+         amr->Par->AccY[p] = (real)0.0;
+         amr->Par->AccZ[p] = (real)0.0;
+      }
+   }
+#  endif
+
+
 // output data
    if ( OutputData || OutputData_RunTime )
    {

--- a/src/Particle/LoadBalance/Par_LB_CollectParticle2OneLevel.cpp
+++ b/src/Particle/LoadBalance/Par_LB_CollectParticle2OneLevel.cpp
@@ -561,9 +561,9 @@ void Par_LB_CollectParticle2OneLevel( const int FaLv, const long AttBitIdx, cons
 
 //          4-1. check if this particle is indeed waiting for the velocity correction (i.e., ParTime = -dt_half < 0.0 for KDK)
 #           ifdef DEBUG_PARTICLE
-            if ( amr->Par->Integ == PAR_INTEG_KDK  &&  amr->Par->Time[ParID] >= (real)0.0 )
-               Aux_Error( ERROR_INFO, "This particle shouldn't be here (FaLv %d, FaPID %d, ParID %ld, ParTime %21.14e) !!\n",
-                          FaLv, FaPID, ParID, amr->Par->Time[ParID] );
+            if ( amr->Par->Integ == PAR_INTEG_KDK  &&  amr->Par->Time[ParID] >= (real)0.0  &&  amr->Par->Type[ParID] != PTYPE_TRACER )
+               Aux_Error( ERROR_INFO, "This particle shouldn't be here (FaLv %d, FaPID %d, ParID %ld, ParTime %21.14e, ParType %d ) !!\n",
+                          FaLv, FaPID, ParID, amr->Par->Time[ParID], (int)amr->Par->Type[ParID] );
 #           endif
 
 //          4-2. add particle data

--- a/src/Particle/Par_CollectParticle2OneLevel.cpp
+++ b/src/Particle/Par_CollectParticle2OneLevel.cpp
@@ -126,9 +126,9 @@ void Par_CollectParticle2OneLevel( const int FaLv, const long AttBitIdx, const b
       {
          const long ParID = amr->patch[0][FaLv][FaPID]->ParList[p];
 
-         if ( amr->Par->Time[ParID] >= (real)0.0 )
-            Aux_Error( ERROR_INFO, "This particle shouldn't be here (FaLv %d, FaPID %d, ParID %ld, ParTime %21.14e) !!\n",
-                       FaLv, FaPID, ParID, amr->Par->Time[ParID] );
+         if ( amr->Par->Time[ParID] >= (real)0.0  &&  amr->Par->Type[ParID] != PTYPE_TRACER )
+            Aux_Error( ERROR_INFO, "This particle shouldn't be here (FaLv %d, FaPID %d, ParID %ld, ParTime %21.14e, ParType %d) !!\n",
+                       FaLv, FaPID, ParID, amr->Par->Time[ParID], (int)amr->Par->Type[ParID] );
       }
 #     endif
 

--- a/src/Particle/Par_GetTimeStep_VelAcc.cpp
+++ b/src/Particle/Par_GetTimeStep_VelAcc.cpp
@@ -81,6 +81,7 @@ void Par_GetTimeStep_VelAcc( double &dt_vel, double &dt_acc, const int lv )
 
 // get the maximum particle velocity and acceleration on the target level
    real MaxVel, MaxAcc;
+   long NParVel=0, NParAcc=0;
 
    real *MaxVel_OMP = new real [NT];
    real *MaxAcc_OMP = new real [NT];
@@ -103,7 +104,7 @@ void Par_GetTimeStep_VelAcc( double &dt_vel, double &dt_acc, const int lv )
       const int TID = 0;
 #     endif
 
-#     pragma omp for schedule( PAR_OMP_SCHED, PAR_OMP_SCHED_CHUNK )
+#     pragma omp for reduction( +:NParVel, NParAcc ) schedule( PAR_OMP_SCHED, PAR_OMP_SCHED_CHUNK )
       for (int PID=0; PID<amr->NPatchComma[lv][1]; PID++)
       {
          int   NParThisPatch;
@@ -157,17 +158,21 @@ void Par_GetTimeStep_VelAcc( double &dt_vel, double &dt_acc, const int lv )
 
             for (int p=0; p<NParThisPatch; p++)
             {
-
                for (int d=0; d<3; d++)
                MaxVel_OMP[TID] = MAX( MaxVel_OMP[TID], FABS(Vel_Copy[d][p]) );
+
+               NParVel ++;
 
 //             don't check acceleration for tracer particles
                if ( Typ_Copy[p] == PTYPE_TRACER )
                   continue;
 
-               if ( UseAcc )
+               if ( UseAcc ) {
                for (int d=0; d<3; d++)
                MaxAcc_OMP[TID] = MAX( MaxAcc_OMP[TID], FABS(Acc_Copy[d][p]) );
+
+               NParAcc ++;
+               }
             }
          } // if ( UseCopy )
 
@@ -180,13 +185,18 @@ void Par_GetTimeStep_VelAcc( double &dt_vel, double &dt_acc, const int lv )
                for (int d=0; d<3; d++)
                MaxVel_OMP[TID] = MAX( MaxVel_OMP[TID], FABS(Vel[d][ParID]) );
 
+               NParVel ++;
+
 //             don't check acceleration for tracer particles
                if ( ParType[ParID] == PTYPE_TRACER )
                   continue;
 
-               if ( UseAcc )
+               if ( UseAcc ) {
                for (int d=0; d<3; d++)
                MaxAcc_OMP[TID] = MAX( MaxAcc_OMP[TID], FABS(Acc[d][ParID]) );
+
+               NParAcc ++;
+               }
             }
          } // if ( UseCopy ) ... else ...
       } // for (int PID=0; PID<amr->NPatchComma[lv][1]; PID++)
@@ -216,23 +226,30 @@ void Par_GetTimeStep_VelAcc( double &dt_vel, double &dt_acc, const int lv )
 
 // get the minimum time-step in all ranks
    MPI_Allreduce( &dt_vel_local, &dt_vel, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD );
+#  ifndef SERIAL
+   MPI_Reduce( (MPI_Rank==0)?MPI_IN_PLACE:&NParVel, &NParVel, 1, MPI_LONG, MPI_SUM, 0, MPI_COMM_WORLD );
+#  endif
 
-   if ( UseAcc )
+   if ( UseAcc ) {
    MPI_Allreduce( &dt_acc_local, &dt_acc, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD );
+#  ifndef SERIAL
+   MPI_Reduce( (MPI_Rank==0)?MPI_IN_PLACE:&NParAcc, &NParAcc, 1, MPI_LONG, MPI_SUM, 0, MPI_COMM_WORLD );
+#  endif
+   }
 
 
 // verify the minimum time-step
-   if ( !Aux_IsFinite(dt_vel)  &&  amr->Par->NPar_Lv[lv] > 0  &&  MPI_Rank == 0 )
+   if ( !Aux_IsFinite(dt_vel)  &&  NParVel > 0  &&  MPI_Rank == 0 )
    {
-      Aux_Message( stderr, "WARNING : time-step estimation by particle velocity is incorrect (dt_vel = %13.7e) !!\n", dt_vel );
+      Aux_Message( stderr, "WARNING : time-step estimation by particle velocity is incorrect (dt_vel = %13.7e, NParVel = %ld) !!\n", dt_vel, NParVel );
       Aux_Message( stderr, "          --> Likely all particles have zero velocity\n" );
 
       if ( DT__PARVEL_MAX < 0.0 )
       Aux_Message( stderr, "          --> You might want to set DT__PARVEL_MAX properly\n" );
    }
 
-   if ( UseAcc  &&  !Aux_IsFinite(dt_acc)  &&  amr->Par->NPar_Lv[lv] )
-      Aux_Error( ERROR_INFO, "time-step estimation by particle acceleration is incorrect (dt_acc = %13.7e) !!\n", dt_acc );
+   if ( UseAcc  &&  !Aux_IsFinite(dt_acc)  &&  NParAcc > 0  &&  MPI_Rank == 0 )
+      Aux_Error( ERROR_INFO, "time-step estimation by particle acceleration is incorrect (dt_acc = %13.7e, NParAcc = %ld) !!\n", dt_acc, NParAcc );
 
 
 // multiply by the safety factor

--- a/src/Particle/Par_Synchronize.cpp
+++ b/src/Particle/Par_Synchronize.cpp
@@ -90,6 +90,9 @@ int Par_Synchronize( const double SyncTime, const ParSync_t SyncOption )
 //    skip inactive particles
       if ( amr->Par->Mass[p] < 0.0 )   continue;
 
+//    skip massive particles when enabling OPT__FREEZE_PAR
+      if ( OPT__FREEZE_PAR  &&  amr->Par->Type[p] != PTYPE_TRACER )  continue;
+
       if (  ! Mis_CompareRealValue( SyncTime_Real, amr->Par->Time[p], NULL, false )  )
       {
 //       backup data before synchronization


### PR DESCRIPTION
This PR fixes the following minor issues with particles.
- Only apply `OPT__FREEZE_PAR` to massive particles
- Set the acceleration of tracer particles to zero to make outputs deterministic
- Fix `DEBUG_PARTICLE` with tracers when collecting particles to a given AMR level
- Fix the warning/error messages in `Par_GetTimeStep_VelAcc()` when there is no target particle

@jzuhone Could you take a look? Thanks.