### PR TITLE
Improve particles

### DIFF
--- a/example/test_problem/Template/Input__Parameter
+++ b/example/test_problem/Template/Input__Parameter
@@ -71,6 +71,7 @@ PAR_NPAR                      0           # total number of particles (must be s
 PAR_INIT                      1           # initialization option for particles: (1=FUNCTION, 2=RESTART, 3=FILE->"PAR_IC")
 PAR_IC_FORMAT                 1           # data format of PAR_IC: (1=[attribute][id], 2=[id][attribute]; row-major) [1]
 PAR_IC_MASS                  -1.0         # mass of all particles for PAR_INIT==3 (<0=off) [-1.0]
+PAR_IC_TYPE                   1           # type of all particles for PAR_INIT==3 (<0=off) [1 (GENERIC)]
 PAR_INTERP                    3           # particle interpolation scheme: (1=NGP, 2=CIC, 3=TSC) [2]
 PAR_INTEG                     2           # particle integration scheme: (1=Euler, 2=KDK) [2]
 PAR_TR_INTERP                 3           # tracer particle interpolation scheme: (1=NGP, 2=CIC, 3=TSC) [3]

--- a/example/test_problem/Template/Input__Parameter
+++ b/example/test_problem/Template/Input__Parameter
@@ -71,7 +71,7 @@ PAR_NPAR                      0           # total number of particles (must be s
 PAR_INIT                      1           # initialization option for particles: (1=FUNCTION, 2=RESTART, 3=FILE->"PAR_IC")
 PAR_IC_FORMAT                 1           # data format of PAR_IC: (1=[attribute][id], 2=[id][attribute]; row-major) [1]
 PAR_IC_MASS                  -1.0         # mass of all particles for PAR_INIT==3 (<0=off) [-1.0]
-PAR_IC_TYPE                   1           # type of all particles for PAR_INIT==3 (<0=off) [1 (GENERIC)]
+PAR_IC_TYPE                  -1           # type of all particles for PAR_INIT==3 (<0=off) [-1]
 PAR_INTERP                    3           # particle interpolation scheme: (1=NGP, 2=CIC, 3=TSC) [2]
 PAR_INTEG                     2           # particle integration scheme: (1=Euler, 2=KDK) [2]
 PAR_TR_INTERP                 3           # tracer particle interpolation scheme: (1=NGP, 2=CIC, 3=TSC) [3]

--- a/include/HDF5_Typedef.h
+++ b/include/HDF5_Typedef.h
@@ -360,6 +360,7 @@ struct InputPara_t
    int    Par_Init;
    int    Par_ICFormat;
    double Par_ICMass;
+   int    Par_ICType;
    int    Par_Interp;
    int    Par_InterpTracer;
    int    Par_Integ;

--- a/include/Macro.h
+++ b/include/Macro.h
@@ -499,9 +499,10 @@
 
 // particle type macros
 
-// number of particle types MUST be 4 for now
-#  define  PAR_NTYPE          4
+// number of particle types (default: 4)
+#  define  PAR_NTYPE                4
 
+// particle type indices (must be in the range 0<=index<PAR_NTYPE)
 #  define  PTYPE_TRACER          (real)0
 #  define  PTYPE_GENERIC_MASSIVE (real)1
 #  define  PTYPE_DARK_MATTER     (real)2

--- a/include/Particle.h
+++ b/include/Particle.h
@@ -38,6 +38,7 @@ void Aux_Error( const char *File, const int Line, const char *Func, const char *
 //                Init                    : Initialization methods (1/2/3 --> call function/restart/load from file)
 //                ParICFormat             : Data format of the particle initialization file (1=[att][id], 2=[id][att])
 //                ParICMass               : Assign this mass to all particles for Init=3
+//                ParICType               : Assign this type to all particles for Init=3
 //                Interp                  : Mass/acceleration/velocity interpolation scheme (NGP,CIC,TSC)
 //                InterpTracer            : Mass/acceleration/velocity interpolation scheme for tracers (NGP,CIC,TSC)
 //                Integ                   : Integration scheme (PAR_INTEG_EULER, PAR_INTEG_KDK)
@@ -117,6 +118,7 @@ struct Particle_t
    ParInit_t     Init;
    ParICFormat_t ParICFormat;
    double        ParICMass;
+   int           ParICType;
    ParInteg_t    Integ;
    ParInterp_t   Interp;
    TracerInteg_t IntegTracer;
@@ -185,6 +187,7 @@ struct Particle_t
       Init                = PAR_INIT_NONE;
       ParICFormat         = PAR_IC_FORMAT_NONE;
       ParICMass           = -1.0;
+      ParICType           = -1;
       Interp              = PAR_INTERP_NONE;
       InterpTracer        = PAR_INTERP_NONE;
       Integ               = PAR_INTEG_NONE;

--- a/include/Particle.h
+++ b/include/Particle.h
@@ -416,6 +416,9 @@ struct Particle_t
            NewAtt[PAR_POSZ] != NewAtt[PAR_POSZ]   )
          Aux_Error( ERROR_INFO, "Adding a particle with strange position (%21.14e, %21.14e, %21.14e) !!\n",
                     NewAtt[PAR_POSX], NewAtt[PAR_POSY], NewAtt[PAR_POSZ] );
+
+      if ( NewAtt[PAR_TYPE] < (real)0  ||  NewAtt[PAR_TYPE] >= (real)PAR_NTYPE )
+         Aux_Error( ERROR_INFO, "Incorrect particle type (%d) !!\n", (int)NewAtt[PAR_TYPE] );
 #     endif
 
 

--- a/src/Auxiliary/Aux_Check_Parameter.cpp
+++ b/src/Auxiliary/Aux_Check_Parameter.cpp
@@ -1358,6 +1358,9 @@ void Aux_Check_Parameter()
 #  ifdef TRACER
    if ( OPT__FLAG_NPAR_PATCH )
       Aux_Message( stderr, "WARNING : OPT__FLAG_NPAR_PATCH includes tracers and thus may affect the results of grid refinement !!\n" );
+
+   if ( OPT__FLAG_NPAR_CELL )
+      Aux_Message( stderr, "WARNING : OPT__FLAG_NPAR_CELL excludes tracers !!\n" );
 #  endif
 
    if ( OPT__FREEZE_PAR )

--- a/src/Auxiliary/Aux_Check_Parameter.cpp
+++ b/src/Auxiliary/Aux_Check_Parameter.cpp
@@ -1331,6 +1331,7 @@ void Aux_Check_Parameter()
    }
 #  endif // #ifdef GRAVITY
 
+
 // warning
 // ------------------------------
    if ( MPI_Rank == 0 ) {
@@ -1352,6 +1353,11 @@ void Aux_Check_Parameter()
 #  ifdef GRAVITY
    if ( OPT__GRA_P5_GRADIENT )
       Aux_Message( stderr, "WARNING : currently \"%s\" is not applied to particle update !!\n", "OPT__GRA_P5_GRADIENT" );
+#  endif
+
+#  ifdef TRACER
+   if ( OPT__FLAG_NPAR_PATCH )
+      Aux_Message( stderr, "WARNING : OPT__FLAG_NPAR_PATCH includes tracers and thus may affect the results of grid refinement !!\n" );
 #  endif
 
    if ( OPT__FREEZE_PAR )

--- a/src/Auxiliary/Aux_TakeNote.cpp
+++ b/src/Auxiliary/Aux_TakeNote.cpp
@@ -732,6 +732,7 @@ void Aux_TakeNote()
       fprintf( Note, "Par->Init                       %d\n",      amr->Par->Init                );
       fprintf( Note, "Par->ParICFormat                %d\n",      amr->Par->ParICFormat         );
       fprintf( Note, "Par->ParICMass                 %14.7e\n",   amr->Par->ParICMass           );
+      fprintf( Note, "Par->ParICType                  %d\n",      amr->Par->ParICType           );
       fprintf( Note, "Par->Interp                     %d\n",      amr->Par->Interp              );
       fprintf( Note, "Par->Integ                      %d\n",      amr->Par->Integ               );
       fprintf( Note, "Par->GhostSize                  %d\n",      amr->Par->GhostSize           );

--- a/src/Init/Init_ByRestart_HDF5.cpp
+++ b/src/Init/Init_ByRestart_HDF5.cpp
@@ -1782,6 +1782,7 @@ void Check_InputPara( const char *FileName, const int FormatVersion )
    LoadField( "Par_Init",                &RS.Par_Init,                SID, TID, NonFatal, &RT.Par_Init,                 1, NonFatal );
    LoadField( "Par_ICFormat",            &RS.Par_ICFormat,            SID, TID, NonFatal, &RT.Par_ICFormat,             1, NonFatal );
    LoadField( "Par_ICMass",              &RS.Par_ICMass,              SID, TID, NonFatal, &RT.Par_ICMass,               1, NonFatal );
+   LoadField( "Par_ICType",              &RS.Par_ICType,              SID, TID, NonFatal, &RT.Par_ICType,               1, NonFatal );
    LoadField( "Par_Interp",              &RS.Par_Interp,              SID, TID, NonFatal, &RT.Par_Interp,               1, NonFatal );
    LoadField( "Par_InterpTracer",        &RS.Par_InterpTracer,        SID, TID, NonFatal, &RT.Par_InterpTracer,         1, NonFatal );
    LoadField( "Par_Integ",               &RS.Par_Integ,               SID, TID, NonFatal, &RT.Par_Integ,                1, NonFatal );

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -77,6 +77,7 @@ void Init_Load_Parameter()
    ReadPara->Add( "PAR_INIT",                   &amr->Par->Init,                 -1,                1,             3              );
    ReadPara->Add( "PAR_IC_FORMAT",              &amr->Par->ParICFormat,      PAR_IC_FORMAT_ATT_ID,  1,             2              );
    ReadPara->Add( "PAR_IC_MASS",                &amr->Par->ParICMass,            -1.0,              NoMin_double,  NoMax_double   );
+   ReadPara->Add( "PAR_IC_TYPE",                &amr->Par->ParICType,  (int)PTYPE_GENERIC_MASSIVE,  NoMin_int,     PAR_NTYPE-1    );
    ReadPara->Add( "PAR_INTERP",                 &amr->Par->Interp,                PAR_INTERP_CIC,   1,             3              );
    ReadPara->Add( "PAR_INTEG",                  &amr->Par->Integ,                 PAR_INTEG_KDK,    1,             2              );
    ReadPara->Add( "PAR_TR_INTERP",              &amr->Par->InterpTracer,          PAR_INTERP_TSC,   1,             3              );

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -77,7 +77,7 @@ void Init_Load_Parameter()
    ReadPara->Add( "PAR_INIT",                   &amr->Par->Init,                 -1,                1,             3              );
    ReadPara->Add( "PAR_IC_FORMAT",              &amr->Par->ParICFormat,      PAR_IC_FORMAT_ATT_ID,  1,             2              );
    ReadPara->Add( "PAR_IC_MASS",                &amr->Par->ParICMass,            -1.0,              NoMin_double,  NoMax_double   );
-   ReadPara->Add( "PAR_IC_TYPE",                &amr->Par->ParICType,  (int)PTYPE_GENERIC_MASSIVE,  NoMin_int,     PAR_NTYPE-1    );
+   ReadPara->Add( "PAR_IC_TYPE",                &amr->Par->ParICType,            -1,                NoMin_int,     PAR_NTYPE-1    );
    ReadPara->Add( "PAR_INTERP",                 &amr->Par->Interp,                PAR_INTERP_CIC,   1,             3              );
    ReadPara->Add( "PAR_INTEG",                  &amr->Par->Integ,                 PAR_INTEG_KDK,    1,             2              );
    ReadPara->Add( "PAR_TR_INTERP",              &amr->Par->InterpTracer,          PAR_INTERP_TSC,   1,             3              );

--- a/src/LoadBalance/LB_EstimateWorkload_AllPatchGroup.cpp
+++ b/src/LoadBalance/LB_EstimateWorkload_AllPatchGroup.cpp
@@ -53,7 +53,7 @@ void LB_EstimateWorkload_AllPatchGroup( const int lv, const double ParWeight, do
       const bool JustCountNPar_Yes = true;
       const bool TimingSendPar_No  = false;
 
-      Par_CollectParticle2OneLevel( lv, _PAR_MASS|_PAR_POSX|_PAR_POSY|_PAR_POSZ, PredictPos_No, NULL_REAL,
+      Par_CollectParticle2OneLevel( lv, _NONE, PredictPos_No, NULL_REAL,
                                     SibBufPatch_No, FaSibBufPatch_No, JustCountNPar_Yes, TimingSendPar_No );
 
       for (int t=0; t<NPG_ThisRank; t++)

--- a/src/Output/Output_DumpData_Total_HDF5.cpp
+++ b/src/Output/Output_DumpData_Total_HDF5.cpp
@@ -69,7 +69,7 @@ Procedure for outputting new variables:
 
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  Output_DumpData_Total_HDF5 (FormatVersion = 2447)
+// Function    :  Output_DumpData_Total_HDF5 (FormatVersion = 2448)
 // Description :  Output all simulation data in the HDF5 format, which can be used as a restart file
 //                or loaded by YT
 //
@@ -218,6 +218,7 @@ Procedure for outputting new variables:
 //                2445 : 2022/03/25 --> output OPT__OUTPUT_ENTR
 //                2446 : 2022/05/10 --> output SUPPORT_LIBYT and LIBYT_USE_PATCH_GROUP
 //                2447 : 2022/05/11 --> output MASSIVE_PARTICLES, TRACER, PAR_NTYPE, GhostSizeTracer
+//                2448 : 2022/05/18 --> output PAR_IC_TYPE
 //-------------------------------------------------------------------------------------------------------
 void Output_DumpData_Total_HDF5( const char *FileName )
 {
@@ -1723,7 +1724,7 @@ void FillIn_KeyInfo( KeyInfo_t &KeyInfo, const int NFieldStored )
 
    const time_t CalTime = time( NULL );   // calendar time
 
-   KeyInfo.FormatVersion        = 2447;
+   KeyInfo.FormatVersion        = 2448;
    KeyInfo.Model                = MODEL;
    KeyInfo.NLevel               = NLEVEL;
    KeyInfo.NCompFluid           = NCOMP_FLUID;
@@ -2330,6 +2331,7 @@ void FillIn_InputPara( InputPara_t &InputPara, const int NFieldStored, char Fiel
    InputPara.Par_Init                = amr->Par->Init;
    InputPara.Par_ICFormat            = amr->Par->ParICFormat;
    InputPara.Par_ICMass              = amr->Par->ParICMass;
+   InputPara.Par_ICType              = amr->Par->ParICType;
    InputPara.Par_Interp              = amr->Par->Interp;
    InputPara.Par_InterpTracer        = amr->Par->InterpTracer;
    InputPara.Par_Integ               = amr->Par->Integ;
@@ -3171,6 +3173,7 @@ void GetCompound_InputPara( hid_t &H5_TypeID, const int NFieldStored )
    H5Tinsert( H5_TypeID, "Par_Init",                HOFFSET(InputPara_t,Par_Init               ), H5T_NATIVE_INT     );
    H5Tinsert( H5_TypeID, "Par_ICFormat",            HOFFSET(InputPara_t,Par_ICFormat           ), H5T_NATIVE_INT     );
    H5Tinsert( H5_TypeID, "Par_ICMass",              HOFFSET(InputPara_t,Par_ICMass             ), H5T_NATIVE_DOUBLE  );
+   H5Tinsert( H5_TypeID, "Par_ICType",              HOFFSET(InputPara_t,Par_ICType             ), H5T_NATIVE_INT     );
    H5Tinsert( H5_TypeID, "Par_Interp",              HOFFSET(InputPara_t,Par_Interp             ), H5T_NATIVE_INT     );
    H5Tinsert( H5_TypeID, "Par_InterpTracer",        HOFFSET(InputPara_t,Par_InterpTracer       ), H5T_NATIVE_INT     );
    H5Tinsert( H5_TypeID, "Par_Integ",               HOFFSET(InputPara_t,Par_Integ              ), H5T_NATIVE_INT     );

--- a/src/Particle/LoadBalance/Par_LB_CollectParticle2OneLevel.cpp
+++ b/src/Particle/LoadBalance/Par_LB_CollectParticle2OneLevel.cpp
@@ -82,6 +82,7 @@ void Par_LB_CollectParticle2OneLevel( const int FaLv, const long AttBitIdx, cons
 // --> PosSendIdx[] is used by Par_PredictPos()
    int NAtt=0, AttIntIdx[PAR_NATT_TOTAL], PosSendIdx[3]={-1, -1, -1};
 
+   if ( !JustCountNPar )
    for (int v=0; v<PAR_NATT_TOTAL; v++)
       if ( AttBitIdx & (1L<<v) )    AttIntIdx[ NAtt ++ ] = v;
 

--- a/src/Particle/LoadBalance/Par_LB_CollectParticle2OneLevel.cpp
+++ b/src/Particle/LoadBalance/Par_LB_CollectParticle2OneLevel.cpp
@@ -117,7 +117,7 @@ void Par_LB_CollectParticle2OneLevel( const int FaLv, const long AttBitIdx, cons
 
 // check
 #  ifdef DEBUG_PARTICLE
-   if ( NAtt == 0  &&  MPI_Rank == 0 )    Aux_Message( stderr, "WARNING : NAtt == 0 !!\n" );
+   if ( NAtt == 0  &&  !JustCountNPar  &&  MPI_Rank == 0 )  Aux_Message( stderr, "WARNING : NAtt == 0 !!\n" );
 
    if ( JustCountNPar )
    {

--- a/src/Particle/Par_Aux_Check_Particle.cpp
+++ b/src/Particle/Par_Aux_Check_Particle.cpp
@@ -7,12 +7,12 @@
 
 //-------------------------------------------------------------------------------------------------------
 // Function    :  Par_Aux_Check_Particle
-// Description :  Verify that
-//                1.   particles reside in their home patches
-//                2.   particles always reside in the leaf patches
-//                3.   there are no missing or redundant particles
-//                4.   no active particles have mass=-1.0
-//                5/6. each particle has one and only one home patch
+// Description :  Verify the following.
+//                1.   Particles reside in their home patches
+//                2.   Particles always reside in the leaf patches
+//                3.   There are no missing or redundant particles
+//                4.   No active particles have mass=-1.0
+//                5/6. Each particle has one and only one home patch
 //                7.   NPar_AcPlusInac == NPar_Active + NPar_Inactive
 //                8.   NPar_Active_AllRank = sum(NPar_Active, All ranks)
 //                9.   NPar_Active = sum(NPar_Lv, all levels)

--- a/src/Particle/Par_Aux_Check_Particle.cpp
+++ b/src/Particle/Par_Aux_Check_Particle.cpp
@@ -17,6 +17,7 @@
 //                8.   NPar_Active_AllRank = sum(NPar_Active, All ranks)
 //                9.   NPar_Active = sum(NPar_Lv, all levels)
 //                10.  All patches have NPar_Copy == -1
+//                11.  Particle types are recognizable
 //
 // Note        :  None
 //
@@ -25,7 +26,7 @@
 void Par_Aux_Check_Particle( const char *comment )
 {
 
-   const int   NCheck    = 10;
+   const int   NCheck    = 11;
    const real *ParPos[3] = { amr->Par->PosX, amr->Par->PosY, amr->Par->PosZ };
 
    int     PassAll    = true;
@@ -64,7 +65,6 @@ void Par_Aux_Check_Particle( const char *comment )
                NParInLeaf += NParThisPatch;
 
 
-//             Check 1: check whether or not all particles find their home patches
                EdgeL = amr->patch[0][lv][PID]->EdgeL;
                EdgeR = amr->patch[0][lv][PID]->EdgeR;
 
@@ -95,6 +95,7 @@ void Par_Aux_Check_Particle( const char *comment )
                      ParHome[ParID] = true;
 
 
+//                Check 1: check whether or not all particles find their home patches
                   for (int d=0; d<3; d++)
                   {
                      if ( ParPos[d][ParID] < EdgeL[d]  ||  ParPos[d][ParID] >= EdgeR[d] )
@@ -118,6 +119,7 @@ void Par_Aux_Check_Particle( const char *comment )
                      }
                   } // for (int d=0; d<3; d++)
 
+
 //                Check 4: no active particles should have mass < 0.0
                   if ( amr->Par->Mass[ParID] < 0.0 )
                   {
@@ -139,8 +141,31 @@ void Par_Aux_Check_Particle( const char *comment )
                                   MPI_Rank, lv, PID, ParID, ParPos[0][ParID], ParPos[1][ParID], ParPos[2][ParID],
                                   amr->Par->Mass[ParID] );
                   }
+
+
+//                Check 11: particle types must be recognizable
+                  if ( amr->Par->Type[ParID] < (real)0  ||  amr->Par->Type[ParID] >= (real)PAR_NTYPE )
+                  {
+                     if ( PassAll )
+                     {
+                        Aux_Message( stderr, "\"%s\" : <%s> FAILED at Time = %13.7e, Step = %ld !!\n",
+                                     comment, __FUNCTION__, Time[lv], Step );
+                        PassAll = false;
+                     }
+
+                     if ( PassCheck[10] )
+                     {
+                        Aux_Message( stderr, "Check 11: %4s  %2s  %7s  %10s  %10s\n",
+                                     "Rank", "Lv", "PID", "ParID", "Type" );
+                        PassCheck[10] = false;
+                     }
+
+                     Aux_Message( stderr, "Check 11: %4d  %2d  %7d  %10ld  %10d\n",
+                                  MPI_Rank, lv, PID, ParID, (int)amr->Par->Type[ParID] );
+                  }
                } // for (int p=0; p<NParThisPatch; p++)
             } // if ( amr->patch[0][lv][PID]->son == -1 )
+
 
 //          Check 2: particles should only reside in the leaf patches
             else if ( NParThisPatch != 0 )

--- a/src/Particle/Par_Aux_InitCheck.cpp
+++ b/src/Particle/Par_Aux_InitCheck.cpp
@@ -40,6 +40,24 @@ void Par_Aux_InitCheck()
       if ( Type[ParID] < (real)0  ||  Type[ParID] >= (real)PAR_NTYPE )
          Aux_Error( ERROR_INFO, "Type[%ld] = %d (accepted range: 0<=index<%d) !!\n", ParID, (int)Type[ParID], PAR_NTYPE );
 
+//    only support tracer particles when disabling GRAVITY
+#     ifndef GRAVITY
+      if ( Type[ParID] != PTYPE_TRACER )
+         Aux_Error( ERROR_INFO, "Type[%ld] = %d != PTYPE_TRACER (%d) when disabling GRAVITY !!\n", ParID, (int)Type[ParID], (int)PTYPE_TRACER );
+#     endif
+
+//    must enable TRACER for tracer particles
+#     ifndef TRACER
+      if ( Type[ParID] == PTYPE_TRACER )
+         Aux_Error( ERROR_INFO, "Type[%ld] = %d (PTYPE_TRACER) when disabling TRACER !!\n", ParID, (int)Type[ParID] );
+#     endif
+
+//    tracer particles must be massless
+#     ifdef TRACER
+      if ( Type[ParID] == PTYPE_TRACER  &&  Mass[ParID] != (real)0.0 )
+         Aux_Error( ERROR_INFO, "Tracer[%ld] has non-zero mass (%13.7e) !!\n", ParID, Mass[ParID] );
+#     endif
+
       for (int d=0; d<3; d++)
       {
          if ( Pos[d][ParID] < (real)0.0  ||  Pos[d][ParID] >= amr->BoxSize[d] )

--- a/src/Particle/Par_Aux_InitCheck.cpp
+++ b/src/Particle/Par_Aux_InitCheck.cpp
@@ -13,6 +13,7 @@
 //                2. Check if all particles lie within the simulation box
 //                3. Remove particles outside the active region for non-periodic B.C.
 //                4. There should be no inactive particles before calling this function
+//                5. Check particle types
 //
 // Parameter   :  None
 //-------------------------------------------------------------------------------------------------------
@@ -22,16 +23,22 @@ void Par_Aux_InitCheck()
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ...\n", __FUNCTION__ );
 
 
-   real *Mass   =   amr->Par->Mass;
-   real *Pos[3] = { amr->Par->PosX, amr->Par->PosY, amr->Par->PosZ };
+   const real *Mass   =   amr->Par->Mass;
+   const real *Pos[3] = { amr->Par->PosX, amr->Par->PosY, amr->Par->PosZ };
+   const real *Type   =   amr->Par->Type;
 
 
 // 1. all active particles should lie within the simulation domain
 //    --> periodicity should be taken care of in the initial condition, not here
+//    --> also check particle types here
    for (long ParID=0; ParID<amr->Par->NPar_AcPlusInac; ParID++)
    {
 //    there should be no inactive particles initially
       if ( Mass[ParID] < 0.0 )   Aux_Error( ERROR_INFO, "Mass[%ld] = %14.7e < 0.0 !!\n", ParID, Mass[ParID] );
+
+//    check particle types
+      if ( Type[ParID] < (real)0  ||  Type[ParID] >= (real)PAR_NTYPE )
+         Aux_Error( ERROR_INFO, "Type[%ld] = %d (accepted range: 0<=index<%d) !!\n", ParID, (int)Type[ParID], PAR_NTYPE );
 
       for (int d=0; d<3; d++)
       {

--- a/src/Particle/Par_Init_ByFunction.cpp
+++ b/src/Particle/Par_Init_ByFunction.cpp
@@ -49,9 +49,9 @@ void (*Par_Init_ByFunction_Ptr)( const long NPar_ThisRank, const long NPar_AllRa
 // Return      :  ParMass, ParPosX/Y/Z, ParVelX/Y/Z, ParTime, AllAttribute
 //-------------------------------------------------------------------------------------------------------
 void Par_Init_ByFunction_Template( const long NPar_ThisRank, const long NPar_AllRank,
-                          real *ParMass, real *ParPosX, real *ParPosY, real *ParPosZ,
-                          real *ParVelX, real *ParVelY, real *ParVelZ, real *ParTime,
-                          real *ParType, real *AllAttribute[PAR_NATT_TOTAL] )
+                                   real *ParMass, real *ParPosX, real *ParPosY, real *ParPosZ,
+                                   real *ParVelX, real *ParVelY, real *ParVelZ, real *ParTime,
+                                   real *ParType, real *AllAttribute[PAR_NATT_TOTAL] )
 {
 
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ...\n", __FUNCTION__ );

--- a/src/Particle/Par_Init_ByFunction.cpp
+++ b/src/Particle/Par_Init_ByFunction.cpp
@@ -46,7 +46,7 @@ void (*Par_Init_ByFunction_Ptr)( const long NPar_ThisRank, const long NPar_AllRa
 //                                --> Use the attribute indices defined in Field.h (e.g., Idx_ParCreTime)
 //                                    to access the data
 //
-// Return      :  ParMass, ParPosX/Y/Z, ParVelX/Y/Z, ParTime, AllAttribute
+// Return      :  ParMass, ParPosX/Y/Z, ParVelX/Y/Z, ParTime, ParType, AllAttribute
 //-------------------------------------------------------------------------------------------------------
 void Par_Init_ByFunction_Template( const long NPar_ThisRank, const long NPar_AllRank,
                                    real *ParMass, real *ParPosX, real *ParPosY, real *ParPosZ,

--- a/src/Particle/Par_MassAssignment.cpp
+++ b/src/Particle/Par_MassAssignment.cpp
@@ -201,8 +201,9 @@ void Par_MassAssignment( const long *ParList, const long NPar, const ParInterp_t
             Idx = p;
 #           endif
 
-//          4.1.0 ignore massless and tracer particles
-            if ( Mass[Idx] <= (real)0.0  ||  PType[Idx] == PTYPE_TRACER )
+//          4.1.0 ignore tracer particles
+//                --> but still keep massless particles (i.e., with Mass[Idx]==0.0) for the option "UnitDens"
+            if ( PType[Idx] == PTYPE_TRACER )
                continue;
 
 //          4.1.1 discard particles far away from the target region
@@ -260,8 +261,9 @@ void Par_MassAssignment( const long *ParList, const long NPar, const ParInterp_t
             Idx = p;
 #           endif
 
-//          4.2.0 ignore massless and tracer particles
-            if ( Mass[Idx] <= (real)0.0  ||  PType[Idx] == PTYPE_TRACER )
+//          4.2.0 ignore tracer particles
+//                --> but still keep massless particles (i.e., with Mass[Idx]==0.0) for the option "UnitDens"
+            if ( PType[Idx] == PTYPE_TRACER )
                continue;
 
 //          4.2.1 discard particles far away from the target region
@@ -335,8 +337,9 @@ void Par_MassAssignment( const long *ParList, const long NPar, const ParInterp_t
             Idx = p;
 #           endif
 
-//          4.3.0 ignore massless and tracer particles
-            if ( Mass[Idx] <= (real)0.0  ||  PType[Idx] == PTYPE_TRACER )
+//          4.3.0 ignore tracer particles
+//                --> but still keep massless particles (i.e., with Mass[Idx]==0.0) for the option "UnitDens"
+            if ( PType[Idx] == PTYPE_TRACER )
                continue;
 
 //          4.3.1 discard particles far away from the target region

--- a/src/Particle/Par_UpdateParticle.cpp
+++ b/src/Particle/Par_UpdateParticle.cpp
@@ -124,7 +124,7 @@ void Par_UpdateParticle( const int lv, const double TimeNew, const double TimeOl
 #  endif
 
 #  ifdef DEBUG_PARTICLE
-// Par->ImproveAcc only works particle interpolation schemes with ParGhost == 1 (CIC & TSC)
+// Par->ImproveAcc only supports particle interpolation schemes with ParGhost == 1 (CIC & TSC)
    if ( amr->Par->ImproveAcc  &&  PotGhost != GRA_GHOST_SIZE )
       Aux_Error( ERROR_INFO, "PotGhost (%d) != GRA_GHOST_SIZE (%d) for amr->Par->ImproveAcc !!\n",
                  PotGhost, GRA_GHOST_SIZE );

--- a/src/Refine/Flag_Real.cpp
+++ b/src/Refine/Flag_Real.cpp
@@ -114,7 +114,7 @@ void Flag_Real( const int lv, const UseLBFunc_t UseLBFunc )
 // Par_CollectParticle2OneLevel() with JustCountNPar_No will set NPar_Copy for each patch as well
 // --> so call Par_CollectParticle2OneLevel() with JustCountNPar_Yes only when OPT__FLAG_NPAR_CELL == false
    else if ( OPT__FLAG_NPAR_PATCH != 0 )
-      Par_CollectParticle2OneLevel( lv, _PAR_MASS|_PAR_POSX|_PAR_POSY|_PAR_POSZ|_PAR_TYPE, PredictPos_No,
+      Par_CollectParticle2OneLevel( lv, _NONE, PredictPos_No,
                                     NULL_REAL, SibBufPatch_No, FaSibBufPatch_No, JustCountNPar_Yes,
                                     TimingSendPar_No );
 #  endif

--- a/src/TestProblem/Hydro/AGORA_IsolatedGalaxy/Par_Init_ByFunction_AGORA.cpp
+++ b/src/TestProblem/Hydro/AGORA_IsolatedGalaxy/Par_Init_ByFunction_AGORA.cpp
@@ -43,7 +43,7 @@ extern bool AGORA_UseMetal;
 //                                --> Use the attribute indices defined in Field.h (e.g., Idx_ParCreTime)
 //                                    to access the data
 //
-// Return      :  ParMass, ParPosX/Y/Z, ParVelX/Y/Z, ParTime, AllAttribute
+// Return      :  ParMass, ParPosX/Y/Z, ParVelX/Y/Z, ParTime, ParType, AllAttribute
 //-------------------------------------------------------------------------------------------------------
 void Par_Init_ByFunction_AGORA( const long NPar_ThisRank, const long NPar_AllRank,
                                 real *ParMass, real *ParPosX, real *ParPosY, real *ParPosZ,

--- a/src/TestProblem/Hydro/CMZ/Par_Init_ByFunction_BarredPot.cpp
+++ b/src/TestProblem/Hydro/CMZ/Par_Init_ByFunction_BarredPot.cpp
@@ -33,7 +33,7 @@
 //                                --> Use the attribute indices defined in Field.h (e.g., Idx_ParCreTime)
 //                                    to access the data
 //
-// Return      :  ParMass, ParPosX/Y/Z, ParVelX/Y/Z, ParTime, AllAttribute
+// Return      :  ParMass, ParPosX/Y/Z, ParVelX/Y/Z, ParTime, ParType, AllAttribute
 //-------------------------------------------------------------------------------------------------------
 void Par_Init_ByFunction_BarredPot( const long NPar_ThisRank, const long NPar_AllRank,
                                   real *ParMass, real *ParPosX, real *ParPosY, real *ParPosZ,

--- a/src/TestProblem/Hydro/ParticleTest/Init_TestProb_Hydro_ParticleTest.cpp
+++ b/src/TestProblem/Hydro/ParticleTest/Init_TestProb_Hydro_ParticleTest.cpp
@@ -53,10 +53,6 @@ void Validate()
    Aux_Error( ERROR_INFO, "PARTICLE must be enabled !!\n" );
 #  endif
 
-#  ifndef TRACER
-   Aux_Error( ERROR_INFO, "TRACER must be enabled !!\n" );
-#  endif
-
 #  ifdef COMOVING
    Aux_Error( ERROR_INFO, "COMOVING must be disabled !!\n" );
 #  endif
@@ -122,6 +118,10 @@ void SetParameter()
    if ( !ParTest_Use_Tracers  &&  !ParTest_Use_Massive )
       Aux_Error( ERROR_INFO,
                  "either ParTest_Use_Tracer, ParTest_Use_Massive, or both must be true !!\n" );
+
+#  ifndef TRACER
+   if ( ParTest_Use_Tracers )    Aux_Error( ERROR_INFO, "must enable TRACER for ParTest_Use_Tracers !!\n" );
+#  endif
 
 #  ifndef GRAVITY
    if ( ParTest_Use_Massive )    Aux_Error( ERROR_INFO, "must enable GRAVITY for ParTest_Use_Massive !!\n" );

--- a/src/TestProblem/Hydro/ParticleTest/Init_TestProb_Hydro_ParticleTest.cpp
+++ b/src/TestProblem/Hydro/ParticleTest/Init_TestProb_Hydro_ParticleTest.cpp
@@ -26,6 +26,9 @@ void Par_Init_ByFunction_ParticleTest( const long NPar_ThisRank, const long NPar
 bool Flag_ParticleTest( const int i, const int j, const int k, const int lv,
                         const int PID, const double *Threshold );
 
+
+
+
 //-------------------------------------------------------------------------------------------------------
 // Function    :  Validate
 // Description :  Validate the compilation flags and runtime parameters for this test problem
@@ -211,7 +214,6 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
    fluid[ENGY] = Etot;
 
 } // FUNCTION : SetGridIC
-
 #endif // #if ( MODEL == HYDRO )
 
 
@@ -259,6 +261,8 @@ void Init_TestProb_Hydro_ParticleTest()
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ... done\n", __FUNCTION__ );
 
 } // FUNCTION : Init_TestProb_Hydro_ParticleTest
+
+
 
 bool Flag_ParticleTest( const int i, const int j, const int k, const int lv,
                         const int PID, const double *Threshold )

--- a/src/TestProblem/Hydro/ParticleTest/Par_Init_ByFunction_ParticleTest.cpp
+++ b/src/TestProblem/Hydro/ParticleTest/Par_Init_ByFunction_ParticleTest.cpp
@@ -8,6 +8,9 @@ extern double ParTest_Par_Sep;
 extern bool   ParTest_Use_Tracers;
 extern bool   ParTest_Use_Massive;
 
+
+
+
 //-------------------------------------------------------------------------------------------------------
 // Function    :  Par_Init_ByFunction_ParticleTest
 // Description :  Initialize all particle attributes for the particle test problem
@@ -47,7 +50,6 @@ extern bool   ParTest_Use_Massive;
 //
 // Return      :  ParMass, ParPosX/Y/Z, ParVelX/Y/Z, ParTime, ParType, AllAttribute
 //-------------------------------------------------------------------------------------------------------
-
 void Par_Init_ByFunction_ParticleTest( const long NPar_ThisRank, const long NPar_AllRank,
                                        real *ParMass, real *ParPosX, real *ParPosY, real *ParPosZ,
                                        real *ParVelX, real *ParVelY, real *ParVelZ, real *ParTime,
@@ -163,9 +165,6 @@ void Par_Init_ByFunction_ParticleTest( const long NPar_ThisRank, const long NPar
 
 } // FUNCTION : Par_Init_ByFunction_ParticleTest
 
+
+
 #endif // #ifdef PARTICLE
-
-
-
-
-


### PR DESCRIPTION
This PR improves the following particle implementation.
- Support (i) including/excluding particle types and (ii) loading user-specified attributes for `PAR_INIT=3`. Add the new parameter `PAR_IC_TYPE`.
- Include massless particles in `Par_MassAssignment()` for the option `UnitDens`.
- No need to specify particle attributes when calling `Par_CollectParticle2OneLevel()` in the mode `JustCountNPar`.
- Exclude tracer particles for `DT__PARVEL`.
- Add more checks in `Par_Aux_InitCheck()`, `Par_Aux_Check_Particle()`, and `AddOneParticle()` for tracer particles.
- Allocate memory just once in `Par_UpdateTracerParticle()`.
- Add warning messages about the restrictions that, for now, `OPT__FLAG_NPAR_PATCH` always _includes_ tracer particles while `OPT__FLAG_NPAR_CELL` always _excludes_ tracer particles.

@jzuhone Could you help review it when you have time? Thanks!