### PR TITLE
Allow test problems to reset the particle number

### DIFF
--- a/example/test_problem/Hydro/ParticleTest/Input__Parameter
+++ b/example/test_problem/Hydro/ParticleTest/Input__Parameter
@@ -44,7 +44,7 @@ OPT__BC_FLU_ZM                1           # fluid boundary condition at the -z f
 OPT__BC_FLU_ZP                1           # fluid boundary condition at the +z face: (1=periodic, 2=outflow, 3=reflecting, 4=user)
 
 # particle (PARTICLE only)
-PAR_NPAR                      32770       # total number of particles (must be set for PAR_INIT == 1/3)
+PAR_NPAR                     -1           # total number of particles (must be set for PAR_INIT == 1/3)
 PAR_INIT                      1           # initialization option for particles: (1=FUNCTION, 2=RESTART, 3=FILE->"PAR_IC")
 PAR_INTERP                    2           # particle interpolation scheme: (1=NGP, 2=CIC, 3=TSC) [2]
 PAR_INTEG                     2           # particle integration scheme: (1=Euler, 2=KDK) [2]

--- a/example/test_problem/Hydro/ParticleTest/README
+++ b/example/test_problem/Hydro/ParticleTest/README
@@ -17,11 +17,7 @@ Note:
    from the fluid with constant angular frequency
 2. Set ParTest_Use_Tracers = 1 to use tracer particles, ParTest_Use_Massive = 1
    to use massive particles. At least one must be enabled.
-3. Use the following scheme to set PAR_NPAR in Input__Parameter:
-   ParTest_Use_Massive only: PAR_NPAR = 2
-   ParTest_Use_Tracers only: PAR_NPAR = ParTest_NParX*ParTest_NParY*ParTest_NParZ
-   ParTest_Use_Massive and ParTest_Use_Tracers: PAR_NPAR = 2 +
-   ParTest_NParX*ParTest_NParY*ParTest_NParZ
+3. No need to set PAR_NPAR in Input__Parameter since it will be reset automatically.
 3. OPT__FREEZE_FLUID must be = 1 for this test.
 4. If OPT__FLAG_USER is set, a rectangle will be refined in the center of the
    domain. Note that the active particle orbit is _not_ stable in this case due

--- a/src/Init/Init_GAMER.cpp
+++ b/src/Init/Init_GAMER.cpp
@@ -88,10 +88,6 @@ void Init_GAMER( int *argc, char ***argv )
 #  endif
 
 
-// initialize parameters for the parallelization (rectangular domain decomposition)
-   Init_Parallelization();
-
-
 #  ifdef GRAVITY
 // initialize FFTW
    Init_FFTW();
@@ -100,6 +96,11 @@ void Init_GAMER( int *argc, char ***argv )
 
 // initialize the test problem parameters
    Init_TestProb();
+
+
+// initialize parameters for the parallelization
+// --> call it after Init_TestProb() since Init_TestProb() may overwrite the total number of particles
+   Init_Parallelization();
 
 
 // initialize all fields and particle attributes

--- a/src/TestProblem/Hydro/ParticleTest/Init_TestProb_Hydro_ParticleTest.cpp
+++ b/src/TestProblem/Hydro/ParticleTest/Init_TestProb_Hydro_ParticleTest.cpp
@@ -60,6 +60,7 @@ void Validate()
    if ( !OPT__FREEZE_FLUID )
       Aux_Error( ERROR_INFO, "OPT__FREEZE_FLUID must be enabled !!\n" );
 
+
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "   Validating test problem %d ... done\n", TESTPROB_ID );
 
 } // FUNCTION : Validate
@@ -143,15 +144,28 @@ void SetParameter()
       PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
    }
 
+// overwrite the total number of particles
+   amr->Par->NPar_Active_AllRank = 0;
+   if ( ParTest_Use_Massive )    amr->Par->NPar_Active_AllRank += 2;
+   if ( ParTest_Use_Tracers )    amr->Par->NPar_Active_AllRank += ParTest_NPar[0]*ParTest_NPar[1]*ParTest_NPar[2];
+   PRINT_WARNING( "PAR_NPAR", amr->Par->NPar_Active_AllRank, FORMAT_LONG );
+
 
 // (4) make a note
    if ( MPI_Rank == 0 )
    {
       Aux_Message( stdout, "=============================================================================\n" );
-      Aux_Message( stdout, "  test problem ID           = %d\n",     TESTPROB_ID     );
-      Aux_Message( stdout, "  background mass density   = %13.7e\n", ParTest_Dens_Bg  );
-      Aux_Message( stdout, "  background pressure       = %13.7e\n", ParTest_Pres_Bg  );
-      Aux_Message( stdout, "  angular frequency         = %13.7e\n", ParTest_Ang_Freq );
+      Aux_Message( stdout, "  test problem ID            = %d\n",     TESTPROB_ID         );
+      Aux_Message( stdout, "  background mass density    = %13.7e\n", ParTest_Dens_Bg     );
+      Aux_Message( stdout, "  background pressure        = %13.7e\n", ParTest_Pres_Bg     );
+      Aux_Message( stdout, "  angular frequency          = %13.7e\n", ParTest_Ang_Freq    );
+      Aux_Message( stdout, "  number of particles (x)    = %d\n",     ParTest_NPar[0]     );
+      Aux_Message( stdout, "                      (y)    = %d\n",     ParTest_NPar[1]     );
+      Aux_Message( stdout, "                      (z)    = %d\n",     ParTest_NPar[2]     );
+      Aux_Message( stdout, "  active particle separation = %13.7e\n", ParTest_Par_Sep     );
+      Aux_Message( stdout, "  active particle mass       = %13.7e\n", ParTest_Point_Mass  );
+      Aux_Message( stdout, "  include tracer particles   = %d\n",     ParTest_Use_Tracers );
+      Aux_Message( stdout, "  include massive particles  = %d\n",     ParTest_Use_Massive );
       Aux_Message( stdout, "=============================================================================\n" );
    }
 


### PR DESCRIPTION
- Allow test problems to reset the total number of particles (i.e., overwriting the input `PAR_NPAR`)
- Demonstrate this capability in `ParticleTest`
- Address #119 