### PR TITLE
Particle profile plot script use peak value of `particle_density_on_grid` as center

### DIFF
--- a/example/test_problem/Hydro/ParticleEquilibriumIC/plot_script/plot_profile.py
+++ b/example/test_problem/Hydro/ParticleEquilibriumIC/plot_script/plot_profile.py
@@ -20,38 +20,40 @@ args=parser.parse_args()
 print( '\nCommand-line arguments:' )
 print( '-------------------------------------------------------------------' )
 for t in range( len(sys.argv) ):
-   print str(sys.argv[t]),
+#   print str(sys.argv[t]), # for python2.X
+   print(str(sys.argv[t]),end=', ') # for python3.X
 print( '' )
 print( '-------------------------------------------------------------------\n' )
 
 
-idx_start   = args.idx_start
-idx_end     = args.idx_end
-didx        = args.didx
-prefix      = args.prefix
+idx_start    = args.idx_start
+idx_end      = args.idx_end
+didx         = args.didx
+prefix       = args.prefix
 
-center_mode = 'max'
-dpi         = 150
-
+dpi          = 150
+field        = ('gas','particle_density_on_grid')
+r_sphere     = 1.5
 
 yt.enable_parallelism()
 
-d0= yt.load(  prefix+'Data_000000' )
-#ts = yt.load( [ prefix+'Data_%06d'%idx for idx in range(idx_start, idx_end+1, didx) ] )
-files = [ prefix+'Data_%06d'%idx for idx in range(idx_start, idx_end+1, didx) ]
-for f in files:
-   print(f+".png")
-   ds  = yt.load(f)
-   sp1 = ds.sphere("c", (1.5, "code_length")) #ds.sphere( center_mode, 0.5*ds.domain_width.to_value().max() )
-   sp0 = d0.sphere("c", (1.5, "code_length"))
-   field ='particle_density_on_grid'
-   rp0 = yt.create_profile(sp0,"radius",field,units={("radius"): "code_length"},logs={("radius"): True})
-   rp1 = yt.create_profile(sp1,"radius",field,units={("radius"): "code_length"},logs={("radius"): True})
-   fig = plt.figure()
-   ax = fig.add_subplot(111)
+d0           = yt.load(  prefix+'Data_000000' )
+center_pos_0 = d0.find_max(field)[1].in_units("code_length")  # return maximum value and position, here use [1] to take peak position only
+sp0          = d0.sphere(center_pos_0, (r_sphere, "code_length"))
+rp0          = yt.create_profile(sp0,"radius",field,units={("radius"): "code_length"},logs={("radius"): True})
+
+ts = yt.DatasetSeries([ prefix+'Data_%06d'%idx for idx in range(idx_start, idx_end+1, didx) ])
+for ds in ts.piter():
+#   print(str(ds)+".png")
+   center_pos_1 = ds.find_max(field)[1].in_units("code_length")  # return maximum value and position, here use [1] to take peak position only
+   sp1          = ds.sphere(center_pos_1, (r_sphere, "code_length"))
+   rp1          = yt.create_profile(sp1,"radius",field,units={("radius"): "code_length"},logs={("radius"): True})
+
+   fig          = plt.figure()
+   ax           = fig.add_subplot(111)
    ax.plot(rp0.x.value,rp0[field].in_units("code_mass/code_length**3").value)
    ax.plot(rp1.x.value,rp1[field].in_units("code_mass/code_length**3").value)
    ax.set_xscale('log')
    ax.set_yscale('log')
    ax.legend(["Later", "Original"])
-   fig.savefig(f+"_profile.png")
+   fig.savefig(str(ds)+"_profile.png")


### PR DESCRIPTION
### Main Changes
* Use `ds.find_max()` to obtain peak position of field `particle_density_on_grid`, then define sphere using this value as center, and finally plot the profile
* Allow parallelization by `ts.piter()`

### Minor Changes
* Adopt `print` function for `python2.X` and `python3.X` respectively