### PR TITLE
Update Taiwania3 job scripts

### DIFF
--- a/example/queue/submit_taiwania3_gnu.job
+++ b/example/queue/submit_taiwania3_gnu.job
@@ -17,6 +17,7 @@
 ##SBATCH -e job.%j.err
 ##SBATCH --mail-type=BEGIN,END,FAIL                         # Mail events (NONE, BEGIN, END, FAIL, ALL)
 ##SBATCH --mail-user=EMAIL_ADDRESS                          # Where to send mail.  Set this to your email address
+#SBATCH --exclude=cpn[3001-3120,3241-3360]                  # Exclude large-memory nodes
 
 LOG_FILE=log_taiwania_III_gnu_4.8.5
 

--- a/example/queue/submit_taiwania3_gnu.job
+++ b/example/queue/submit_taiwania3_gnu.job
@@ -11,7 +11,7 @@
 #SBATCH --nodes=2                                           # (-N) Maximum number of nodes to be allocated
 #SBATCH --ntasks-per-node=4                                 # Maximum number of tasks on each node
 #SBATCH --cpus-per-task=14                                  # (-c) Number of cores per MPI task
-#SBATCH --mem=65536                                         # Memory limit per compute node for the  job.Do not use with mem-per-cpu flag
+#SBATCH --mem=162400M                                       # Memory limit per compute node for the job. Do not use with mem-per-cpu flag.
 #SBATCH --time=00:30:00                                     # (-t) Wall time limit (days-hrs:min:sec)
 ##SBATCH -o log_taiwania_III
 ##SBATCH -e job.%j.err

--- a/example/queue/submit_taiwania3_intel.job
+++ b/example/queue/submit_taiwania3_intel.job
@@ -17,6 +17,7 @@
 ##SBATCH -e job.%j.err
 #SBATCH --mail-type=BEGIN,END,FAIL                      # Mail events (NONE, BEGIN, END, FAIL, ALL)
 #SBATCH --mail-user=EMAIL_ACCOUNT                       # Where to send mail.  Set this to your email address
+#SBATCH --exclude=cpn[3001-3120,3241-3360]              # Exclude large-memory nodes
 
 LOG_FILE=log_taiwania_III_intel_2018
 

--- a/example/queue/submit_taiwania3_intel.job
+++ b/example/queue/submit_taiwania3_intel.job
@@ -11,7 +11,7 @@
 #SBATCH --nodes=2                                       # (-N) Maximum number of nodes to be allocated
 #SBATCH --ntasks-per-node=4                             # Maximum number of tasks on each node
 #SBATCH --cpus-per-task=14                              # (-c) Number of cores per MPI task
-#SBATCH --mem=65536                                     # Memory limit per compute node for the  job.Do not use with mem-per-cpu flag
+#SBATCH --mem=162400M                                   # Memory limit per compute node for the job. Do not use with mem-per-cpu flag.
 #SBATCH --time=00:30:00                                 # (-t) Wall time limit (days-hrs:min:sec)
 ##SBATCH -o log_taiwania_III
 ##SBATCH -e job.%j.err


### PR DESCRIPTION
1. Exclude the large-memory nodes.
Memory size: cpn[3001-3120] are 768GB and cpn[3241-3360] are 384GB

2. Set the memory limit per node according to this [Q&A](https://iservice.nchc.org.tw/nchc_service/nchc_service_qa_single.php?qa_code=689).