### PR TITLE
Add -fp-model option for Intel C/C++ Compiler

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -240,6 +240,7 @@ SIMU_OPTION += -DRANDOM_NUMBER=RNG_GNU_EXT
 ##CXXFLAG     = -g -O3 -std=c++11 #-gxx-name=YOUR_G++
 ##CXXFLAG     = -g -fast
 # CXXFLAG    += -w1                                       # warning flags
+# CXXFLAG    += -fp-model precise                         # disable optimizations that are not value-safe
 # OPENMPFLAG  = -fopenmp                                  # openmp flag
 # LIB         = -limf                                     # libraries and linker flags
 #


### PR DESCRIPTION
- Add `-fp-model precise` for Intel C/C++ Compiler to guarantee value-safe on floating-point calculations
  - official document: https://www.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/compiler-options/floating-point-options/fp-model-fp.html
- Check whether this will hurt the performance
  - [x] CCSN
  - [x] Partciles
  - [x] ELBDM