### PR TITLE
[BUGFIX] Improve MHD stability

### DIFF
--- a/example/test_problem/Template/Input__Parameter
+++ b/example/test_problem/Template/Input__Parameter
@@ -197,7 +197,7 @@ OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined 
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (-1=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]
 DUAL_ENERGY_SWITCH            2.0e-2      # apply dual-energy if E_int/E_kin < DUAL_ENERGY_SWITCH [2.0e-2] ##DUAL_ENERGY ONLY##
-OPT__SAME_INTERFACE_B         1           # ensure B field consistency on the shared interfaces between sibling patches (for debugging) [0] ##MHD ONLY##
+OPT__SAME_INTERFACE_B         0           # ensure B field consistency on the shared interfaces between sibling patches (for debugging) [0] ##MHD ONLY##
 
 
 # fluid solver in ELBDM (MODEL==ELBDM only)

--- a/example/test_problem/Template/Input__Parameter
+++ b/example/test_problem/Template/Input__Parameter
@@ -197,6 +197,7 @@ OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined 
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (-1=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]
 DUAL_ENERGY_SWITCH            2.0e-2      # apply dual-energy if E_int/E_kin < DUAL_ENERGY_SWITCH [2.0e-2] ##DUAL_ENERGY ONLY##
+OPT__SAME_INTERFACE_B         1           # ensure B field consistency on the shared interfaces between sibling patches (for debugging) [0] ##MHD ONLY##
 
 
 # fluid solver in ELBDM (MODEL==ELBDM only)

--- a/include/Global.h
+++ b/include/Global.h
@@ -112,7 +112,7 @@ extern bool             OPT__FIXUP_ELECTRIC, OPT__CK_INTERFACE_B, OPT__OUTPUT_CC
 extern bool             OPT__OUTPUT_DIVMAG;
 extern int              OPT__CK_DIVERGENCE_B;
 extern double           UNIT_B;
-extern bool             OPT__INIT_BFIELD_BYFILE;
+extern bool             OPT__INIT_BFIELD_BYFILE, OPT__SAME_INTERFACE_B;
 #endif
 
 #elif ( MODEL == ELBDM )

--- a/include/HDF5_Typedef.h
+++ b/include/HDF5_Typedef.h
@@ -471,7 +471,13 @@ struct InputPara_t
    int    Opt__LR_Limiter;
    int    Opt__1stFluxCorr;
    int    Opt__1stFluxCorrScheme;
+#  ifdef DUAL_ENERGY
+   double DualEnergySwitch;
 #  endif
+#  ifdef MHD
+   int    Opt__SameInterfaceB;
+#  endif
+#  endif // HYDRO
 
 // ELBDM solvers
 #  if ( MODEL == ELBDM )
@@ -482,7 +488,7 @@ struct InputPara_t
 #  endif
    double ELBDM_Taylor3_Coeff;
    int    ELBDM_Taylor3_Auto;
-#  endif
+#  endif // ELBDM
 
 // fluid solvers in different models
    int    Flu_GPU_NPGroup;
@@ -519,9 +525,6 @@ struct InputPara_t
    int    JeansMinPres;
    int    JeansMinPres_Level;
    int    JeansMinPres_NCell;
-#  endif
-#  ifdef DUAL_ENERGY
-   double DualEnergySwitch;
 #  endif
 
 // gravity

--- a/include/LoadBalance.h
+++ b/include/LoadBalance.h
@@ -402,6 +402,8 @@ struct LB_t
             RecvG_PCr1D_IdxTable [lv][r] = NULL;
 #           endif
          } // for (int r=0; r<MPI_NRank; r++)
+
+         CutPoint[lv][MPI_NRank] = -1;
       } // for (int lv=0; lv<NLEVEL; lv++)
 
    } // METHOD : LB_t

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -486,6 +486,7 @@ void MHD_AllocateElectricArray( const int lv );
 void MHD_Aux_Check_InterfaceB( const char *comment );
 void MHD_Aux_Check_DivergenceB( const bool Verbose, const char *comment );
 void MHD_FixUp_Electric( const int lv );
+void MHD_SameInterfaceB( const int lv );
 void MHD_CopyPatchInterfaceBField( const int lv, const int PID, const int SibID, const int MagSg );
 void MHD_BoundaryCondition_Outflow( real **Array, const int BC_Face, const int NVar, const int GhostSize,
                                     const int ArraySizeX, const int ArraySizeY, const int ArraySizeZ,

--- a/include/ReadPara.h
+++ b/include/ReadPara.h
@@ -151,7 +151,7 @@ struct ReadPara_t
 
 
 //    parameter name
-      strcpy( Key[NPara], NewKey );
+      strncpy( Key[NPara], NewKey, MAX_STRING );
 
 //    parameter address
       Ptr[NPara] = NewPtr;
@@ -197,7 +197,7 @@ struct ReadPara_t
 
 
 //    parameter name
-      strcpy( Key[NPara], NewKey );
+      strncpy( Key[NPara], NewKey, MAX_STRING );
 
 //    parameter address
       Ptr[NPara] = NewPtr;
@@ -208,11 +208,11 @@ struct ReadPara_t
 //    set the default value
 //    --> use malloc() and free() since they are more appropriate for the void* pointers
 //    --> string parameter doesn't need range
-      Def[NPara] = (char*)malloc( (MAX_STRING+1)*sizeof(char) );
+      Def[NPara] = (char*)malloc( MAX_STRING*sizeof(char) );
       Min[NPara] = NULL;
       Max[NPara] = NULL;
 
-      strcpy( (char*)Def[NPara], NewDef );
+      strncpy( (char*)Def[NPara], NewDef, MAX_STRING );
 
       NPara ++;
 
@@ -287,7 +287,7 @@ struct ReadPara_t
                case TYPE_BOOL   :   GET_VOID( bool,   Ptr[MatchIdx] ) = (bool  )atol( LoadValue );    break;
                case TYPE_FLOAT  :   GET_VOID( float,  Ptr[MatchIdx] ) = (float )atof( LoadValue );    break;
                case TYPE_DOUBLE :   GET_VOID( double, Ptr[MatchIdx] ) = (double)atof( LoadValue );    break;
-               case TYPE_STRING :   strcpy( (char*)Ptr[MatchIdx], LoadValue );                        break;
+               case TYPE_STRING :   strncpy( (char*)Ptr[MatchIdx], LoadValue, MAX_STRING );           break;
 
                default: Aux_Error( ERROR_INFO, "unsupported data type (char*, float*, double*, int*, long*, unit*, ulong*, bool* only) !!\n" );
             }
@@ -338,7 +338,7 @@ struct ReadPara_t
                case TYPE_BOOL   :   def_int = GET_VOID( bool,   Ptr[t] ) = GET_VOID( bool,   Def[t] );   break;
                case TYPE_FLOAT  :   def_flt = GET_VOID( float,  Ptr[t] ) = GET_VOID( float,  Def[t] );   break;
                case TYPE_DOUBLE :   def_flt = GET_VOID( double, Ptr[t] ) = GET_VOID( double, Def[t] );   break;
-               case TYPE_STRING :   strcpy( (char*)Ptr[t], (char*)Def[t] );                              break;
+               case TYPE_STRING :   strncpy( (char*)Ptr[t], (char*)Def[t], MAX_STRING );                 break;
 
                default: Aux_Error( ERROR_INFO, "no default value for this data type (char*, float*, double*, int*, long*, unit*, ulong*, bool* only) !!\n" );
             }

--- a/include/ReadPara.h
+++ b/include/ReadPara.h
@@ -249,8 +249,8 @@ struct ReadPara_t
 //       load the key and value at the target line
          NLoad = sscanf( Line, "%s%s", LoadKey, LoadValue );
 
-//       skip lines with incorrect format (e.g., empyt lines)
-         if ( NLoad < 2  &&  MPI_Rank == 0 )
+//       skip lines with incorrect format (e.g., empty lines)
+         if ( NLoad < 2 )
          {
             if ( NLoad == 1  &&  LoadKey[0] != COMMENT_SYM )
                Aux_Error( ERROR_INFO, "cannot find the value to assign to the key \"%s\" at line %d !!\n",

--- a/src/Auxiliary/Aux_TakeNote.cpp
+++ b/src/Auxiliary/Aux_TakeNote.cpp
@@ -942,6 +942,12 @@ void Aux_TakeNote()
                                                                   ( OPT__1ST_FLUX_CORR_SCHEME == RSOLVER_1ST_HLLD ) ? "RSOLVER_1ST_HLLD" :
                                                                   ( OPT__1ST_FLUX_CORR_SCHEME == RSOLVER_1ST_NONE ) ? "NONE"             :
                                                                                                                 "UNKNOWN" );
+#     ifdef DUAL_ENERGY
+      fprintf( Note, "DUAL_ENERGY_SWITCH              %13.7e\n",  DUAL_ENERGY_SWITCH       );
+#     endif
+#     ifdef MHD
+      fprintf( Note, "OPT__SAME_INTERFACE_B           %d\n",      OPT__SAME_INTERFACE_B    );
+#     endif
 
 #     elif ( MODEL == ELBDM )
       if ( OPT__UNIT ) {
@@ -1031,9 +1037,6 @@ void Aux_TakeNote()
       if ( JEANS_MIN_PRES ) {
       fprintf( Note, "JEANS_MIN_PRES_LEVEL            %d\n",      JEANS_MIN_PRES_LEVEL     );
       fprintf( Note, "JEANS_MIN_PRES_NCELL            %d\n",      JEANS_MIN_PRES_NCELL     ); }
-#     endif
-#     ifdef DUAL_ENERGY
-      fprintf( Note, "DUAL_ENERGY_SWITCH              %13.7e\n",  DUAL_ENERGY_SWITCH       );
 #     endif
       fprintf( Note, "WITH_COARSE_FINE_FLUX           %d\n",      amr->WithFlux            );
 #     ifdef MHD

--- a/src/Fluid/Flu_Close.cpp
+++ b/src/Fluid/Flu_Close.cpp
@@ -982,7 +982,7 @@ void CorrectUnphysical( const int lv, const int NPG, const int *PID0_List,
 #                 endif
                   fprintf( File, ")\n" );
 
-                  fprintf( File, "ouptut (old) = (%14.7e, %14.7e, %14.7e, %14.7e, %14.7e, %14.7e",
+                  fprintf( File, "output (old) = (%14.7e, %14.7e, %14.7e, %14.7e, %14.7e, %14.7e",
                            Out[DENS], Out[MOMX], Out[MOMY], Out[MOMZ], Out[ENGY],
                            Hydro_Con2Eint(Out[DENS], Out[MOMX], Out[MOMY], Out[MOMZ], Out[ENGY],
                                           CheckMinEint_No, NULL_REAL, Emag_Out) );

--- a/src/Init/Init_ByRestart_HDF5.cpp
+++ b/src/Init/Init_ByRestart_HDF5.cpp
@@ -1893,7 +1893,13 @@ void Check_InputPara( const char *FileName, const int FormatVersion )
    LoadField( "Opt__LR_Limiter",         &RS.Opt__LR_Limiter,         SID, TID, NonFatal, &RT.Opt__LR_Limiter,          1, NonFatal );
    LoadField( "Opt__1stFluxCorr",        &RS.Opt__1stFluxCorr,        SID, TID, NonFatal, &RT.Opt__1stFluxCorr,         1, NonFatal );
    LoadField( "Opt__1stFluxCorrScheme",  &RS.Opt__1stFluxCorrScheme,  SID, TID, NonFatal, &RT.Opt__1stFluxCorrScheme,   1, NonFatal );
+#  ifdef DUAL_ENERGY
+   LoadField( "DualEnergySwitch",        &RS.DualEnergySwitch,        SID, TID, NonFatal, &RT.DualEnergySwitch,         1, NonFatal );
 #  endif
+#  ifdef MHD
+   LoadField( "Opt__SameInterfaceB",     &RS.Opt__SameInterfaceB,     SID, TID, NonFatal, &RT.Opt__SameInterfaceB,      1, NonFatal );
+#  endif
+#  endif // HYDRO
 
 // ELBDM solvers
 #  if ( MODEL == ELBDM )
@@ -1904,7 +1910,7 @@ void Check_InputPara( const char *FileName, const int FormatVersion )
 #  endif
    LoadField( "ELBDM_Taylor3_Coeff",     &RS.ELBDM_Taylor3_Coeff,     SID, TID, NonFatal, &RT.ELBDM_Taylor3_Coeff,      1, NonFatal );
    LoadField( "ELBDM_Taylor3_Auto",      &RS.ELBDM_Taylor3_Auto,      SID, TID, NonFatal, &RT.ELBDM_Taylor3_Auto,       1, NonFatal );
-#  endif
+#  endif // ELBDM
 
 // fluid solvers in both HYDRO/ELBDM
    LoadField( "Flu_GPU_NPGroup",         &RS.Flu_GPU_NPGroup,         SID, TID, NonFatal, &RT.Flu_GPU_NPGroup,          1, NonFatal );
@@ -1937,9 +1943,6 @@ void Check_InputPara( const char *FileName, const int FormatVersion )
    LoadField( "JeansMinPres",            &RS.JeansMinPres,            SID, TID, NonFatal, &RT.JeansMinPres,             1, NonFatal );
    LoadField( "JeansMinPres_Level",      &RS.JeansMinPres_Level,      SID, TID, NonFatal, &RT.JeansMinPres_Level,       1, NonFatal );
    LoadField( "JeansMinPres_NCell",      &RS.JeansMinPres_NCell,      SID, TID, NonFatal, &RT.JeansMinPres_NCell,       1, NonFatal );
-#  endif
-#  ifdef DUAL_ENERGY
-   LoadField( "DualEnergySwitch",        &RS.DualEnergySwitch,        SID, TID, NonFatal, &RT.DualEnergySwitch,         1, NonFatal );
 #  endif
 
 // self-gravity

--- a/src/Init/Init_GAMER.cpp
+++ b/src/Init/Init_GAMER.cpp
@@ -232,6 +232,13 @@ void Init_GAMER( int *argc, char ***argv )
    }
 
 
+// ensure B field consistency on the shared interfaces between sibling patches
+#  if ( MODEL == HYDRO  &&  defined MHD )
+   if ( OPT__SAME_INTERFACE_B )
+   for (int lv=0; lv<NLEVEL; lv++)  MHD_SameInterfaceB( lv );
+#  endif
+
+
 // user-defined initialization
    if ( Init_User_Ptr != NULL )  Init_User_Ptr();
 
@@ -303,5 +310,6 @@ void Init_GAMER( int *argc, char ***argv )
 #  endif // #ifdef TRACER
 
 #  endif // #ifdef PARTICLE
+
 
 } // FUNCTION : Init_GAMER

--- a/src/Init/Init_Load_FlagCriteria.cpp
+++ b/src/Init/Init_Load_FlagCriteria.cpp
@@ -147,7 +147,7 @@ void Init_Load_FlagCriteria()
                           lv, TargetName );
             }
 
-//          OPT__FLAG_ENGY_DENSITY and OPT__FLAG_LOHNER have two and three columns to be loaded, respectively
+//          OPT__FLAG_ENGY_DENSITY and OPT__FLAG_LOHNER have two and five columns to be loaded, respectively
             if      ( FlagMode == 3 )  sscanf( input_line, "%d%lf%lf", &Trash, &FlagTable_EngyDensity[lv][0],
                                                                                &FlagTable_EngyDensity[lv][1] );
             else if ( FlagMode == 4 )  sscanf( input_line, "%d%lf%lf%lf%lf%lf", &Trash, &FlagTable_Lohner[lv][0],

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -237,7 +237,7 @@ void Init_Load_Parameter()
    ReadPara->Add( "MINMOD_COEFF",               &MINMOD_COEFF,                    1.5,             1.0,           2.0            );
    ReadPara->Add( "MINMOD_MAX_ITER",            &MINMOD_MAX_ITER,                   0,               0,           NoMax_int      );
    ReadPara->Add( "OPT__LR_LIMITER",            &OPT__LR_LIMITER,             LR_LIMITER_DEFAULT, -1,             6              );
-   ReadPara->Add( "OPT__1ST_FLUX_CORR",         &OPT__1ST_FLUX_CORR,             -1,               NoMin_int,     2              );
+   ReadPara->Add( "OPT__1ST_FLUX_CORR",         &OPT__1ST_FLUX_CORR,               -1,             NoMin_int,     2              );
 #  ifdef MHD
    ReadPara->Add( "OPT__1ST_FLUX_CORR_SCHEME",  &OPT__1ST_FLUX_CORR_SCHEME,   RSOLVER_1ST_DEFAULT, NoMin_int,     4              );
 #  else
@@ -245,6 +245,9 @@ void Init_Load_Parameter()
 #  endif
 #  ifdef DUAL_ENERGY
    ReadPara->Add( "DUAL_ENERGY_SWITCH",         &DUAL_ENERGY_SWITCH,              2.0e-2,          0.0,           NoMax_double   );
+#  endif
+#  ifdef MHD
+   ReadPara->Add( "OPT__SAME_INTERFACE_B",      &OPT__SAME_INTERFACE_B,           false,           Useless_bool,  Useless_bool   );
 #  endif
 #  endif // #if ( MODEL == HYDRO )
 

--- a/src/LoadBalance/LB_Init_LoadBalance.cpp
+++ b/src/LoadBalance/LB_Init_LoadBalance.cpp
@@ -166,7 +166,7 @@ void LB_Init_LoadBalance( const bool Redistribute, const bool SendGridData, cons
 
    for (int lv=lv_min; lv<=lv_max; lv++)
    {
-      if ( OPT__VERBOSE  &&  MPI_Rank == 0 ) Aux_Message( stdout, "      Constructing patch relation at Lv %2d ... ", lv );
+      if ( OPT__VERBOSE  &&  MPI_Rank == 0 )    Aux_Message( stdout, "      Constructing patch relation at Lv %2d ... ", lv );
 
 //    4.1 sibling relation at lv
       LB_SiblingSearch( lv, true, NULL_INT, NULL );
@@ -255,7 +255,7 @@ void LB_Init_LoadBalance( const bool Redistribute, const bool SendGridData, cons
 // 6. get the buffer data
    for (int lv=lv_min_mpi; lv<=lv_max_mpi; lv++)
    {
-      if ( OPT__VERBOSE  &&  MPI_Rank == 0 ) Aux_Message( stdout, "      Transferring buffer data at Lv %2d ... ", lv );
+      if ( OPT__VERBOSE  &&  MPI_Rank == 0 )    Aux_Message( stdout, "      Transferring buffer data at Lv %2d ... ", lv );
 
       Buf_GetBufferData( lv, amr->FluSg[lv], amr->MagSg[lv], NULL_INT, DATA_GENERAL, _TOTAL, _MAG, Flu_ParaBuf, USELB_YES );
 

--- a/src/Main/Main.cpp
+++ b/src/Main/Main.cpp
@@ -104,7 +104,7 @@ bool                 OPT__FIXUP_ELECTRIC, OPT__CK_INTERFACE_B, OPT__OUTPUT_CC_MA
 bool                 OPT__OUTPUT_DIVMAG;
 int                  OPT__CK_DIVERGENCE_B;
 double               UNIT_B;
-bool                 OPT__INIT_BFIELD_BYFILE;
+bool                 OPT__INIT_BFIELD_BYFILE, OPT__SAME_INTERFACE_B;
 #endif
 
 #elif ( MODEL == ELBDM )
@@ -556,10 +556,25 @@ int main( int argc, char *argv[] )
 
 
 //    2. apply various corrections
-//       --> synchronize particles, restrict data, recalculate potential and particle acceleration, ...
+//       --> synchronize particles, restrict data, recalculate potential and particle acceleration,
+//           B field consistency ...
 //    ---------------------------------------------------------------------------------------------------
       if ( OPT__CORR_AFTER_ALL_SYNC == CORR_AFTER_SYNC_EVERY_STEP )
       TIMING_FUNC(   Flu_CorrAfterAllSync(),          Timer_Main[6],   TIMER_ON   );
+
+#     if ( MODEL == HYDRO  &&  defined MHD )
+      if ( OPT__SAME_INTERFACE_B )
+      {
+         if ( OPT__VERBOSE  &&  MPI_Rank == 0 )
+            Aux_Message( stdout, "   MHD_SameInterfaceB                       ... " );
+
+         for (int lv=0; lv<NLEVEL; lv++)
+         TIMING_FUNC(   MHD_SameInterfaceB( lv ),     Timer_Main[6],   TIMER_ON   );
+
+         if ( OPT__VERBOSE  &&  MPI_Rank == 0 )
+            Aux_Message( stdout, "done\n" );
+      }
+#     endif
 //    ---------------------------------------------------------------------------------------------------
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -513,7 +513,8 @@ ifeq "$(filter -DMHD, $(SIMU_OPTION))" "-DMHD"
 CPU_FILE    += MHD_GetCellCenteredBInPatch.cpp  MHD_InterpolateBField.cpp  MHD_AllocateElectricArray.cpp \
                MHD_Aux_Check_InterfaceB.cpp  MHD_FixUp_Electric.cpp  MHD_Aux_Check_DivergenceB.cpp \
                MHD_BoundaryCondition_Outflow.cpp  MHD_BoundaryCondition_Reflecting.cpp  MHD_BoundaryCondition_User.cpp \
-               MHD_BoundaryCondition_Diode.cpp  MHD_CopyPatchInterfaceBField.cpp MHD_Init_BField_ByFile.cpp
+               MHD_BoundaryCondition_Diode.cpp  MHD_CopyPatchInterfaceBField.cpp  MHD_Init_BField_ByFile.cpp \
+               MHD_SameInterfaceB.cpp
 
 CPU_FILE    += CPU_Shared_ConstrainedTransport.cpp  CPU_Shared_RiemannSolver_HLLD.cpp
 

--- a/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_MHM.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_MHM.cpp
@@ -340,8 +340,6 @@ void CPU_FluidSolver_MHM(
       for (int P=0; P<NPatchGroup; P++)
 #     endif
       {
-
-         s_FullStepFailure = 0;
          Iteration = 0;
 
 //       1. half-step prediction
@@ -407,6 +405,14 @@ void CPU_FluidSolver_MHM(
 
          do {
 
+#           ifdef __CUDACC__
+            __syncthreads();
+#           endif
+            s_FullStepFailure = 0;
+#           ifdef __CUDACC__
+            __syncthreads();
+#           endif
+
             real AdaptiveMinModCoeff = ( MinMod_MaxIter == 0 ) ? MinMod_Coeff :
             MinMod_Coeff - (real)Iteration * MinMod_Coeff / (real)MinMod_MaxIter;
 
@@ -428,6 +434,14 @@ void CPU_FluidSolver_MHM(
 
          do {
 
+#           ifdef __CUDACC__
+            __syncthreads();
+#           endif
+            s_FullStepFailure = 0;
+#           ifdef __CUDACC__
+            __syncthreads();
+#           endif
+
             real AdaptiveMinModCoeff = ( MinMod_MaxIter == 0 ) ? MinMod_Coeff :
             MinMod_Coeff - (real)Iteration * MinMod_Coeff / (real)MinMod_MaxIter;
 
@@ -443,7 +457,6 @@ void CPU_FluidSolver_MHM(
                                       JeansMinPres, JeansMinPres_Coeff, &EoS );
 
 #        endif // #if ( FLU_SCHEME == MHM_RP ) ... else ...
-
 
 
 //          2. evaluate the full-step fluxes

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_FullStepUpdate.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_FullStepUpdate.cpp
@@ -202,14 +202,7 @@ void Hydro_FullStepUpdate( const real g_Input[][ CUBE(FLU_NXT) ], real g_Output[
 #           endif
          }
 
-
-//       5-2. synchronize all threads within a GPU thread block
-#        ifdef __CUDACC__
-         __syncthreads();
-#        endif
-
-
-//       5-3. print out unphysical results after iterations for debugging
+//       5-2. print out unphysical results after iterations for debugging
 #        ifdef CHECK_UNPHYSICAL_IN_FLUID
          if ( FullStepFailure  &&  Iteration == MinMod_MaxIter )
          {
@@ -224,6 +217,12 @@ void Hydro_FullStepUpdate( const real g_Input[][ CUBE(FLU_NXT) ], real g_Output[
 #        endif
       } // if ( s_FullStepFailure != NULL )
    } // CGPU_LOOP( idx_out, CUBE(PS2) )
+
+
+// 6. synchronize s_FullStepFailure for all threads within a GPU thread block
+#  ifdef __CUDACC__
+   __syncthreads();
+#  endif
 
 } // FUNCTION : Hydro_FullStepUpdate
 

--- a/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
+++ b/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
@@ -179,11 +179,9 @@ void Hydro_Init_ByFunction_AssignData( const int lv )
 
 
 #  ifdef MHD
-
-   if ( OPT__INIT_BFIELD_BYFILE )
-     MHD_Init_BField_ByFile(lv);
-
+   if ( OPT__INIT_BFIELD_BYFILE )   MHD_Init_BField_ByFile( lv );
 #  endif
+
 
 #  pragma omp parallel for schedule( runtime ) num_threads( OMP_NThread )
    for (int PID=0; PID<amr->NPatchComma[lv][1]; PID++)
@@ -228,7 +226,7 @@ void Hydro_Init_ByFunction_AssignData( const int lv )
                amr->patch[ amr->MagSg[lv] ][lv][PID]->magnetic[v][ idx ++ ] = magnetic_1v*_NSub2;
             }}} // i,j,k
          } // for (int v=0; v<NCOMP_MAG; v++)
-      } // if ( !OPT__INIT_BFIELD_BY_FILE )
+      } // if ( !OPT__INIT_BFIELD_BYFILE )
 
 #     endif // #ifdef MHD
 

--- a/src/Model_Hydro/MHD_CopyPatchInterfaceBField.cpp
+++ b/src/Model_Hydro/MHD_CopyPatchInterfaceBField.cpp
@@ -61,11 +61,11 @@ void MHD_CopyPatchInterfaceBField( const int lv, const int PID, const int SibID,
 
 // copy data
 #  ifdef GAMER_DEBUG
-   if ( amr->patch[MagSg][lv][   PID]->magnetic[Bdir] == NULL )
-      Aux_Error( ERROR_INFO, "amr->patch[%d][%d][%d]->magnetic[%d] == NULL !!\n", MagSg, lv,    PID, Bdir );
+   if ( amr->patch[MagSg][lv][   PID]->magnetic == NULL )
+      Aux_Error( ERROR_INFO, "amr->patch[%d][%d][%d]->magnetic == NULL !!\n", MagSg, lv,    PID );
 
-   if ( amr->patch[MagSg][lv][SibPID]->magnetic[Bdir] == NULL )
-      Aux_Error( ERROR_INFO, "amr->patch[%d][%d][%d]->magnetic[%d] == NULL !!\n", MagSg, lv, SibPID, Bdir );
+   if ( amr->patch[MagSg][lv][SibPID]->magnetic == NULL )
+      Aux_Error( ERROR_INFO, "amr->patch[%d][%d][%d]->magnetic == NULL !!\n", MagSg, lv, SibPID );
 #  endif
 
    const real    *MagPtr0 = amr->patch[MagSg][lv][   PID]->magnetic[Bdir] + Bidx_offset[           SibID  ];

--- a/src/Model_Hydro/MHD_CopyPatchInterfaceBField.cpp
+++ b/src/Model_Hydro/MHD_CopyPatchInterfaceBField.cpp
@@ -10,7 +10,7 @@
 // Description :  Copy the longitudinal B field from the common interface of one patch to its sibling patch
 //
 // Note        :  1. Copy data from [lv][PID] to [lv][PID]->sibling[SibID]
-//                2. Invoked by Flu_FixUp_Restrict() and LB_GetBufferData()
+//                2. Invoked by Flu_FixUp_Restrict(), LB_GetBufferData(), and MHD_SameInterfaceB()
 //                3. Do nothing if the target sibling patch does not exist
 //
 // Parameter   :  lv    : AMR level

--- a/src/Model_Hydro/MHD_LB_AllocateElectricArray.cpp
+++ b/src/Model_Hydro/MHD_LB_AllocateElectricArray.cpp
@@ -97,11 +97,11 @@ void MHD_LB_AllocateElectricArray( const int FaLv )
                      {
 //                      determine the target rank and LB_Idx
 #                       if ( LOAD_BALANCE == HILBERT )
-                        const int SibSonLBIdx = 8*amr->patch[0][FaLv][SibPID]->LB_Idx;  // faster
+                        const long SibSonLBIdx = 8*amr->patch[0][FaLv][SibPID]->LB_Idx;   // faster
 #                       else
-                        const int SibSonLBIdx = LB_Corner2Index( SonLv, amr->patch[0][FaLv][SibPID]->corner, CHECK_OFF );
+                        const long SibSonLBIdx = LB_Corner2Index( SonLv, amr->patch[0][FaLv][SibPID]->corner, CHECK_OFF );
 #                       endif
-                        const int TRank       = SON_OFFSET_LB - SibSonPID;
+                        const int  TRank       = SON_OFFSET_LB - SibSonPID;
 
 //                      allocate enough memory
                         if ( LB_RecvE_NList[TRank] >= MemSize[TRank] )
@@ -175,11 +175,11 @@ void MHD_LB_AllocateElectricArray( const int FaLv )
                {
 //                determine the target rank and LB_Idx
 #                 if ( LOAD_BALANCE == HILBERT )
-                  const int SibSonLBIdx = 8*amr->patch[0][FaLv][ MPISibPID ]->LB_Idx;
+                  const long SibSonLBIdx = 8*amr->patch[0][FaLv][ MPISibPID ]->LB_Idx;
 #                 else
-                  const int SibSonLBIdx = LB_Corner2Index( SonLv, amr->patch[0][FaLv][ MPISibPID ]->corner, CHECK_OFF );
+                  const long SibSonLBIdx = LB_Corner2Index( SonLv, amr->patch[0][FaLv][ MPISibPID ]->corner, CHECK_OFF );
 #                 endif
-                  const int TRank       = SON_OFFSET_LB - MPISibSonPID;
+                  const int  TRank       = SON_OFFSET_LB - MPISibSonPID;
 
 //                allocate enough memory
                   if ( LB_RecvE_NList[TRank] >= MemSize[TRank] )

--- a/src/Model_Hydro/MHD_SameInterfaceB.cpp
+++ b/src/Model_Hydro/MHD_SameInterfaceB.cpp
@@ -14,7 +14,7 @@
 // Note        :  1. Applied to both real and buffer patches
 //                2. Invoked by Init_GAMER() and Main()
 //                3. Controlled by the runtime option OPT__SAME_INTERFACE_B
-//                4. Always use the B field on the +x/+y/+z sides to overwite that on the -x/-y/-z sides
+//                4. Always use the B field on the +x/+y/+z sides to overwrite that on the -x/-y/-z sides
 //                5. Mainly for debugging purposes since this consistency should already be guaranteed
 //                   even when disabling OPT__SAME_INTERFACE_B
 //
@@ -38,7 +38,7 @@ void MHD_SameInterfaceB( const int lv )
 #  pragma omp parallel for schedule( runtime )
    for (int PID=0; PID<amr->num[lv]; PID++)
    {
-//    use the B field on the +x/+y/+z sides to overwite that on the -x/-y/-z sides
+//    use the B field on the +x/+y/+z sides to overwrite that on the -x/-y/-z sides
 //    --> skip s=1/3/5
       for (int s=0; s<6; s+=2)
       {

--- a/src/Model_Hydro/MHD_SameInterfaceB.cpp
+++ b/src/Model_Hydro/MHD_SameInterfaceB.cpp
@@ -1,0 +1,59 @@
+#include "GAMER.h"
+
+#if ( MODEL == HYDRO  &&  defined MHD )
+
+
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  MHD_SameInterfaceB
+// Description :  Ensure that adjacent patches on the same level (i.e., sibling patches) have *exactly*
+//                the same B field on their shared interfaces
+//                --> Even round-off errors are the same
+//
+// Note        :  1. Applied to both real and buffer patches
+//                2. Invoked by Init_GAMER() and Main()
+//                3. Controlled by the runtime option OPT__SAME_INTERFACE_B
+//                4. Always use the B field on the +x/+y/+z sides to overwite that on the -x/-y/-z sides
+//                5. Mainly for debugging purposes since this consistency should already be guaranteed
+//                   even when disabling OPT__SAME_INTERFACE_B
+//
+// Parameter   :  lv : AMR level
+//
+// Return      :  Longitudinal B field on the interfaces between sibling patches
+//-------------------------------------------------------------------------------------------------------
+void MHD_SameInterfaceB( const int lv )
+{
+
+// check
+#  ifdef GAMER_DEBUG
+   if ( lv < 0  ||  lv > TOP_LEVEL )
+      Aux_Error( ERROR_INFO, "incorrect lv = %d !!\n", lv );
+#  endif
+
+
+   const int MagSg = amr->MagSg[lv];
+
+// iterate over all real and buffer patches
+#  pragma omp parallel for schedule( runtime )
+   for (int PID=0; PID<amr->num[lv]; PID++)
+   {
+//    use the B field on the +x/+y/+z sides to overwite that on the -x/-y/-z sides
+//    --> skip s=1/3/5
+      for (int s=0; s<6; s+=2)
+      {
+         const int SibPID = amr->patch[0][lv][PID]->sibling[s];
+
+//       some buffer patches may have magnetic == NULL --> skip them
+         if ( SibPID >= 0  &&
+              amr->patch[MagSg][lv][   PID]->magnetic != NULL  &&
+              amr->patch[MagSg][lv][SibPID]->magnetic != NULL     )
+            MHD_CopyPatchInterfaceBField( lv, PID, s, MagSg );
+      }
+   } // for (int PID=0; PID<amr->num[lv]; PID++)
+
+} // FUNCTION : MHD_SameInterfaceB
+
+
+
+#endif // #if ( MODEL == HYDRO  &&  defined MHD )

--- a/src/Output/Output_DumpData_Part.cpp
+++ b/src/Output/Output_DumpData_Part.cpp
@@ -38,7 +38,7 @@ void Output_DumpData_Part( const OptOutputPart_t Part, const bool BaseOnly, cons
                            const double z, const char *FileName )
 {
 
-   if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d) ...\n", __FUNCTION__, DumpID );
+   if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d)           ...\n", __FUNCTION__, DumpID );
 
 
 // check the input parameters
@@ -251,7 +251,7 @@ void Output_DumpData_Part( const OptOutputPart_t Part, const bool BaseOnly, cons
    delete [] Der_MagCC;
 #  endif
 
-   if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d) ... done\n", __FUNCTION__, DumpID );
+   if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d)           ... done\n", __FUNCTION__, DumpID );
 
 } // FUNCTION : Output_DumpData_Part
 

--- a/src/Output/Output_DumpData_Total.cpp
+++ b/src/Output/Output_DumpData_Total.cpp
@@ -52,7 +52,7 @@ void Output_DumpData_Total( const char *FileName )
 #  endif
 
 
-   if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d) ...\n", __FUNCTION__, DumpID );
+   if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d)     ...\n", __FUNCTION__, DumpID );
 
 
 // check the synchronization
@@ -1020,7 +1020,7 @@ void Output_DumpData_Total( const char *FileName )
    }
 
 
-   if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d) ... done\n", __FUNCTION__, DumpID );
+   if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d)     ... done\n", __FUNCTION__, DumpID );
 
 } // FUNCTION : Output_DumpData_Total
 

--- a/src/Output/Output_DumpData_Total_HDF5.cpp
+++ b/src/Output/Output_DumpData_Total_HDF5.cpp
@@ -225,7 +225,7 @@ Procedure for outputting new variables:
 void Output_DumpData_Total_HDF5( const char *FileName )
 {
 
-   if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d) ...\n", __FUNCTION__, DumpID );
+   if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d)     ...\n", __FUNCTION__, DumpID );
 
 
 // check the synchronization
@@ -1705,7 +1705,7 @@ void Output_DumpData_Total_HDF5( const char *FileName )
    }
 
 
-   if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d) ... done\n", __FUNCTION__, DumpID );
+   if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d)     ... done\n", __FUNCTION__, DumpID );
 
 } // FUNCTION : Output_DumpData_Total_HDF5
 

--- a/src/Output/Output_DumpData_Total_HDF5.cpp
+++ b/src/Output/Output_DumpData_Total_HDF5.cpp
@@ -69,7 +69,7 @@ Procedure for outputting new variables:
 
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  Output_DumpData_Total_HDF5 (FormatVersion = 2450)
+// Function    :  Output_DumpData_Total_HDF5 (FormatVersion = 2451)
 // Description :  Output all simulation data in the HDF5 format, which can be used as a restart file
 //                or loaded by YT
 //
@@ -221,6 +221,7 @@ Procedure for outputting new variables:
 //                2448 : 2022/05/18 --> output PAR_IC_TYPE
 //                2449 : 2022/07/08 --> output OPT__OUTPUT_RESTART
 //                2450 : 2022/07/13 --> output OPT__INT_PRIM
+//                2451 : 2022/10/10 --> output OPT__SAME_INTERFACE_B
 //-------------------------------------------------------------------------------------------------------
 void Output_DumpData_Total_HDF5( const char *FileName )
 {
@@ -1726,7 +1727,7 @@ void FillIn_KeyInfo( KeyInfo_t &KeyInfo, const int NFieldStored )
 
    const time_t CalTime = time( NULL );   // calendar time
 
-   KeyInfo.FormatVersion        = 2450;
+   KeyInfo.FormatVersion        = 2451;
    KeyInfo.Model                = MODEL;
    KeyInfo.NLevel               = NLEVEL;
    KeyInfo.NCompFluid           = NCOMP_FLUID;
@@ -2441,7 +2442,13 @@ void FillIn_InputPara( InputPara_t &InputPara, const int NFieldStored, char Fiel
    InputPara.Opt__LR_Limiter         = OPT__LR_LIMITER;
    InputPara.Opt__1stFluxCorr        = OPT__1ST_FLUX_CORR;
    InputPara.Opt__1stFluxCorrScheme  = OPT__1ST_FLUX_CORR_SCHEME;
+#  ifdef DUAL_ENERGY
+   InputPara.DualEnergySwitch        = DUAL_ENERGY_SWITCH;
 #  endif
+#  ifdef MHD
+   InputPara.Opt__SameInterfaceB     = OPT__SAME_INTERFACE_B;
+#  endif
+#  endif // HYDRO
 
 // ELBDM solvers
 #  if ( MODEL == ELBDM )
@@ -2452,7 +2459,7 @@ void FillIn_InputPara( InputPara_t &InputPara, const int NFieldStored, char Fiel
 #  endif
    InputPara.ELBDM_Taylor3_Coeff     = ELBDM_TAYLOR3_COEFF;
    InputPara.ELBDM_Taylor3_Auto      = ELBDM_TAYLOR3_AUTO;
-#  endif
+#  endif // ELBDM
 
 // fluid solvers in different models
    InputPara.Flu_GPU_NPGroup         = FLU_GPU_NPGROUP;
@@ -2501,9 +2508,6 @@ void FillIn_InputPara( InputPara_t &InputPara, const int NFieldStored, char Fiel
    InputPara.JeansMinPres            = JEANS_MIN_PRES;
    InputPara.JeansMinPres_Level      = JEANS_MIN_PRES_LEVEL;
    InputPara.JeansMinPres_NCell      = JEANS_MIN_PRES_NCELL;
-#  endif
-#  ifdef DUAL_ENERGY
-   InputPara.DualEnergySwitch        = DUAL_ENERGY_SWITCH;
 #  endif
 
 // self-gravity
@@ -3295,7 +3299,13 @@ void GetCompound_InputPara( hid_t &H5_TypeID, const int NFieldStored )
    H5Tinsert( H5_TypeID, "Opt__LR_Limiter",         HOFFSET(InputPara_t,Opt__LR_Limiter        ), H5T_NATIVE_INT     );
    H5Tinsert( H5_TypeID, "Opt__1stFluxCorr",        HOFFSET(InputPara_t,Opt__1stFluxCorr       ), H5T_NATIVE_INT     );
    H5Tinsert( H5_TypeID, "Opt__1stFluxCorrScheme",  HOFFSET(InputPara_t,Opt__1stFluxCorrScheme ), H5T_NATIVE_INT     );
+#  ifdef DUAL_ENERGY
+   H5Tinsert( H5_TypeID, "DualEnergySwitch",        HOFFSET(InputPara_t,DualEnergySwitch       ), H5T_NATIVE_DOUBLE  );
 #  endif
+#  ifdef MHD
+   H5Tinsert( H5_TypeID, "Opt__SameInterfaceB",     HOFFSET(InputPara_t,Opt__SameInterfaceB    ), H5T_NATIVE_INT     );
+#  endif
+#  endif // HYDRO
 
 // ELBDM solvers
 #  if ( MODEL == ELBDM )
@@ -3306,7 +3316,7 @@ void GetCompound_InputPara( hid_t &H5_TypeID, const int NFieldStored )
 #  endif
    H5Tinsert( H5_TypeID, "ELBDM_Taylor3_Coeff",     HOFFSET(InputPara_t,ELBDM_Taylor3_Coeff    ), H5T_NATIVE_DOUBLE  );
    H5Tinsert( H5_TypeID, "ELBDM_Taylor3_Auto",      HOFFSET(InputPara_t,ELBDM_Taylor3_Auto     ), H5T_NATIVE_INT     );
-#  endif
+#  endif // ELBDM
 
 // fluid solvers in different models
    H5Tinsert( H5_TypeID, "Flu_GPU_NPGroup",         HOFFSET(InputPara_t,Flu_GPU_NPGroup        ), H5T_NATIVE_INT     );
@@ -3365,9 +3375,6 @@ void GetCompound_InputPara( hid_t &H5_TypeID, const int NFieldStored )
    H5Tinsert( H5_TypeID, "JeansMinPres",            HOFFSET(InputPara_t,JeansMinPres           ), H5T_NATIVE_INT              );
    H5Tinsert( H5_TypeID, "JeansMinPres_Level",      HOFFSET(InputPara_t,JeansMinPres_Level     ), H5T_NATIVE_INT              );
    H5Tinsert( H5_TypeID, "JeansMinPres_NCell",      HOFFSET(InputPara_t,JeansMinPres_NCell     ), H5T_NATIVE_INT              );
-#  endif
-#  ifdef DUAL_ENERGY
-   H5Tinsert( H5_TypeID, "DualEnergySwitch",        HOFFSET(InputPara_t,DualEnergySwitch       ), H5T_NATIVE_DOUBLE           );
 #  endif
 
 // self-gravity


### PR DESCRIPTION
### Major fixes
- Declare `SibSonLBIdx` as `long` in `MHD_LB_AllocateElectricArray()`
- Set `s_FullStepFailure` and call `__syncthreads()` properly for `MHM/MHM_RP`

### Minor fixes
- Check `magnetic` instead of `magnetic[Bdir]` in `MHD_CopyPatchInterfaceBField()`
- Add the runtime option `OPT__SAME_INTERFACE_B` for debugging purposes ([wiki](https://github.com/gamer-project/gamer/wiki/Hydro#OPT__SAME_INTERFACE_B)). The corresponding source file is `Model_Hydro/MHD_SameInterfaceB.cpp`.
- Replace `strcpy` by `strncpy` in `ReadPara.h`
- Skip empty lines in `ReadPara.h` for _all_ MPI ranks
- Initialize `CutPoint[*][MPI_NRank]` as `-1`