### PR TITLE
Allow the ClusterMerger test problem to override PAR_NPAR

### DIFF
--- a/example/test_problem/Hydro/ClusterMerger/Input__Parameter
+++ b/example/test_problem/Hydro/ClusterMerger/Input__Parameter
@@ -52,7 +52,7 @@ OPT__BC_POT                   2           # gravity boundary condition: (1=perio
 
 
 # particle (PARTICLE only)
-PAR_NPAR                      2040000     # total number of particles (must be set for PAR_INIT == 1/3)
+PAR_NPAR                      -1          # total number of particles (must be set for PAR_INIT == 1/3)
 PAR_INIT                      1           # initialization option for particles: (1=FUNCTION, 2=RESTART, 3=FILE->"PAR_IC")
 PAR_INTERP                    2           # particle interpolation scheme: (1=NGP, 2=CIC, 3=TSC) [2]
 PAR_INTEG                     2           # particle integration scheme: (1=Euler, 2=KDK) [2]

--- a/example/test_problem/Hydro/ClusterMerger/README
+++ b/example/test_problem/Hydro/ClusterMerger/README
@@ -39,7 +39,8 @@ Note:
        (2) cd cluster_generator
        (3) python -m pip install .
        (4) Go back to the gamer_cluster_ics.py script and run with python "gamer_cluster_ics.py"
-4. Some handy yt analysis scripts and a notebook are put in "yt_script"
+4. No need to set PAR_NPAR in Input__Parameter since it will be reset automatically.
+5. Some handy yt analysis scripts and a notebook are put in "yt_script"
    --> For example, to generate the slice plots, one can
        (1) cd yt_script
        (2) Edit "idx_start" and "idx_end" in plot_slice-z.py

--- a/src/TestProblem/Hydro/ClusterMerger/Init_TestProb_ClusterMerger.cpp
+++ b/src/TestProblem/Hydro/ClusterMerger/Init_TestProb_ClusterMerger.cpp
@@ -32,6 +32,8 @@ static char    Merger_File_Prof3[1000];   // profile table of cluster 3
        double  Merger_Coll_VelY2;         // y-velocity of the second cluster
        double  Merger_Coll_VelX3;         // x-velocity of the third cluster
        double  Merger_Coll_VelY3;         // y-velocity of the third cluster
+       long    NPar_EachCluster[3];       // Number of particles in each cluster
+       long    NPar_AllCluster;           // Number of particles in all clusters
 
 static double *Table_R1 = NULL;           // radius of cluster 1
 static double *Table_D1 = NULL;           // density of cluster 1
@@ -60,6 +62,7 @@ static FieldIdx_t ColorField3Idx = Idx_Undefined;
 
 // problem-specific function prototypes
 #ifdef MASSIVE_PARTICLES
+long Read_Particle_Number_ClusterMerger(std::string filename);
 void Par_Init_ByFunction_ClusterMerger(const long NPar_ThisRank,
                                        const long NPar_AllRank,
                                        real *ParMass, real *ParPosX, real *ParPosY, real *ParPosZ,
@@ -111,8 +114,8 @@ void Validate()
       Aux_Error( ERROR_INFO, "OPT__UNIT must be enabled !!\n" );
 
    for (int f=0; f<6; f++)
-   if ( OPT__BC_FLU[f] == BC_FLU_PERIODIC )
-      Aux_Error( ERROR_INFO, "do not use periodic BC (OPT__BC_FLU* = 1) for this test !!\n" );
+     if ( OPT__BC_FLU[f] == BC_FLU_PERIODIC )
+        Aux_Error( ERROR_INFO, "do not use periodic BC (OPT__BC_FLU* = 1) for this test !!\n" );
 
 #  ifdef GRAVITY
    if ( OPT__BC_POT == BC_POT_PERIODIC )
@@ -211,9 +214,9 @@ void SetParameter()
    Merger_Coll_VelX3 *= (Const_km/Const_s) / UNIT_V;
    Merger_Coll_VelY3 *= (Const_km/Const_s) / UNIT_V;
 
-// (2) load the radial profiles
    if ( OPT__INIT != INIT_BY_RESTART ) {
 
+//    (2) load the radial profiles
       const std::string filename1(Merger_File_Prof1);
       const std::string filename2(Merger_File_Prof2);
       const std::string filename3(Merger_File_Prof3);
@@ -336,10 +339,57 @@ void SetParameter()
 
       } // if ( Merger_Coll_NumHalos > 2 && Merger_Coll_IsGas3 )
 
+//    (3) Determine particle number
+
+      // check file existence
+      if ( !Aux_CheckFileExist(Merger_File_Par1) )
+ 	 Aux_Error( ERROR_INFO, "file \"%s\" does not exist !!\n", Merger_File_Par1 );
+
+      if ( Merger_Coll_NumHalos > 1  &&  !Aux_CheckFileExist(Merger_File_Par2) )
+	 Aux_Error( ERROR_INFO, "file \"%s\" does not exist !!\n", Merger_File_Par2 );
+
+      if ( Merger_Coll_NumHalos > 2  &&  !Aux_CheckFileExist(Merger_File_Par3) )
+	 Aux_Error( ERROR_INFO, "file \"%s\" does not exist !!\n", Merger_File_Par3 );
+
+      const std::string pfilename1(Merger_File_Par1);
+      const std::string pfilename2(Merger_File_Par2);
+      const std::string pfilename3(Merger_File_Par3);
+
+      if ( MPI_Rank == 0 ) {
+
+	 NPar_EachCluster[0] = Read_Particle_Number_ClusterMerger(pfilename1);
+
+	 Aux_Message( stdout, "   Number of particles in cluster 1 = %ld\n",
+		      NPar_EachCluster[0] );
+
+	 if ( Merger_Coll_NumHalos > 1 ) {
+	    NPar_EachCluster[1] = Read_Particle_Number_ClusterMerger(pfilename2);
+	    Aux_Message( stdout, "   Number of particles in cluster 2 = %ld\n", NPar_EachCluster[1] );
+	 } else {
+	    NPar_EachCluster[1] = 0;
+	 }
+
+	 if ( Merger_Coll_NumHalos > 2 ) {
+	    NPar_EachCluster[2] = Read_Particle_Number_ClusterMerger(pfilename3);
+	    Aux_Message( stdout, "   Number of particles in cluster 3 = %ld\n", NPar_EachCluster[2] );
+	 } else {
+	    NPar_EachCluster[2] = 0;
+	 }
+
+      }
+
+      MPI_Bcast(NPar_EachCluster, 3, MPI_LONG, 0, MPI_COMM_WORLD);
+
+      NPar_AllCluster = NPar_EachCluster[0] + NPar_EachCluster[1] + NPar_EachCluster[2];
+
+      // overwrite the total number of particles
+      amr->Par->NPar_Active_AllRank = NPar_AllCluster;
+      PRINT_WARNING( "PAR_NPAR", amr->Par->NPar_Active_AllRank, FORMAT_LONG );
+
    } // if ( OPT__INIT != INIT_BY_RESTART )
 
 
-// (3) reset other general-purpose parameters
+// (4) reset other general-purpose parameters
 //     --> a helper macro PRINT_WARNING is defined in TestProb.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    = 10.0*Const_Gyr/UNIT_T;
@@ -691,6 +741,29 @@ void Read_Profile_ClusterMerger(std::string filename, std::string fieldname,
    return;
 
 } // FUNCTION : Read_Profile_ClusterMerger
+
+long Read_Particle_Number_ClusterMerger(std::string filename)
+{
+
+   hid_t   file_id, dataset, dataspace;
+   herr_t  status;
+   hsize_t dims[1], maxdims[1];
+
+   int rank;
+
+   file_id = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+
+   dataset   = H5Dopen(file_id, "particle_mass", H5P_DEFAULT);
+   dataspace = H5Dget_space(dataset);
+   rank      = H5Sget_simple_extent_dims(dataspace, dims, maxdims);
+
+   H5Sclose(dataspace);
+   H5Dclose(dataset);
+   H5Fclose(file_id);
+
+   return (long)dims[0];
+
+} // FUNCTION : Read_Particle_Number_ClusterMerger
 
 #endif // #ifdef SUPPORT_HDF5
 

--- a/src/TestProblem/Hydro/ClusterMerger/Par_Init_ByFunction_ClusterMerger.cpp
+++ b/src/TestProblem/Hydro/ClusterMerger/Par_Init_ByFunction_ClusterMerger.cpp
@@ -26,9 +26,11 @@ extern double  Merger_Coll_VelX2;
 extern double  Merger_Coll_VelY2;
 extern double  Merger_Coll_VelX3;
 extern double  Merger_Coll_VelY3;
+extern long    NPar_EachCluster[3];
+extern long    NPar_AllCluster;
+
 
 #ifdef MASSIVE_PARTICLES
-long Read_Particle_Number_ClusterMerger(std::string filename);
 void Read_Particles_ClusterMerger(std::string filename, long offset, long num,
                                   real_par_in xpos[], real_par_in ypos[],
                                   real_par_in zpos[], real_par_in xvel[],
@@ -83,53 +85,7 @@ void Par_Init_ByFunction_ClusterMerger( const long NPar_ThisRank, const long NPa
 
 #ifdef SUPPORT_HDF5
 
-
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ...\n", __FUNCTION__ );
-
-// check file existence
-   if ( !Aux_CheckFileExist(Merger_File_Par1) )
-      Aux_Error( ERROR_INFO, "file \"%s\" does not exist !!\n", Merger_File_Par1 );
-
-   if ( Merger_Coll_NumHalos > 1  &&  !Aux_CheckFileExist(Merger_File_Par2) )
-      Aux_Error( ERROR_INFO, "file \"%s\" does not exist !!\n", Merger_File_Par2 );
-
-   if ( Merger_Coll_NumHalos > 2  &&  !Aux_CheckFileExist(Merger_File_Par3) )
-      Aux_Error( ERROR_INFO, "file \"%s\" does not exist !!\n", Merger_File_Par3 );
-
-   const std::string filename1(Merger_File_Par1);
-   const std::string filename2(Merger_File_Par2);
-   const std::string filename3(Merger_File_Par3);
-
-// check file size
-   long NPar_EachCluster[3] = {0,0,0};
-   long NPar_AllCluster;
-
-   if ( MPI_Rank == 0 ) {
-
-      NPar_EachCluster[0] = Read_Particle_Number_ClusterMerger(filename1);
-
-      Aux_Message( stdout, "   Number of particles in cluster 1 = %ld\n",
-                   NPar_EachCluster[0] );
-
-      if ( Merger_Coll_NumHalos > 1 ) {
-         NPar_EachCluster[1] = Read_Particle_Number_ClusterMerger(filename2);
-         Aux_Message( stdout, "   Number of particles in cluster 2 = %ld\n", NPar_EachCluster[1] );
-      }
-
-      if ( Merger_Coll_NumHalos > 2 ) {
-         NPar_EachCluster[2] = Read_Particle_Number_ClusterMerger(filename3);
-         Aux_Message( stdout, "   Number of particles in cluster 3 = %ld\n", NPar_EachCluster[2] );
-      }
-
-   }
-
-   MPI_Bcast(NPar_EachCluster, 3, MPI_LONG, 0, MPI_COMM_WORLD);
-
-   NPar_AllCluster = NPar_EachCluster[0] + NPar_EachCluster[1] + NPar_EachCluster[2];
-
-   if ( NPar_AllCluster != NPar_AllRank )
-      Aux_Error( ERROR_INFO, "total number of particles found in cluster [%ld] != expect [%ld] !!\n",
-                 NPar_AllCluster, NPar_AllRank );
 
    // prepare to load data
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "   Preparing to load data ... " );
@@ -324,29 +280,6 @@ void Par_Init_ByFunction_ClusterMerger( const long NPar_ThisRank, const long NPa
 } // FUNCTION : Par_Init_ByFunction_ClusterMerger
 
 #ifdef SUPPORT_HDF5
-
-long Read_Particle_Number_ClusterMerger(std::string filename)
-{
-
-   hid_t   file_id, dataset, dataspace;
-   herr_t  status;
-   hsize_t dims[1], maxdims[1];
-
-   int rank;
-
-   file_id = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
-
-   dataset   = H5Dopen(file_id, "particle_mass", H5P_DEFAULT);
-   dataspace = H5Dget_space(dataset);
-   rank      = H5Sget_simple_extent_dims(dataspace, dims, maxdims);
-
-   H5Sclose(dataspace);
-   H5Dclose(dataset);
-   H5Fclose(file_id);
-
-   return (long)dims[0];
-
-} // FUNCTION : Read_Particle_Number_ClusterMerger
 
 void Read_Particles_ClusterMerger( std::string filename, long offset, long num,
                                    real_par_in xpos[], real_par_in ypos[],


### PR DESCRIPTION
This PR allows PAR_NPAR to be overridden by the `ClusterMerger` test problem, so that the value in `Input__Parameter` no longer needs to be set correctly. 