### PR TITLE
Integer overflow and bugfix

### DIFF
--- a/include/Particle.h
+++ b/include/Particle.h
@@ -61,7 +61,7 @@ void Aux_Error( const char *File, const int Line, const char *Func, const char *
 //                                          --> R2B : Real to Buffer
 //                                          --> Mainly for the Poisson solver
 //                                          --> For LOAD_BALANCE only
-//                R2B_Buff_NPatchEachRank :  Number of buffer patches to receive data from different MPI ranks
+//                R2B_Buff_NPatchEachRank : Number of buffer patches to receive data from different MPI ranks
 //                R2B_Buff_PIDList        : Buffer patch IDs list to receive particles from other ranks
 //                                          --> Mainly for the Poisson solver
 //                                          --> For LOAD_BALANCE only

--- a/src/LoadBalance/LB_AllocateFluxArray.cpp
+++ b/src/LoadBalance/LB_AllocateFluxArray.cpp
@@ -25,6 +25,10 @@ void LB_AllocateFluxArray( const int FaLv )
       Aux_Message( stderr, "WARNING : why invoking %s when amr->WithFlux is off ??\n", __FUNCTION__ );
 
 
+// nothing to do on the top level
+   if ( FaLv == TOP_LEVEL )   return;
+
+
    const int SonLv   = FaLv + 1;
    const int FaNReal = amr->NPatchComma[FaLv][1];
    const int MemUnit = 1 + FaNReal/MPI_NRank;         // set arbitrarily

--- a/src/LoadBalance/LB_GetBufferData.cpp
+++ b/src/LoadBalance/LB_GetBufferData.cpp
@@ -1796,9 +1796,10 @@ void LB_GetBufferData( const int lv, const int FluSg, const int MagSg, const int
 
 //-------------------------------------------------------------------------------------------------------
 // Function    :  LB_GetBufferData_MemAllocate_Send
-// Description :  Allocate the MPI send buffer used by LG_GetBufferData (and Par_LB_SendParticleData)
+// Description :  Allocate the MPI send buffer used by LG_GetBufferData(), Par_LB_CollectParticle2OneLevel(),
+//                Par_LB_ExchangeParticleBetweenPatch() and Par_LB_CollectParticleFromRealPatch()
 //
-// Note        :  1. Call LB_GetBufferData_MemFree to free memory
+// Note        :  1. Call LB_GetBufferData_MemFree() to free memory
 //                2. This function is used by some particle routines as well
 //                3. We reallocate send/recv buffers only when the current buffer size is not large enough
 //                   --> It greatly improves MPI performance
@@ -1827,7 +1828,7 @@ real *LB_GetBufferData_MemAllocate_Send( const int NSend )
 
 //-------------------------------------------------------------------------------------------------------
 // Function    :  LB_GetBufferData_MemAllocate_Recv
-// Description :  Allocate the MPI recv buffer used by LG_GetBufferData (and Par_LB_SendParticleData)
+// Description :  Allocate the MPI recv buffer used by LG_GetBufferData() and Par_LB_SendParticleData()
 //
 // Note        :  1. Call LB_GetBufferData_MemFree to free memory
 //                2. This function is used by some particle routines as well

--- a/src/LoadBalance/LB_GetBufferData.cpp
+++ b/src/LoadBalance/LB_GetBufferData.cpp
@@ -1816,7 +1816,13 @@ real *LB_GetBufferData_MemAllocate_Send( const int NSend )
       if ( MPI_SendBuf_Shared != NULL )   delete [] MPI_SendBuf_Shared;
 
 //    allocate BufSizeFactor more memory to sustain longer
-      SendBufSize        = int(NSend*BufSizeFactor);
+      SendBufSize = int(NSend*BufSizeFactor);
+
+//    check integer overflow
+      if ( SendBufSize < 0 )
+         Aux_Error( ERROR_INFO, "NSend %d, BufSizeFactor %13.7e, SendBufSize %d < 0 !!\n",
+                    NSend, BufSizeFactor, SendBufSize );
+
       MPI_SendBuf_Shared = new real [SendBufSize];
    }
 
@@ -1847,7 +1853,13 @@ real *LB_GetBufferData_MemAllocate_Recv( const int NRecv )
       if ( MPI_RecvBuf_Shared != NULL )   delete [] MPI_RecvBuf_Shared;
 
 //    allocate BufSizeFactor more memory to sustain longer
-      RecvBufSize        = int(NRecv*BufSizeFactor);
+      RecvBufSize = int(NRecv*BufSizeFactor);
+
+//    check integer overflow
+      if ( RecvBufSize < 0 )
+         Aux_Error( ERROR_INFO, "NRecv %d, BufSizeFactor %13.7e, RecvBufSize %d < 0 !!\n",
+                    NRecv, BufSizeFactor, RecvBufSize );
+
       MPI_RecvBuf_Shared = new real [RecvBufSize];
    }
 

--- a/src/LoadBalance/LB_GetBufferData.cpp
+++ b/src/LoadBalance/LB_GetBufferData.cpp
@@ -3,7 +3,7 @@
 #ifdef LOAD_BALANCE
 
 
-const real BufSizeFactor = 1.2;  // Send/RecvBufSize = int(NSend/NRecv*BufSizeFactor) --> must be >= 1.0
+const real BufSizeFactor = 1.05;    // Send/RecvBufSize = int(NSend/NRecv*BufSizeFactor) --> must be >= 1.0
 
 // MPI buffers are shared by some particle routines
 static real *MPI_SendBuf_Shared = NULL;

--- a/src/Makefile
+++ b/src/Makefile
@@ -274,6 +274,8 @@ SIMU_OPTION += -DRANDOM_NUMBER=RNG_GNU_EXT
 # for debug only
 ifeq "$(filter -DGAMER_DEBUG, $(SIMU_OPTION))" "-DGAMER_DEBUG"
 #CXXFLAG    += -fstack-protector-all
+#CXXFLAG    += -fsanitize=undefined -fsanitize=address
+#LIB        += -fsanitize=undefined -fsanitize=address
 endif
 
 # suppress warning when OpenMP is disabled

--- a/src/Model_Hydro/MHD_LB_AllocateElectricArray.cpp
+++ b/src/Model_Hydro/MHD_LB_AllocateElectricArray.cpp
@@ -25,6 +25,10 @@ void MHD_LB_AllocateElectricArray( const int FaLv )
       Aux_Message( stderr, "WARNING : why invoking %s when amr->WithElectric is off ??\n", __FUNCTION__ );
 
 
+// nothing to do on the top level
+   if ( FaLv == TOP_LEVEL )   return;
+
+
    const int SonLv      = FaLv + 1;
    const int FaNReal    = amr->NPatchComma[FaLv][1];
    const int MemUnit    = 1 + FaNReal/MPI_NRank;      // set arbitrarily

--- a/src/Particle/LoadBalance/Par_LB_CollectParticleFromRealPatch.cpp
+++ b/src/Particle/LoadBalance/Par_LB_CollectParticleFromRealPatch.cpp
@@ -14,11 +14,8 @@
 //                   and the corresponding real patches "Real_NPatchTotal, Real_PIDList, Real_NPatchEachRank" must be
 //                   provided. The information of real patches can be calculated in advance by using Par_LB_MapBuffer2RealPatch()
 //                2. All Target patches (those in Buff_PIDList[] and Real_PIDList[]) must be patches at the same level "lv"
-//                3. Currently this function only collects particle mass and position
-//                   --> For particle mass assignment only
-//                   --> But it should be generalized to work with arbitrary particle attributes in the future
-//                4. This function is called by Par_LB_CollectParticle2OneLevel()
-//                5. ParAtt_Copy[] will be allocated for all target buffer patches with particles in the
+//                3. This function is called by Par_LB_CollectParticle2OneLevel()
+//                4. ParAtt_Copy[] will be allocated for all target buffer patches with particles in the
 //                   corresponding real patches
 //                   --> Must be deallocated afterward by calling Par_LB_CollectParticle2OneLevel_FreeMemory()
 //


### PR DESCRIPTION
- Reduce `BufSizeFactor` to `1.05` in `LB_GetBufferData.cpp` to reduce memory consumption and the chance of integer overflow
- Check integer overflow in `LB_GetBufferData_MemAllocate_Send/Recv()`
- [BUGFIX] Return immediately on the top level in `LB_AllocateFluxArray()` and `MHD_LB_AllocateElectricArray()`
- Add `-fsanitize` for the gnu compiler (disabled by default)