### PR TITLE
Support user-defined Flag_Region()

### DIFF
--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -308,7 +308,6 @@ bool Flag_Check( const int lv, const int PID, const int i, const int j, const in
                  const real Vel[][PS1][PS1][PS1], const real Pres[][PS1][PS1],
                  const real *Lohner_Var, const real *Lohner_Ave, const real *Lohner_Slope, const int Lohner_NVar,
                  const real ParCount[][PS1][PS1], const real ParDens[][PS1][PS1], const real JeansCoeff );
-bool Flag_Region( const int i, const int j, const int k, const int lv, const int PID );
 bool Flag_Lohner( const int i, const int j, const int k, const OptLohnerForm_t Form, const real *Var1D, const real *Ave1D,
                   const real *Slope1D, const int NVar, const double Threshold, const double Filter, const double Soften );
 void Refine( const int lv, const UseLBFunc_t UseLBFunc );

--- a/include/TestProb.h
+++ b/include/TestProb.h
@@ -31,6 +31,7 @@ extern void (*Init_ByFile_User_Ptr)( real fluid_out[], const real fluid_in[], co
 extern void (*Init_Field_User_Ptr)();
 extern void (*Init_User_Ptr)();
 extern void (*Output_User_Ptr)();
+extern bool (*Flag_Region_Ptr)( const int i, const int j, const int k, const int lv, const int PID );
 extern bool (*Flag_User_Ptr)( const int i, const int j, const int k, const int lv, const int PID, const double *Threshold );
 extern double (*Mis_GetTimeStep_User_Ptr)( const int lv, const double dTime_dt );
 extern void (*Mis_UserWorkBeforeNextLevel_Ptr)( const int lv, const double TimeNew, const double TimeOld, const double dt );

--- a/src/Refine/Flag_Check.cpp
+++ b/src/Refine/Flag_Check.cpp
@@ -4,6 +4,7 @@ static bool Check_Gradient( const int i, const int j, const int k, const real In
 static bool Check_Curl( const int i, const int j, const int k,
                         const real vx[][PS1][PS1], const real vy[][PS1][PS1], const real vz[][PS1][PS1],
                         const double Threshold );
+extern bool (*Flag_Region_Ptr)( const int i, const int j, const int k, const int lv, const int PID );
 extern bool (*Flag_User_Ptr)( const int i, const int j, const int k, const int lv, const int PID, const double *Threshold );
 
 
@@ -51,7 +52,7 @@ bool Flag_Check( const int lv, const int PID, const int i, const int j, const in
 // ===========================================================================================
    if ( OPT__FLAG_REGION )
    {
-      if (  !Flag_Region( i, j, k, lv, PID )  )    return false;
+      if (  !Flag_Region_Ptr( i, j, k, lv, PID )  )    return false;
    }
 
 

--- a/src/Refine/Flag_Check.cpp
+++ b/src/Refine/Flag_Check.cpp
@@ -52,6 +52,8 @@ bool Flag_Check( const int lv, const int PID, const int i, const int j, const in
 // ===========================================================================================
    if ( OPT__FLAG_REGION )
    {
+      if ( Flag_Region_Ptr == NULL )   Aux_Error( ERROR_INFO, "Flag_Region_Ptr == NULL for OPT__FLAG_REGION !!\n" );
+
       if (  !Flag_Region_Ptr( i, j, k, lv, PID )  )    return false;
    }
 

--- a/src/Refine/Flag_Region.cpp
+++ b/src/Refine/Flag_Region.cpp
@@ -1,14 +1,22 @@
 #include "GAMER.h"
 
+// declare as static so that other functions cannot invoke it directly and must use the function pointer
+static bool Flag_Region_Template( const int i, const int j, const int k, const int lv, const int PID );
+
+// this function pointer must be set by a test problem initializer
+bool (*Flag_Region_Ptr)( const int i, const int j, const int k, const int lv, const int PID ) = NULL;
+
 
 
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  Flag_Region
-// Description :  Check if the element (i,j,k) of the input patch is within the regions allowed to be refined
+// Function    :  Flag_Region_Template
+// Description :  Template for checking if the element (i,j,k) of the input patch is within
+//                the regions allowed to be refined
 //
-// Note        :  To use this functionality, please turn on the option "OPT__FLAG_REGION" and then specify the
-//                target regions in this file
+// Note        :  1. Invoked by Flag_Check() using the function pointer "Flag_Region_Ptr",
+//                   which must be set by a test problem initializer
+//                2. Enabled by the runtime option "OPT__FLAG_REGION"
 //
 // Parameter   :  i,j,k       : Indices of the target element in the patch ptr[0][lv][PID]
 //                lv          : Refinement level of the target patch
@@ -16,7 +24,7 @@
 //
 // Return      :  "true/false"  if the input cell "is/is not" within the region allowed for refinement
 //-------------------------------------------------------------------------------------------------------
-bool Flag_Region( const int i, const int j, const int k, const int lv, const int PID )
+bool Flag_Region_Template( const int i, const int j, const int k, const int lv, const int PID )
 {
 
    const double dh     = amr->dh[lv];                                         // cell size
@@ -43,5 +51,4 @@ bool Flag_Region( const int i, const int j, const int k, const int lv, const int
 
    return Within;
 
-} // FUNCTION : Flag_Region
-
+} // FUNCTION : Flag_Region_Template

--- a/src/TestProblem/Template/Init_TestProb_Template.cpp
+++ b/src/TestProblem/Template/Init_TestProb_Template.cpp
@@ -278,6 +278,7 @@ void Init_TestProb_Template()
 // comment out Init_ByFile_User_Ptr to use the default
 // Init_ByFile_User_Ptr              = NULL; // option: OPT__INIT=3;             example: Init/Init_ByFile.cpp -> Init_ByFile_Default()
    Init_Field_User_Ptr               = NULL; // set NCOMP_PASSIVE_USER;          example: TestProblem/Hydro/Plummer/Init_TestProb_Hydro_Plummer.cpp --> AddNewField()
+   Flag_Region_Ptr                   = NULL; // option: OPT__FLAG_REGION;        example: Refing/Flag_Region.cpp
    Flag_User_Ptr                     = NULL; // option: OPT__FLAG_USER;          example: Refine/Flag_User.cpp
    Mis_GetTimeStep_User_Ptr          = NULL; // option: OPT__DT_USER;            example: Miscellaneous/Mis_GetTimeStep_User.cpp
    Mis_UserWorkBeforeNextLevel_Ptr   = NULL; //                                  example: Miscellaneous/Mis_UserWorkBeforeNextLevel.cpp


### PR DESCRIPTION
Modify the built-in `Flag_Region()` to be a function pointer such that user can define their problem-dependent `Flag_Region()`

Related issue: #114 