### PR TITLE
Add the simulation option SUPPORT_FFTW

### DIFF
--- a/include/GAMER.h
+++ b/include/GAMER.h
@@ -25,7 +25,7 @@
 #  include <omp.h>
 #endif
 
-#ifdef GRAVITY
+#ifdef SUPPORT_FFTW
 #  ifdef FLOAT8
 #     ifdef SERIAL
 #        include <drfftw.h>

--- a/include/HDF5_Typedef.h
+++ b/include/HDF5_Typedef.h
@@ -116,6 +116,7 @@ struct Makefile_t
    int Laohu;
    int SupportHDF5;
    int SupportGSL;
+   int SupportFFTW;
    int SupportLibYT;
 #  ifdef SUPPORT_LIBYT
    int LibYTUsePatchGroup;

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -340,6 +340,7 @@ void CPU_PoissonGravitySolver( const real h_Rho_Array    [][RHO_NXT][RHO_NXT][RH
 void CPU_ExtPotSolver_BaseLevel( const ExtPot_t Func, const double AuxArray_Flt[], const int AuxArray_Int[],
                                  const real Table[], void **GenePtr,
                                  const double Time, const bool PotIsInit, const int SaveSg );
+#ifdef SUPPORT_FFTW
 void CPU_PoissonSolver_FFT( const real Poi_Coeff, const int SaveSg, const double PrepTime );
 void Patch2Slab( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *SendBuf_SIdx, long *RecvBuf_SIdx,
                  int **List_PID, int **List_k, int *List_NSend_Rho, int *List_NRecv_Rho,
@@ -348,6 +349,7 @@ void Patch2Slab( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *SendBuf
 void Slab2Patch( const real *RhoK, real *SendBuf, real *RecvBuf, const int SaveSg, const long *List_SIdx,
                  int **List_PID, int **List_k, int *List_NSend, int *List_NRecv, const int local_nz, const int FFT_Size[],
                  const int NSendSlice );
+#endif
 void End_MemFree_PoissonGravity();
 void Gra_AdvanceDt( const int lv, const double TimeNew, const double TimeOld, const double dt,
                     const int SaveSg_Flu, const int SaveSg_Pot, const bool Poisson, const bool Gravity,
@@ -365,8 +367,10 @@ void Gra_Prepare_USG( const int lv, const double PrepTime,
                       real h_Pot_Array_USG_G[][USG_NXT_G][USG_NXT_G][USG_NXT_G],
                       real h_Flu_Array_USG_G[][GRA_NIN-1][PS1][PS1][PS1], const int NPG, const int *PID0_List );
 #endif
+#ifdef SUPPORT_FFTW
 void End_FFTW();
 void Init_FFTW();
+#endif
 void Init_ExtAccPot();
 void End_ExtAccPot();
 void Init_LoadExtPotTable();

--- a/src/Auxiliary/Aux_Check_Parameter.cpp
+++ b/src/Auxiliary/Aux_Check_Parameter.cpp
@@ -1147,6 +1147,10 @@ void Aux_Check_Parameter()
 
 // errors
 // ------------------------------
+#  ifndef SUPPORT_FFTW
+#     error : ERROR : SUPPORT_FFTW must be enabled in the makefile when GRAVITY is on !!
+#  endif
+
 #  if ( POT_SCHEME != SOR  &&  POT_SCHEME != MG )
 #     error : ERROR : unsupported Poisson solver in the makefile (SOR/MG) !!
 #  endif

--- a/src/Auxiliary/Aux_TakeNote.cpp
+++ b/src/Auxiliary/Aux_TakeNote.cpp
@@ -356,6 +356,12 @@ void Aux_TakeNote()
       fprintf( Note, "SUPPORT_GSL                     OFF\n" );
 #     endif
 
+#     ifdef SUPPORT_FFTW
+      fprintf( Note, "SUPPORT_FFTW                    ON\n" );
+#     else
+      fprintf( Note, "SUPPORT_FFTW                    OFF\n" );
+#     endif
+
 #     ifdef SUPPORT_LIBYT
       fprintf( Note, "SUPPORT_LIBYT                   ON\n" );
 #     else

--- a/src/Init/End_GAMER.cpp
+++ b/src/Init/End_GAMER.cpp
@@ -27,8 +27,10 @@ void End_GAMER()
 
    if ( End_User_Ptr != NULL )   End_User_Ptr();
 
+#  ifdef SUPPORT_FFTW
 #  ifdef GRAVITY
    End_FFTW();
+#  endif
 #  endif
 
 #  ifdef SUPPORT_LIBYT

--- a/src/Init/Init_ByRestart_HDF5.cpp
+++ b/src/Init/Init_ByRestart_HDF5.cpp
@@ -1458,6 +1458,7 @@ void Check_Makefile( const char *FileName, const int FormatVersion )
    LoadField( "Laohu",                  &RS.Laohu,                  SID, TID, NonFatal, &RT.Laohu,                  1, NonFatal );
    LoadField( "SupportHDF5",            &RS.SupportHDF5,            SID, TID, NonFatal, &RT.SupportHDF5,            1, NonFatal );
    LoadField( "SupportGSL",             &RS.SupportGSL,             SID, TID, NonFatal, &RT.SupportGSL,             1, NonFatal );
+   LoadField( "SupportFFTW",            &RS.SupportFFTW,            SID, TID, NonFatal, &RT.SupportFFTW,            1, NonFatal );
    LoadField( "SupportLibYT",           &RS.SupportLibYT,           SID, TID, NonFatal, &RT.SupportLibYT,           1, NonFatal );
 #  ifdef SUPPORT_LIBYT
    LoadField( "LibYTUsePatchGroup",     &RS.LibYTUsePatchGroup,     SID, TID, NonFatal, &RT.LibYTUsePatchGroup,     1, NonFatal );

--- a/src/Init/Init_GAMER.cpp
+++ b/src/Init/Init_GAMER.cpp
@@ -88,9 +88,11 @@ void Init_GAMER( int *argc, char ***argv )
 #  endif
 
 
-#  ifdef GRAVITY
+#  ifdef SUPPORT_FFTW
 // initialize FFTW
+#  ifdef GRAVITY
    Init_FFTW();
+#  endif
 #  endif
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -36,6 +36,7 @@ COMPILE_VERBOSE := 0
 SIMU_OPTION += -DMODEL=HYDRO
 
 # enable gravity
+# --> must enable SUPPORT_FFTW
 #SIMU_OPTION += -DGRAVITY
 
 # enable particles
@@ -210,6 +211,10 @@ SIMU_OPTION += -DOPENMP
 
 # support GNU scientific library
 #SIMU_OPTION += -DSUPPORT_GSL
+
+# support FFTW library
+# --> must be enabled when GRAVITY is enabled
+#SIMU_OPTION += -DSUPPORT_FFTW
 
 # support yt inline analysis
 #SIMU_OPTION += -DSUPPORT_LIBYT
@@ -736,7 +741,7 @@ ifeq "$(filter -DLAOHU, $(SIMU_OPTION))" "-DLAOHU"
 LIB += -L$(GPUID_PATH) -lgpudevmgr
 endif
 
-ifeq "$(filter -DGRAVITY, $(SIMU_OPTION))" "-DGRAVITY"
+ifeq "$(filter -DSUPPORT_FFTW, $(SIMU_OPTION))" "-DSUPPORT_FFTW"
    LIB += -L$(FFTW_PATH)/lib
    ifeq "$(filter -DFLOAT8, $(SIMU_OPTION))" "-DFLOAT8"
       ifeq "$(filter -DSERIAL, $(SIMU_OPTION))" "-DSERIAL"
@@ -782,7 +787,7 @@ ifeq "$(filter -DSERIAL, $(SIMU_OPTION))" ""
 INCLUDE += -I$(MPI_PATH)/include
 endif
 
-ifeq "$(filter -DGRAVITY, $(SIMU_OPTION))" "-DGRAVITY"
+ifeq "$(filter -DSUPPORT_FFTW, $(SIMU_OPTION))" "-DSUPPORT_FFTW"
 INCLUDE += -I$(FFTW_PATH)/include
 endif
 

--- a/src/Output/Output_BasePowerSpectrum.cpp
+++ b/src/Output/Output_BasePowerSpectrum.cpp
@@ -1,6 +1,6 @@
 #include "GAMER.h"
 
-#ifdef GRAVITY
+#if ( defined GRAVITY  &&  defined SUPPORT_FFTW )
 
 //output the dimensionless power spectrum
 //#define DIMENSIONLESS_FORM
@@ -286,4 +286,4 @@ void GetBasePowerSpectrum( real *RhoK, const int j_start, const int dj, double *
 
 
 
-#endif // #ifdef GRAVITY
+#endif // #if ( defined GRAVITY  &&  defined SUPPORT_FFTW )

--- a/src/Output/Output_DumpData_Total_HDF5.cpp
+++ b/src/Output/Output_DumpData_Total_HDF5.cpp
@@ -69,7 +69,7 @@ Procedure for outputting new variables:
 
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  Output_DumpData_Total_HDF5 (FormatVersion = 2455)
+// Function    :  Output_DumpData_Total_HDF5 (FormatVersion = 2456)
 // Description :  Output all simulation data in the HDF5 format, which can be used as a restart file
 //                or loaded by YT
 //
@@ -228,6 +228,7 @@ Procedure for outputting new variables:
 //                                             AUTO_REDUCE_INT_MONO_FACTOR, AUTO_REDUCE_INT_MONO_MIN,
 //                                             INT_MONO_COEFF_B
 //                2455 : 2022/11/04 --> output REFINE_NLEVEL
+//                2456 : 2022/12/15 --> output SUPPORT_FFTW
 //-------------------------------------------------------------------------------------------------------
 void Output_DumpData_Total_HDF5( const char *FileName )
 {
@@ -1733,7 +1734,7 @@ void FillIn_KeyInfo( KeyInfo_t &KeyInfo, const int NFieldStored )
 
    const time_t CalTime = time( NULL );   // calendar time
 
-   KeyInfo.FormatVersion        = 2455;
+   KeyInfo.FormatVersion        = 2456;
    KeyInfo.Model                = MODEL;
    KeyInfo.NLevel               = NLEVEL;
    KeyInfo.NCompFluid           = NCOMP_FLUID;
@@ -1922,6 +1923,12 @@ void FillIn_Makefile( Makefile_t &Makefile )
    Makefile.SupportGSL             = 1;
 #  else
    Makefile.SupportGSL             = 0;
+#  endif
+
+#  ifdef SUPPORT_FFTW
+   Makefile.SupportFFTW            = 1;
+#  else
+   Makefile.SupportFFTW            = 0;
 #  endif
 
 #  ifdef SUPPORT_LIBYT
@@ -2914,6 +2921,7 @@ void GetCompound_Makefile( hid_t &H5_TypeID )
    H5Tinsert( H5_TypeID, "Laohu",                  HOFFSET(Makefile_t,Laohu                  ), H5T_NATIVE_INT );
    H5Tinsert( H5_TypeID, "SupportHDF5",            HOFFSET(Makefile_t,SupportHDF5            ), H5T_NATIVE_INT );
    H5Tinsert( H5_TypeID, "SupportGSL",             HOFFSET(Makefile_t,SupportGSL             ), H5T_NATIVE_INT );
+   H5Tinsert( H5_TypeID, "SupportFFTW",            HOFFSET(Makefile_t,SupportFFTW            ), H5T_NATIVE_INT );
    H5Tinsert( H5_TypeID, "SupportLibYT",           HOFFSET(Makefile_t,SupportLibYT           ), H5T_NATIVE_INT );
 #  ifdef SUPPORT_LIBYT
    H5Tinsert( H5_TypeID, "LibYTUsePatchGroup",     HOFFSET(Makefile_t,LibYTUsePatchGroup     ), H5T_NATIVE_INT );

--- a/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_FFT.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_FFT.cpp
@@ -1,6 +1,6 @@
 #include "GAMER.h"
 
-#ifdef GRAVITY
+#if ( defined GRAVITY  &&  defined SUPPORT_FFTW )
 
 
 
@@ -713,4 +713,4 @@ void CPU_PoissonSolver_FFT( const real Poi_Coeff, const int SaveSg, const double
 
 
 
-#endif // #ifdef GRAVITY
+#endif // #if ( defined GRAVITY  &&  defined SUPPORT_FFTW )

--- a/src/SelfGravity/Gra_AdvanceDt.cpp
+++ b/src/SelfGravity/Gra_AdvanceDt.cpp
@@ -118,8 +118,10 @@ void Gra_AdvanceDt( const int lv, const double TimeNew, const double TimeOld, co
       if ( UsePot )
       {
          if ( OPT__SELF_GRAVITY )
+#        ifdef SUPPORT_FFTW
          TIMING_FUNC(   CPU_PoissonSolver_FFT( Poi_Coeff, SaveSg_Pot, TimeNew ),
                         Timer_Gra_Advance[lv],   Timing   );
+#        endif
 
          if ( OPT__EXT_POT )
          TIMING_FUNC(   CPU_ExtPotSolver_BaseLevel( CPUExtPot_Ptr, ExtPot_AuxArray_Flt, ExtPot_AuxArray_Int,

--- a/src/SelfGravity/Init_FFTW.cpp
+++ b/src/SelfGravity/Init_FFTW.cpp
@@ -1,6 +1,6 @@
 #include "GAMER.h"
 
-#ifdef GRAVITY
+#if ( defined GRAVITY  &&  defined SUPPORT_FFTW )
 
 
 
@@ -107,4 +107,4 @@ void End_FFTW()
 
 
 
-#endif // #ifdef GRAVITY
+#endif // #if ( defined GRAVITY  &&  defined SUPPORT_FFTW )

--- a/src/SelfGravity/Init_GreenFuncK.cpp
+++ b/src/SelfGravity/Init_GreenFuncK.cpp
@@ -1,6 +1,6 @@
 #include "GAMER.h"
 
-#ifdef GRAVITY
+#if ( defined GRAVITY  &&  defined SUPPORT_FFTW )
 
 #ifdef SERIAL
 extern rfftwnd_plan     FFTW_Plan;
@@ -94,4 +94,4 @@ void Init_GreenFuncK()
 
 
 
-#endif // #ifdef GRAVITY
+#endif // #if ( defined GRAVITY  &&  defined SUPPORT_FFTW )


### PR DESCRIPTION
Add a new compilation option `SUPPORT_FFTW`.
Now it can support FFTW without turning on `GRAVITY` (for future use).
But to turn on `GRAVITY`, `SUPPORT_FFTW` must be enabled for the base-level Poisson solver.