### PR TITLE
Generalization for FFT

### DIFF
--- a/example/test_problem/Hydro/EnergyPowerSpectrum/Input__Parameter
+++ b/example/test_problem/Hydro/EnergyPowerSpectrum/Input__Parameter
@@ -1,0 +1,156 @@
+
+
+# =================================================================================================================
+# NOTE:
+# 1. Comment symbol: #
+# 2. [*]: defaults
+# 3. Parameters set to "auto" (usually by setting to a negative value) do not have deterministic default values
+#    and will be set according to the adopted compilation options and/or other runtime parameters
+# 4. To add new parameters, please edit "Init/Init_Load_Parameter.cpp"
+# 5. All dimensional variables should be set consistently with the code units (set by UNIT_L/M/T/V/D)
+# 6. For boolean options: 0/1 -> off/on
+# =================================================================================================================
+
+
+# simulation scale
+BOX_SIZE                      2.0         # box size along the longest side (in Mpc/h if COMOVING is adopted)
+NX0_TOT_X                     256         # number of base-level cells along x
+NX0_TOT_Y                     256         # number of base-level cells along y
+NX0_TOT_Z                     256         # number of base-level cells along z
+OMP_NTHREAD                  -1           # number of OpenMP threads (<=0=auto -> omp_get_max_threads) [-1] ##OPENMP ONLY##
+END_T                        -1.0         # end physical time (<0=auto -> must be set by test problems or restart) [-1.0]
+END_STEP                     -1           # end step (<0=auto -> must be set by test problems or restart) [-1]
+
+
+# test problems
+TESTPROB_ID                   200         # test problem ID [0]
+                                          # 200: energy power spectrum in pure hydro
+
+
+# boundary conditions
+OPT__BC_FLU_XM                1           # fluid boundary condition at the -x face: (1=periodic, 2=outflow, 3=reflecting, 4=user, 5=diode)
+OPT__BC_FLU_XP                1           # fluid boundary condition at the +x face: (1=periodic, 2=outflow, 3=reflecting, 4=user, 5=diode)
+OPT__BC_FLU_YM                1           # fluid boundary condition at the -y face: (1=periodic, 2=outflow, 3=reflecting, 4=user, 5=diode)
+OPT__BC_FLU_YP                1           # fluid boundary condition at the +y face: (1=periodic, 2=outflow, 3=reflecting, 4=user, 5=diode)
+OPT__BC_FLU_ZM                1           # fluid boundary condition at the -z face: (1=periodic, 2=outflow, 3=reflecting, 4=user, 5=diode)
+OPT__BC_FLU_ZP                1           # fluid boundary condition at the +z face: (1=periodic, 2=outflow, 3=reflecting, 4=user, 5=diode)
+
+
+# time-step
+DT__FLUID                    -1.0         # dt criterion: fluid solver CFL factor (<0=auto) [-1.0]
+DT__FLUID_INIT               -1.0         # dt criterion: DT__FLUID at the first step (<0=auto) [-1.0]
+OPT__DT_USER                  0           # dt criterion: user-defined -> edit "Mis_GetTimeStep_UserCriteria.cpp" [0]
+OPT__RECORD_DT                1           # record info of the dt determination [1]
+AUTO_REDUCE_DT                1           # reduce dt automatically when the program fails (for OPT__DT_LEVEL==3 only) [1]
+AUTO_REDUCE_DT_FACTOR         0.8         # reduce dt by a factor of AUTO_REDUCE_DT_FACTOR when the program fails [0.8]
+AUTO_REDUCE_DT_FACTOR_MIN     0.1         # minimum allowed AUTO_REDUCE_DT_FACTOR after consecutive failures [0.1]
+AUTO_REDUCE_MINMOD_FACTOR     0.8         # reduce MINMOD_COEFF by this factor together with AUTO_REDUCE_DT (1.0=off) [0.8] ##HYDRO ONLY##
+AUTO_REDUCE_MINMOD_MIN        1.0e-2      # minimum allowed MINMOD_COEFF after consecutive failures [1.0e-2] ##HYDRO ONLY##
+AUTO_REDUCE_INT_MONO_FACTOR   0.8         # reduce INT_MONO_COEFF(_B) by this factor together with AUTO_REDUCE_DT (1.0=off) [0.8]
+AUTO_REDUCE_INT_MONO_MIN      1.0e-2      # minimum allowed INT_MONO_COEFF(_B) after consecutive failures [1.0e-2]
+
+
+# grid refinement (examples of Input__Flag_XXX tables are put at "example/input/")
+REGRID_COUNT                  4           # refine every REGRID_COUNT sub-step [4]
+FLAG_BUFFER_SIZE             -1           # number of buffer cells for the flag operation (0~PATCH_SIZE; <0=auto -> PATCH_SIZE) [-1]
+FLAG_BUFFER_SIZE_MAXM1_LV    -1           # FLAG_BUFFER_SIZE at the level MAX_LEVEL-1 (<0=auto -> REGRID_COUNT) [-1]
+FLAG_BUFFER_SIZE_MAXM2_LV    -1           # FLAG_BUFFER_SIZE at the level MAX_LEVEL-2 (<0=auto) [-1]
+MAX_LEVEL                     0           # maximum refinement level (0~NLEVEL-1) [NLEVEL-1]
+OPT__FLAG_RHO                 0           # flag: density (Input__Flag_Rho) [0]
+OPT__FLAG_RHO_GRADIENT        0           # flag: density gradient (Input__Flag_RhoGradient) [0]
+OPT__FLAG_PRES_GRADIENT       0           # flag: pressure gradient (Input__Flag_PresGradient) [0] ##HYDRO ONLY##
+OPT__FLAG_VORTICITY           0           # flag: vorticity (Input__Flag_Vorticity) [0] ##HYDRO ONLY##
+OPT__FLAG_JEANS               0           # flag: Jeans length (Input__Flag_Jeans) [0] ##HYDRO ONLY##
+OPT__FLAG_LOHNER_DENS         0           # flag: Lohner for mass density   (Input__Flag_Lohner) [0] ##BOTH HYDRO AND ELBDM##
+OPT__FLAG_LOHNER_ENGY         0           # flag: Lohner for energy density (Input__Flag_Lohner) [0] ##HYDRO ONLY##
+OPT__FLAG_LOHNER_PRES         0           # flag: Lohner for pressure       (Input__Flag_Lohner) [0] ##HYDRO ONLY##
+OPT__FLAG_LOHNER_TEMP         0           # flag: Lohner for temperature    (Input__Flag_Lohner) [0] ##HYDRO ONLY##
+OPT__FLAG_LOHNER_ENTR         0           # flag: Lohner for entropy        (Input__Flag_Lohner) [0] ##HYDRO ONLY##
+OPT__FLAG_LOHNER_FORM         2           # form of Lohner: (1=FLASH-1, 2=FLASH-2, 3=form-invariant-1, 4=form-invariant-2) [2]
+OPT__FLAG_USER                0           # flag: user-defined (Input__Flag_User) -> edit "Flag_User.cpp" [0]
+OPT__FLAG_REGION              0           # flag: specify the regions **allowed** to be refined -> edit "Flag_Region.cpp" [0]
+OPT__NO_FLAG_NEAR_BOUNDARY    0           # flag: disallow refinement near the boundaries [0]
+OPT__PATCH_COUNT              1           # record the # of patches   at each level: (0=off, 1=every step, 2=every sub-step) [1]
+OPT__REUSE_MEMORY             2           # reuse patch memory to reduce memory fragmentation: (0=off, 1=on, 2=aggressive) [2]
+OPT__MEMORY_POOL              0           # preallocate patches for OPT__REUSE_MEMORY=1/2 (Input__MemoryPool) [0]
+
+
+# load balance (LOAD_BALANCE only)
+LB_INPUT__WLI_MAX             0.1         # weighted-load-imbalance (WLI) threshold for redistributing all patches [0.1]
+OPT__RECORD_LOAD_BALANCE      1           # record the load-balance info [1]
+OPT__MINIMIZE_MPI_BARRIER     0           # minimize MPI barriers to improve load balance, especially with particles [1]
+                                          # (STORE_POT_GHOST, PAR_IMPROVE_ACC=1, OPT__TIMING_BARRIER=0 only; recommend AUTO_REDUCE_DT=0)
+
+
+# fluid solver in HYDRO (MODEL==HYDRO only)
+GAMMA                         1.666666666666666667 # ratio of specific heats (i.e., adiabatic index) [5.0/3.0]
+MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently only for post-processing [0.6]
+MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
+MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
+OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
+                                          # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
+OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]
+DUAL_ENERGY_SWITCH            2.0e-2      # apply dual-energy if E_int/E_kin < DUAL_ENERGY_SWITCH [2.0e-2] ##DUAL_ENERGY ONLY##
+
+
+# fluid solvers in all models
+FLU_GPU_NPGROUP              -1           # number of patch groups sent into the GPU fluid solver (<=0=auto) [-1]
+GPU_NSTREAM                  -1           # number of CUDA streams for the asynchronous memory copy in GPU (<=0=auto) [-1]
+OPT__FIXUP_FLUX               1           # correct coarse grids by the fine-grid boundary fluxes [1] ##HYDRO and ELBDM ONLY##
+OPT__FIXUP_RESTRICT           1           # correct coarse grids by averaging the fine-grid data [1]
+OPT__CORR_AFTER_ALL_SYNC     -1           # apply various corrections after all levels are synchronized (see "Flu_CorrAfterAllSync"):
+                                          # (-1=auto, 0=off, 1=every step, 2=before dump) [-1]
+MIN_DENS                      0.0         # minimum mass density    (must >= 0.0) [0.0] ##HYDRO, MHD, and ELBDM ONLY##
+MIN_PRES                      0.0         # minimum pressure        (must >= 0.0) [0.0] ##HYDRO and MHD ONLY##
+MIN_EINT                      0.0         # minimum internal energy (must >= 0.0) [0.0] ##HYDRO and MHD ONLY##
+MIN_ENTR                      0.0         # minimum entropy         (must >= 0.0) [0.0] ##HYDRO and MHD ONLY##
+
+
+# initialization
+OPT__INIT                     1           # initialization option: (1=FUNCTION, 2=RESTART, 3=FILE->"UM_IC")
+OPT__GPUID_SELECT            -1           # GPU ID selection mode: (-3=Laohu, -2=CUDA, -1=MPI rank, >=0=input) [-1]
+INIT_SUBSAMPLING_NCELL        0           # perform sub-sampling during initialization: (0=off, >0=# of sub-sampling cells) [0]
+
+
+# data dump
+OPT__OUTPUT_TOTAL             0           # output the simulation snapshot: (0=off, 1=HDF5, 2=C-binary) [1]
+OPT__OUTPUT_PART              7           # output a single line or slice: (0=off, 1=xy, 2=yz, 3=xz, 4=x, 5=y, 6=z, 7=diag) [0]
+OPT__OUTPUT_USER              1           # output the user-specified data -> edit "Output_User.cpp" [0]
+OPT__OUTPUT_BASEPS            1           # output the base-level power spectrum [0]
+OPT__OUTPUT_PRES              0           # output gas pressure [0] ##HYDRO ONLY##
+OPT__OUTPUT_TEMP              0           # output gas temperature [0] ##HYDRO ONLY##
+OPT__OUTPUT_ENTR              0           # output gas entropy [0] ##HYDRO ONLY##
+OPT__OUTPUT_CS                0           # output sound speed [0] ##HYDRO ONLY##
+OPT__OUTPUT_DIVVEL            0           # output divergence(velocity) [0] ##HYDRO ONLY##
+OPT__OUTPUT_MACH              0           # output mach number [0] ##HYDRO ONLY##
+OPT__OUTPUT_DIVMAG            0           # output |divergence(B)*dh/|B|| [0] ##MHD ONLY##
+OPT__OUTPUT_USER_FIELD        0           # output user-defined derived fields [0] -> edit "Flu_DerivedField_User.cpp"
+OPT__OUTPUT_MODE              1           # (1=const step, 2=const dt, 3=dump table) -> edit "Input__DumpTable" for 3
+OUTPUT_STEP                   5           # output data every OUTPUT_STEP step ##OPT__OUTPUT_MODE==1 ONLY##
+OUTPUT_DT                     1.0         # output data every OUTPUT_DT time interval ##OPT__OUTPUT_MODE==2 ONLY##
+OUTPUT_PART_X                 0.0         # x coordinate for OPT__OUTPUT_PART [-1.0]
+OUTPUT_PART_Y                 0.0         # y coordinate for OPT__OUTPUT_PART [-1.0]
+OUTPUT_PART_Z                 0.0         # z coordinate for OPT__OUTPUT_PART [-1.0]
+INIT_DUMPID                  -1           # set the first dump ID (<0=auto) [-1]
+
+
+# miscellaneous
+OPT__VERBOSE                  0           # output the simulation progress in detail [0]
+OPT__RECORD_MEMORY            1           # record the memory consumption [1]
+OPT__RECORD_PERFORMANCE       1           # record the code performance [1]
+OPT__RECORD_USER              0           # record the user-specified info -> edit "Aux_RecordUser.cpp" [0]
+
+
+# checks
+OPT__CK_REFINE                0           # check the grid refinement [0]
+OPT__CK_PROPER_NESTING        0           # check the proper-nesting condition [0]
+OPT__CK_CONSERVATION          1           # check the conservation law [0]
+OPT__CK_NORMALIZE_PASSIVE     0           # check the normalization of passive scalars [0] ##OPT__NORMALIZE_PASSIVE ONLY##
+OPT__CK_RESTRICT              0           # check the data restriction [0]
+OPT__CK_FINITE                0           # check if all variables are finite [0]
+OPT__CK_PATCH_ALLOCATE        0           # check if all patches are properly allocated [0]
+OPT__CK_FLUX_ALLOCATE         0           # check if all flux arrays are properly allocated ##HYDRO and ELBDM ONLY## [0]
+OPT__CK_NEGATIVE              0           # check the negative values: (0=off, 1=density, 2=pressure and entropy, 3=both) [0] ##HYDRO ONLY##
+OPT__CK_MEMFREE               1.0         # check the free memory in GB (0=off, >0=threshold) [1.0]

--- a/example/test_problem/Hydro/EnergyPowerSpectrum/Input__Parameter
+++ b/example/test_problem/Hydro/EnergyPowerSpectrum/Input__Parameter
@@ -23,8 +23,8 @@ END_STEP                     -1           # end step (<0=auto -> must be set by 
 
 
 # test problems
-TESTPROB_ID                   200         # test problem ID [0]
-                                          # 200: energy power spectrum in pure hydro
+TESTPROB_ID                   19          # test problem ID [0]
+                                          # 19: energy power spectrum in pure hydro
 
 
 # boundary conditions
@@ -118,7 +118,7 @@ INIT_SUBSAMPLING_NCELL        0           # perform sub-sampling during initiali
 OPT__OUTPUT_TOTAL             0           # output the simulation snapshot: (0=off, 1=HDF5, 2=C-binary) [1]
 OPT__OUTPUT_PART              7           # output a single line or slice: (0=off, 1=xy, 2=yz, 3=xz, 4=x, 5=y, 6=z, 7=diag) [0]
 OPT__OUTPUT_USER              1           # output the user-specified data -> edit "Output_User.cpp" [0]
-OPT__OUTPUT_BASEPS            1           # output the base-level power spectrum [0]
+OPT__OUTPUT_BASEPS            0           # output the base-level power spectrum [0]
 OPT__OUTPUT_PRES              0           # output gas pressure [0] ##HYDRO ONLY##
 OPT__OUTPUT_TEMP              0           # output gas temperature [0] ##HYDRO ONLY##
 OPT__OUTPUT_ENTR              0           # output gas entropy [0] ##HYDRO ONLY##

--- a/example/test_problem/Hydro/EnergyPowerSpectrum/Input__TestProb
+++ b/example/test_problem/Hydro/EnergyPowerSpectrum/Input__TestProb
@@ -1,0 +1,2 @@
+# problem-specific runtime parameters
+Energy_GauWidth      0.01           # width of gaussian distribution [0.01]

--- a/example/test_problem/Hydro/EnergyPowerSpectrum/README
+++ b/example/test_problem/Hydro/EnergyPowerSpectrum/README
@@ -1,0 +1,16 @@
+Compilation flags:
+========================================
+Enable : MODEL=HYDRO, SUPPORT_FFTW
+Disable: COMOVING, PARTICLE, GRAVITY, MHD
+
+
+Default setup:
+========================================
+1. Resolution = 256^3
+2. Run for initial conditions only
+
+
+Note:
+========================================
+1. Calculate the power spectrum of a 3D Gaussian distribution of energy
+2. A simple gnuplot script "plot.gpt" is attached

--- a/example/test_problem/Hydro/EnergyPowerSpectrum/README
+++ b/example/test_problem/Hydro/EnergyPowerSpectrum/README
@@ -1,7 +1,7 @@
 Compilation flags:
 ========================================
-Enable : MODEL=HYDRO, SUPPORT_FFTW
-Disable: COMOVING, PARTICLE, GRAVITY, MHD
+Enable : MODEL=HYDRO, SUPPORT_FFTW, EOS=EOS_GAMMA
+Disable: COMOVING, PARTICLE, MHD
 
 
 Default setup:

--- a/example/test_problem/Hydro/EnergyPowerSpectrum/clean.sh
+++ b/example/test_problem/Hydro/EnergyPowerSpectrum/clean.sh
@@ -1,0 +1,7 @@
+rm -f Record__Note Record__Timing Record__TimeStep Record__PatchCount Record__Dump Record__MemInfo Record__L1Err \
+      Record__Conservation Data* stderr stdout log XYslice* YZslice* XZslice* Xline* Yline* Zline* \
+      Diag* BaseXYslice* BaseYZslice* BaseXZslice* BaseXline* BaseYline* BaseZline* BaseDiag* \
+      PowerSpec_* Particle_* nohup.out Record__Performance Record__TimingMPI_* \
+      Record__ParticleCount Record__User Patch_* Record__NCorrUnphy FailedPatchGroup* *.pyc Record__LoadBalance
+
+rm -f EnergyPowerSpectrum_*

--- a/example/test_problem/Hydro/EnergyPowerSpectrum/plot.gpt
+++ b/example/test_problem/Hydro/EnergyPowerSpectrum/plot.gpt
@@ -1,0 +1,97 @@
+# -----------------------------------------------------------
+# GNUPLOT template 1D v1.1
+# -----------------------------------------------------------
+
+
+reset
+
+
+# target files
+# -----------------------------------------------------------
+FILE_IN_PREFIX  = 'EnergyPowerSpectrum'
+FILE_IN_SUFFIX  = ''
+FILE_OUT_PREFIX = 'Fig__EnergyPowerSpectrum'
+START_ID        = 0
+END_ID          = 0
+DELTA_ID        = 1
+PAUSE           = -1.0  # <= 0.0 --> mouse
+BOX_SIZE        = 2.0
+GaussianWidth   = 0.01
+
+
+# terminal
+# -----------------------------------------------------------
+ set term x11 enhanced
+#set term png enhanced crop size 1280,800
+#set term postscript eps enhanced color 'Helvetica' 16
+
+
+# plot style
+# -----------------------------------------------------------
+#set log xy
+ set key reverse Left spacing 2 right
+#set key reverse Left spacing 1 at first 1.5e2, 1e8
+ set xlabel "k"
+ set ylabel "P(k)"
+#set format x "10^{%T}"
+#set format y "10^{%T}"
+ set pointsize 1.0
+ set size square
+
+
+# constants
+# -----------------------------------------------------------
+
+
+# set the output file extension automatically
+# -----------------------------------------------------------
+if      ( GPVAL_TERM eq 'pngcairo'   ) FILE_OUT_EXT='png'; \
+else if ( GPVAL_TERM eq 'postscript' ) FILE_OUT_EXT='eps'; \
+else if ( GPVAL_TERM ne 'x11'        ) print 'Unkown terminal for settting the output file extension !!'; quit
+
+
+
+# loop over all files
+# -----------------------------------------------------------
+print "Start plotting ..."
+
+do for [ID=START_ID:END_ID:DELTA_ID] {
+
+#  set the input and output filenames
+   ID1     = ID%10
+   ID2     = (ID%100)/10
+   ID3     = (ID%1000)/100
+   ID4     = ID/1000
+   FILE_IN = sprintf( '%s_00%d%d%d%d%s', FILE_IN_PREFIX, ID4, ID3, ID2, ID1, FILE_IN_SUFFIX )
+
+   if ( GPVAL_TERM ne 'x11' ) { set output sprintf( '%s_00%d%d%d%d.%s', FILE_OUT_PREFIX, ID4, ID3, ID2, ID1, FILE_OUT_EXT ) }
+
+
+#  load the physical time
+   DUMP_TABLE   = './Record__Dump'
+   NHEADER      = 1
+   LOAD_TIME    = sprintf( "awk '{if(NR==%d+%d) {print $2}}' %s", NHEADER, ID+1, DUMP_TABLE  )
+   TIME         = system( LOAD_TIME )*1.0    # *1.0 --> convert string to number
+
+
+#  set title
+   set title sprintf( 'DataID %d%d%d%d (t = %5.2f)', ID4, ID3, ID2, ID1, TIME )
+   print sprintf( '   Plotting DataID %d%d%d%d (t = %5.2f) ...', ID4, ID3, ID2, ID1, TIME )
+
+
+#  plot
+   first = 0
+
+   plot FILE_IN u 1:2 w lp pt 6 lc 6 title 'Simulation'\
+       ,exp(-(GaussianWidth*x)**2)*BOX_SIZE**3 w l lc 7 title 'Analytical'
+
+
+   if ( GPVAL_TERM eq 'x11' ) { if ( PAUSE <= 0.0 ) { pause mouse }   else { pause PAUSE } };
+
+} #do for [ID=START_ID:END_ID:DELTA_ID]
+
+
+print "Done";
+if ( GPVAL_TERM eq 'x11' ) { pause -1 };
+
+

--- a/example/test_problem/Hydro/EnergyPowerSpectrum/plot.gpt
+++ b/example/test_problem/Hydro/EnergyPowerSpectrum/plot.gpt
@@ -28,15 +28,17 @@ GaussianWidth   = 0.01
 
 # plot style
 # -----------------------------------------------------------
-#set log xy
- set key reverse Left spacing 2 right
+ set log xy
+ set key reverse Left spacing 2 bottom left
 #set key reverse Left spacing 1 at first 1.5e2, 1e8
  set xlabel "k"
  set ylabel "P(k)"
-#set format x "10^{%T}"
-#set format y "10^{%T}"
+ set format x "10^{%T}"
+ set format y "10^{%T}"
  set pointsize 1.0
  set size square
+ set xrange [1e0:4.5e2]
+ set yrange [1e-8:2e1]
 
 
 # constants

--- a/example/test_problem/Template/Input__Parameter
+++ b/example/test_problem/Template/Input__Parameter
@@ -43,6 +43,7 @@ TESTPROB_ID                   0           # test problem ID [0]
                                           #   15: HYDRO MHD linear wave (+MHD)
                                           #   16: HYDRO Jeans instability (+GRAVITY) [+MHD]
                                           #   17: HYDRO particle in equilibrium (+GRAVITY & PARTICLE)
+                                          #   19: HYDRO energy power spectrum
                                           #  100: HYDRO CDM cosmological simulation (+GRAVITY & COMOVING & PARTICLE)
                                           #  101: HYDRO Zeldovich pancake collapse (+GRAVITY & COMOVING & PARTICLE)
                                           # 1000: ELBDM external potential (+GRAVITY)

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -219,7 +219,7 @@ void Init_FFTW();
 void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf_SIdx, long *RecvBuf_SIdx,
                  int **List_PID, int **List_k, int *List_NSend_Var, int *List_NRecv_Var,
                  const int *List_z_start, const int local_nz, const int FFT_Size[], const int NRecvSlice,
-                 const double PrepTime, const long TVar, const bool InPlacePad, const bool AddExtraMass );
+                 const double PrepTime, const long TVar, const bool InPlacePad, const bool ForPoisson, const bool AddExtraMass );
 void Slab2Patch( const real *VarS, real *SendBuf, real *RecvBuf, const int SaveSg, const long *List_SIdx,
                  int **List_PID, int **List_k, int *List_NSend, int *List_NRecv, const int local_nz, const int FFT_Size[],
                  const int NSendSlice, const long TVar, const bool InPlacePad );

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -216,15 +216,13 @@ void Init_ByRestart_HDF5( const char *FileName );
 #ifdef SUPPORT_FFTW
 void End_FFTW();
 void Init_FFTW();
-void Patch2Slab_Rho( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *SendBuf_SIdx, long *RecvBuf_SIdx,
-                     int **List_PID, int **List_k, int *List_NSend_Rho, int *List_NRecv_Rho,
-                     const int *List_z_start, const int local_nz, const int FFT_Size[], const int NRecvSlice,
-                     const double PrepTime, const bool AddExtraMass );
-#ifdef GRAVITY
-void Slab2Patch_Pot( const real *RhoK, real *SendBuf, real *RecvBuf, const int SaveSg, const long *List_SIdx,
-                     int **List_PID, int **List_k, int *List_NSend, int *List_NRecv, const int local_nz, const int FFT_Size[],
-                     const int NSendSlice );
-#endif
+void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf_SIdx, long *RecvBuf_SIdx,
+                 int **List_PID, int **List_k, int *List_NSend_Var, int *List_NRecv_Var,
+                 const int *List_z_start, const int local_nz, const int FFT_Size[], const int NRecvSlice,
+                 const double PrepTime, const long TVar, const bool InPlacePad, const bool AddExtraMass );
+void Slab2Patch( const real *VarS, real *SendBuf, real *RecvBuf, const int SaveSg, const long *List_SIdx,
+                 int **List_PID, int **List_k, int *List_NSend, int *List_NRecv, const int local_nz, const int FFT_Size[],
+                 const int NSendSlice, const long TVar, const bool InPlacePad );
 #endif // #ifdef SUPPORT_FFTW
 
 

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -298,7 +298,9 @@ void Output_PreparedPatch_Fluid( const int TLv, const int TPID,
                                  const real h_Flu_Array[][FLU_NIN][ CUBE(FLU_NXT) ],
                                  const real h_Mag_Array[][NCOMP_MAG][ FLU_NXT_P1*SQR(FLU_NXT) ],
                                  const int NPG, const int *PID0_List, const int CLv, const char *comment );
+#ifdef SUPPORT_FFTW
 void Output_BasePowerSpectrum( const char *FileName, const long TVar );
+#endif
 void Output_L1Error( void (*AnalFunc_Flu)( real fluid[], const double x, const double y, const double z, const double Time,
                                            const int lv, double AuxArray[] ),
                      void (*AnalFunc_Mag)( real magnetic[], const double x, const double y, const double z, const double Time,

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -298,7 +298,7 @@ void Output_PreparedPatch_Fluid( const int TLv, const int TPID,
                                  const real h_Flu_Array[][FLU_NIN][ CUBE(FLU_NXT) ],
                                  const real h_Mag_Array[][NCOMP_MAG][ FLU_NXT_P1*SQR(FLU_NXT) ],
                                  const int NPG, const int *PID0_List, const int CLv, const char *comment );
-void Output_BasePowerSpectrum( const char *FileName );
+void Output_BasePowerSpectrum( const char *FileName, const long TVar );
 void Output_L1Error( void (*AnalFunc_Flu)( real fluid[], const double x, const double y, const double z, const double Time,
                                            const int lv, double AuxArray[] ),
                      void (*AnalFunc_Mag)( real magnetic[], const double x, const double y, const double z, const double Time,

--- a/include/Typedef.h
+++ b/include/Typedef.h
@@ -52,10 +52,10 @@ const TestProbID_t
    TESTPROB_HYDRO_JEANS_INSTABILITY            =   16,
    TESTPROB_HYDRO_PARTICLE_EQUILIBRIUM_IC      =   17,
    TESTPROB_HYDRO_PARTICLE_TEST                =   18,
+   TESTPROB_HYDRO_ENERGY_POWER_SPECTRUM        =   19,
    TESTPROB_HYDRO_BARRED_POT                   =   51,
    TESTPROB_HYDRO_CDM_LSS                      =  100,
    TESTPROB_HYDRO_ZELDOVICH                    =  101,
-   TESTPROB_HYDRO_ENERGY_POWER_SPECTRUM        =  200,
    TESTPROB_ELBDM_EXTPOT                       = 1000;
 
 

--- a/include/Typedef.h
+++ b/include/Typedef.h
@@ -55,6 +55,7 @@ const TestProbID_t
    TESTPROB_HYDRO_BARRED_POT                   =   51,
    TESTPROB_HYDRO_CDM_LSS                      =  100,
    TESTPROB_HYDRO_ZELDOVICH                    =  101,
+   TESTPROB_HYDRO_ENERGY_POWER_SPECTRUM        =  200,
    TESTPROB_ELBDM_EXTPOT                       = 1000;
 
 

--- a/src/Init/Init_FFTW.cpp
+++ b/src/Init/Init_FFTW.cpp
@@ -154,7 +154,7 @@ void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf
 
 // check
 // check only single field
-   if ( TVar == 0  ||  ( TVar & (TVar-1) ) != 0 )
+   if ( TVar == 0  ||  TVar & (TVar-1) )
       Aux_Error( ERROR_INFO, "number of target variables is not one !!\n" );
 
 #  ifdef GRAVITY
@@ -496,7 +496,7 @@ void Slab2Patch( const real *VarS, real *SendBuf, real *RecvBuf, const int SaveS
 
 // check
 // check only single field
-   if ( TVar == 0  ||  ( TVar & (TVar-1) ) != 0 )
+   if ( TVar == 0  ||  TVar & (TVar-1) )
       Aux_Error( ERROR_INFO, "number of target variables is not one !!\n" );
 
 // check TVar is one of the fields in NCOMP_TOTAL or POTE

--- a/src/Init/Init_FFTW.cpp
+++ b/src/Init/Init_FFTW.cpp
@@ -124,34 +124,36 @@ void End_FFTW()
 
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  Patch2Slab_Rho
-// Description :  Patch-based data --> slab domain decomposition (for density)
+// Function    :  Patch2Slab
+// Description :  Patch-based data --> slab domain decomposition
 //
-// Parameter   :  RhoK           : In-place FFT array
-//                SendBuf_Rho    : Sending MPI buffer of density
-//                RecvBuf_Rho    : Receiving MPI buffer of density
+// Parameter   :  VarS           : Arrary of target variable for FFT
+//                SendBuf_Var    : Sending MPI buffer of data
+//                RecvBuf_Var    : Receiving MPI buffer of data
 //                SendBuf_SIdx   : Sending MPI buffer of 1D coordinate in slab
 //                RecvBuf_SIdx   : Receiving MPI buffer of 1D coordinate in slab
 //                List_PID       : PID of each patch slice sent to each rank
 //                List_k         : Local z coordinate of each patch slice sent to each rank
-//                List_NSend_Rho : Size of density data sent to each rank
-//                List_NRecv_Rho : Size of density data received from each rank
+//                List_NSend_Var : Size of data sent to each rank
+//                List_NRecv_Var : Size of data received from each rank
 //                List_z_start   : Starting z coordinate of each rank in the FFTW slab decomposition
 //                local_nz       : Slab thickness of this MPI rank
 //                FFT_Size       : Size of the FFT operation including the zero-padding regions
 //                NRecvSlice     : Total number of z slices received from other ranks (could be zero in the isolated BC)
-//                PrepTime       : Physical time for preparing the density field
+//                PrepTime       : Physical time for preparing the target variable field
+//                TVar           : Target variable to be prepared
+//                InPlacePad     : Whether padded the array size for in-place real-to-complex FFT
 //                AddExtraMass   : Adding an extra density field for computing gravitational potential only
 //-------------------------------------------------------------------------------------------------------
-void Patch2Slab_Rho( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *SendBuf_SIdx, long *RecvBuf_SIdx,
-                     int **List_PID, int **List_k, int *List_NSend_Rho, int *List_NRecv_Rho,
-                     const int *List_z_start, const int local_nz, const int FFT_Size[], const int NRecvSlice,
-                     const double PrepTime, const bool AddExtraMass )
+void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf_SIdx, long *RecvBuf_SIdx,
+                 int **List_PID, int **List_k, int *List_NSend_Var, int *List_NRecv_Var,
+                 const int *List_z_start, const int local_nz, const int FFT_Size[], const int NRecvSlice,
+                 const double PrepTime, const long TVar, const bool InPlacePad, const bool AddExtraMass )
 {
 
 #  ifdef GRAVITY
 // check
-   if ( AddExtraMass  &&  Poi_AddExtraMassForGravity_Ptr == NULL )
+   if ( ( TVar == _TOTAL_DENS )  &&  AddExtraMass  &&  Poi_AddExtraMassForGravity_Ptr == NULL )
       Aux_Error( ERROR_INFO, "Poi_AddExtraMassForGravity_Ptr == NULL for AddExtraMass !!\n" );
 #  endif // GRAVITY
 
@@ -162,7 +164,7 @@ void Patch2Slab_Rho( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *Sen
 #  endif // GAMER_DEBUG
 
 
-   const int SSize[2]   = { 2*(FFT_Size[0]/2+1), FFT_Size[1] };   // padded slab size in the x and y directions
+   const int SSize[2]   = { ( ( InPlacePad ) ? 2*(FFT_Size[0]/2+1) : FFT_Size[0]), FFT_Size[1] };     // padded slab size in the x and y directions
    const int PSSize     = PS1*PS1;                                // patch slice size
 // const int MemUnit    = amr->NPatchComma[0][1]*PS1/MPI_NRank;   // set arbitrarily
    const int MemUnit    = amr->NPatchComma[0][1]*PS1;             // set arbitrarily
@@ -176,8 +178,8 @@ void Patch2Slab_Rho( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *Sen
    int   List_NSend_SIdx[MPI_NRank];   // number of patch slices sent to each rank
    int   List_NRecv_SIdx[MPI_NRank];   // number of patch slices received from each rank
    long *TempBuf_SIdx   [MPI_NRank];   // 1D slab coordinate of each patch slice sent to each rank
-   real *TempBuf_Rho    [MPI_NRank];   // density of each patch slice sent to each rank
-   real *TempBuf_Rho_Ptr = NULL;
+   real *TempBuf_Var    [MPI_NRank];   // data of each patch slice sent to each rank
+   real *TempBuf_Var_Ptr = NULL;
 
    int TRank, TRank_Guess, MemSize[MPI_NRank], idx;
 
@@ -189,7 +191,7 @@ void Patch2Slab_Rho( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *Sen
       List_PID       [r] = (int* )malloc( MemSize[r]*sizeof(int)         );
       List_k         [r] = (int* )malloc( MemSize[r]*sizeof(int)         );
       TempBuf_SIdx   [r] = (long*)malloc( MemSize[r]*sizeof(long)        );
-      TempBuf_Rho    [r] = (real*)malloc( MemSize[r]*sizeof(real)*PSSize );
+      TempBuf_Var    [r] = (real*)malloc( MemSize[r]*sizeof(real)*PSSize );
       List_NSend_SIdx[r] = 0;
    }
 
@@ -207,21 +209,21 @@ void Patch2Slab_Rho( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *Sen
    const int         GhostSize         = 0;
    const int         NPG               = 1;
 
-   real (*Dens)[PS1][PS1][PS1] = new real [8*NPG][PS1][PS1][PS1];
+   real (*Var)[PS1][PS1][PS1] = new real [8*NPG][PS1][PS1][PS1];
 
    for (int PID0=0; PID0<amr->NPatchComma[0][1]; PID0+=8)
    {
 //    even with NSIDE_00 and GhostSize=0, we still need OPT__BC_FLU to determine whether periodic BC is adopted
 //    for depositing particle mass onto grids.
 //    also note that we do not check minimum density here since no ghost zones are required
-      Prepare_PatchData( 0, PrepTime, Dens[0][0][0], NULL, GhostSize, NPG, &PID0, _TOTAL_DENS, _NONE,
+      Prepare_PatchData( 0, PrepTime, Var[0][0][0], NULL, GhostSize, NPG, &PID0, TVar, _NONE,
                          IntScheme, INT_NONE, UNIT_PATCH, NSide_None, IntPhase_No, OPT__BC_FLU, PotBC_None,
                          MinDens_No, MinPres_No, MinTemp_No, MinEntr_No, DE_Consistency_No );
 
 
 #     ifdef GRAVITY
 //    add extra mass source for gravity if required
-      if ( AddExtraMass )
+      if ( ( TVar == _TOTAL_DENS )  &&  AddExtraMass )
       {
          const double dh = amr->dh[0];
 
@@ -236,7 +238,7 @@ void Patch2Slab_Rho( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *Sen
             for (int k=0; k<PS1; k++)  {  z = z0 + k*dh;
             for (int j=0; j<PS1; j++)  {  y = y0 + j*dh;
             for (int i=0; i<PS1; i++)  {  x = x0 + i*dh;
-               Dens[LocalID][k][j][i] += Poi_AddExtraMassForGravity_Ptr( x, y, z, Time[0], 0, NULL );
+               Var[LocalID][k][j][i] += Poi_AddExtraMassForGravity_Ptr( x, y, z, Time[0], 0, NULL );
             }}}
          }
       }
@@ -268,7 +270,7 @@ void Patch2Slab_Rho( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *Sen
                List_PID    [TRank]  = (int* )realloc( List_PID    [TRank], MemSize[TRank]*sizeof(int)         );
                List_k      [TRank]  = (int* )realloc( List_k      [TRank], MemSize[TRank]*sizeof(int)         );
                TempBuf_SIdx[TRank]  = (long*)realloc( TempBuf_SIdx[TRank], MemSize[TRank]*sizeof(long)        );
-               TempBuf_Rho [TRank]  = (real*)realloc( TempBuf_Rho [TRank], MemSize[TRank]*sizeof(real)*PSSize );
+               TempBuf_Var [TRank]  = (real*)realloc( TempBuf_Var [TRank], MemSize[TRank]*sizeof(real)*PSSize );
             }
 
 //          record list
@@ -276,21 +278,21 @@ void Patch2Slab_Rho( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *Sen
             List_k      [TRank][ List_NSend_SIdx[TRank] ] = k;
             TempBuf_SIdx[TRank][ List_NSend_SIdx[TRank] ] = SIdx;
 
-//          store density
-            TempBuf_Rho_Ptr = TempBuf_Rho[TRank] + List_NSend_SIdx[TRank]*PSSize;
+//          store data
+            TempBuf_Var_Ptr = TempBuf_Var[TRank] + List_NSend_SIdx[TRank]*PSSize;
 
             idx = 0;
             for (int j=0; j<PS1; j++)
             for (int i=0; i<PS1; i++)
-               TempBuf_Rho_Ptr[ idx ++ ] = Dens[LocalID][k][j][i];
+               TempBuf_Var_Ptr[ idx ++ ] = Var[LocalID][k][j][i];
 
 #           ifdef GRAVITY
 //          subtract the background density (which is assumed to be UNITY) for the isolated BC in the comoving frame
 //          --> to be consistent with the comoving-frame Poisson eq.
 #           ifdef COMOVING
-            if ( OPT__BC_POT == BC_POT_ISOLATED )
+            if ( ( TVar == _TOTAL_DENS )  &&  OPT__BC_POT == BC_POT_ISOLATED )
             {
-               for (int t=0; t<PSSize; t++)  TempBuf_Rho_Ptr[t] -= (real)1.0;
+               for (int t=0; t<PSSize; t++)  TempBuf_Var_Ptr[t] -= (real)1.0;
             }
 #           endif
 #           endif // #ifdef GRAVITY
@@ -300,40 +302,40 @@ void Patch2Slab_Rho( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *Sen
       } // for (int PID=PID0, LocalID=0; PID<PID0+8; PID++, LocalID++)
    } // for (int PID0=0; PID0<amr->NPatchComma[0][1]; PID0+=8)
 
-   delete [] Dens;
+   delete [] Var;
 
 
 // 3. prepare the send buffer
-   int   Send_Disp_Rho[MPI_NRank], Recv_Disp_Rho[MPI_NRank], Send_Disp_SIdx[MPI_NRank], Recv_Disp_SIdx[MPI_NRank];
+   int   Send_Disp_Var[MPI_NRank], Recv_Disp_Var[MPI_NRank], Send_Disp_SIdx[MPI_NRank], Recv_Disp_SIdx[MPI_NRank];
    long *SendPtr_SIdx = NULL;
-   real *SendPtr_Rho  = NULL;
+   real *SendPtr_Var  = NULL;
 
 // 3.1 broadcast the number of elements sending to different ranks
    MPI_Alltoall( List_NSend_SIdx, 1, MPI_INT, List_NRecv_SIdx, 1, MPI_INT, MPI_COMM_WORLD );
 
    for (int r=0; r<MPI_NRank; r++)
    {
-      List_NSend_Rho[r] = List_NSend_SIdx[r]*PSSize;
-      List_NRecv_Rho[r] = List_NRecv_SIdx[r]*PSSize;
+      List_NSend_Var[r] = List_NSend_SIdx[r]*PSSize;
+      List_NRecv_Var[r] = List_NRecv_SIdx[r]*PSSize;
    }
 
 // 3.2 calculate the displacement
    Send_Disp_SIdx[0] = 0;
    Recv_Disp_SIdx[0] = 0;
-   Send_Disp_Rho [0] = 0;
-   Recv_Disp_Rho [0] = 0;
+   Send_Disp_Var [0] = 0;
+   Recv_Disp_Var [0] = 0;
    for (int r=1; r<MPI_NRank; r++)
    {
       Send_Disp_SIdx[r] = Send_Disp_SIdx[r-1] + List_NSend_SIdx[r-1];
       Recv_Disp_SIdx[r] = Recv_Disp_SIdx[r-1] + List_NRecv_SIdx[r-1];
-      Send_Disp_Rho [r] = Send_Disp_Rho [r-1] + List_NSend_Rho [r-1];
-      Recv_Disp_Rho [r] = Recv_Disp_Rho [r-1] + List_NRecv_Rho [r-1];
+      Send_Disp_Var [r] = Send_Disp_Var [r-1] + List_NSend_Var [r-1];
+      Recv_Disp_Var [r] = Recv_Disp_Var [r-1] + List_NRecv_Var [r-1];
    }
 
 // check
 #  ifdef GAMER_DEBUG
-   const int NSend_Total  = Send_Disp_Rho[MPI_NRank-1] + List_NSend_Rho[MPI_NRank-1];
-   const int NRecv_Total  = Recv_Disp_Rho[MPI_NRank-1] + List_NRecv_Rho[MPI_NRank-1];
+   const int NSend_Total  = Send_Disp_Var[MPI_NRank-1] + List_NSend_Var[MPI_NRank-1];
+   const int NRecv_Total  = Recv_Disp_Var[MPI_NRank-1] + List_NRecv_Var[MPI_NRank-1];
    const int NSend_Expect = amr->NPatchComma[0][1]*CUBE(PS1);
    const int NRecv_Expect = NX0_TOT[0]*NX0_TOT[1]*NRecvSlice;
 
@@ -352,12 +354,12 @@ void Patch2Slab_Rho( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *Sen
       SendPtr_SIdx += List_NSend_SIdx[r];
    }
 
-// 3.4 prepare the send buffer of density
-   SendPtr_Rho = SendBuf_Rho;
+// 3.4 prepare the send buffer of data
+   SendPtr_Var = SendBuf_Var;
    for (int r=0; r<MPI_NRank; r++)
    {
-      memcpy( SendPtr_Rho, TempBuf_Rho[r], List_NSend_Rho[r]*sizeof(real) );
-      SendPtr_Rho += List_NSend_Rho[r];
+      memcpy( SendPtr_Var, TempBuf_Var[r], List_NSend_Var[r]*sizeof(real) );
+      SendPtr_Var += List_NSend_Var[r];
    }
 
 
@@ -366,29 +368,29 @@ void Patch2Slab_Rho( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *Sen
                   RecvBuf_SIdx, List_NRecv_SIdx, Recv_Disp_SIdx, MPI_LONG,   MPI_COMM_WORLD );
 
 #  ifdef FLOAT8
-   MPI_Alltoallv( SendBuf_Rho,  List_NSend_Rho,  Send_Disp_Rho,  MPI_DOUBLE,
-                  RecvBuf_Rho,  List_NRecv_Rho,  Recv_Disp_Rho,  MPI_DOUBLE, MPI_COMM_WORLD );
+   MPI_Alltoallv( SendBuf_Var,  List_NSend_Var,  Send_Disp_Var,  MPI_DOUBLE,
+                  RecvBuf_Var,  List_NRecv_Var,  Recv_Disp_Var,  MPI_DOUBLE, MPI_COMM_WORLD );
 #  else
-   MPI_Alltoallv( SendBuf_Rho,  List_NSend_Rho,  Send_Disp_Rho,  MPI_FLOAT,
-                  RecvBuf_Rho,  List_NRecv_Rho,  Recv_Disp_Rho,  MPI_FLOAT,  MPI_COMM_WORLD );
+   MPI_Alltoallv( SendBuf_Var,  List_NSend_Var,  Send_Disp_Var,  MPI_FLOAT,
+                  RecvBuf_Var,  List_NRecv_Var,  Recv_Disp_Var,  MPI_FLOAT,  MPI_COMM_WORLD );
 #  endif
 
 
-// 5. store the received density to the padded array "RhoK" for FFTW
+// 5. store the received data to the padded array "VarS" for FFTW
    const long NPSlice = (long)NX0_TOT[0]*NX0_TOT[1]*NRecvSlice/PSSize;  // total number of received patch slices
    long  dSIdx, Counter = 0;
-   real *RhoK_Ptr = NULL;
+   real *VarS_Ptr = NULL;
 
    for (long t=0; t<NPSlice; t++)
    {
       SIdx     = RecvBuf_SIdx[t];
-      RhoK_Ptr = RhoK + SIdx;
+      VarS_Ptr = VarS + SIdx;
 
       for (int j=0; j<PS1; j++)
       for (int i=0; i<PS1; i++)
       {
          dSIdx           = j*SSize[0] + i;
-         RhoK_Ptr[dSIdx] = RecvBuf_Rho[ Counter ++ ];
+         VarS_Ptr[dSIdx] = RecvBuf_Var[ Counter ++ ];
       }
    }
 
@@ -397,10 +399,10 @@ void Patch2Slab_Rho( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *Sen
    for (int r=0; r<MPI_NRank; r++)
    {
       free( TempBuf_SIdx[r] );
-      free( TempBuf_Rho [r] );
+      free( TempBuf_Var [r] );
    }
 
-} // FUNCTION : Patch2Slab_Rho
+} // FUNCTION : Patch2Slab
 
 
 
@@ -424,10 +426,12 @@ int ZIndex2Rank( const int IndexZ, const int *List_z_start, const int TRank_Gues
 #  ifdef GAMER_DEBUG
 #  ifdef GRAVITY
    const int FFT_SizeZ = ( OPT__BC_POT == BC_POT_ISOLATED ) ? 2*NX0_TOT[2] : NX0_TOT[2];
+#  else
+   const int FFT_SizeZ = NX0_TOT[2];
+#  endif // #ifdef GRAVITY
 
    if ( List_z_start[MPI_NRank] < FFT_SizeZ )
       Aux_Error( ERROR_INFO, "incorrect parameter %s = %d !!\n", "List_z_start[MPI_NRank]", List_z_start[MPI_NRank] );
-#  endif // #ifdef GRAVITY
 
    if ( IndexZ < 0  ||  IndexZ >= NX0_TOT[2] )
       Aux_Error( ERROR_INFO, "incorrect parameter %s = %d !!\n", "IndexZ", IndexZ );
@@ -457,47 +461,48 @@ int ZIndex2Rank( const int IndexZ, const int *List_z_start, const int TRank_Gues
 
 
 
-#ifdef GRAVITY
 //-------------------------------------------------------------------------------------------------------
-// Function    :  Slab2Patch_Pot
-// Description :  Slab domain decomposition --> patch-based data (for potential)
+// Function    :  Slab2Patch
+// Description :  Slab domain decomposition --> patch-based data
 //
-// Parameter   :  RhoK       : In-place FFT array
-//                SendBuf    : Sending MPI buffer of potential
-//                RecvBuf    : Receiving MPI buffer of potential
+// Parameter   :  VarS       : Arrary of target variable after FFT
+//                SendBuf    : Sending MPI buffer of data
+//                RecvBuf    : Receiving MPI buffer of data
 //                SaveSg     : Sandglass to store the updated data
 //                List_SIdx  : 1D coordinate in slab
 //                List_PID   : PID of each patch slice sent to each rank
 //                List_k     : Local z coordinate of each patch slice sent to each rank
-//                List_NSend : Size of potential data sent to each rank
-//                List_NRecv : Size of potential data received from each rank
+//                List_NSend : Size of data sent to each rank
+//                List_NRecv : Size of data received from each rank
 //                local_nz   : Slab thickness of this MPI rank
 //                FFT_Size   : Size of the FFT operation including the zero-padding regions
 //                NSendSlice : Total number of z slices need to be sent to other ranks (could be zero in the isolated BC)
+//                TVar       : Target variable to be prepared
+//                InPlacePad : Whether padded the array size for in-place real-to-complex FFT
 //-------------------------------------------------------------------------------------------------------
-void Slab2Patch_Pot( const real *RhoK, real *SendBuf, real *RecvBuf, const int SaveSg, const long *List_SIdx,
-                     int **List_PID, int **List_k, int *List_NSend, int *List_NRecv, const int local_nz, const int FFT_Size[],
-                     const int NSendSlice )
+void Slab2Patch( const real *VarS, real *SendBuf, real *RecvBuf, const int SaveSg, const long *List_SIdx,
+                 int **List_PID, int **List_k, int *List_NSend, int *List_NRecv, const int local_nz, const int FFT_Size[],
+                 const int NSendSlice, const long TVar, const bool InPlacePad )
 {
 
-// 1. store the evaluated potential to the send buffer
-   const int   SSize[2]   = { 2*(FFT_Size[0]/2+1), FFT_Size[1] };             // padded slab size in the x and y directions
+// 1. store the evaluated data to the send buffer
+   const int   SSize[2]   = { ( ( InPlacePad ) ? 2*(FFT_Size[0]/2+1) : FFT_Size[0]), FFT_Size[1] };  // padded slab size in the x and y directions
    const int   PSSize     = PS1*PS1;                                          // patch slice size
    const long  NPSlice    = (long)NX0_TOT[0]*NX0_TOT[1]*NSendSlice/PSSize;    // total number of patch slices to be sent
-   const real *RhoK_Ptr   = NULL;
+   const real *VarS_Ptr   = NULL;
 
    long SIdx, dSIdx, Counter = 0;
 
    for (long t=0; t<NPSlice; t++)
    {
       SIdx     = List_SIdx[t];
-      RhoK_Ptr = RhoK + SIdx;
+      VarS_Ptr = VarS + SIdx;
 
       for (int j=0; j<PS1; j++)
       for (int i=0; i<PS1; i++)
       {
          dSIdx                 = j*SSize[0] + i;
-         SendBuf[ Counter ++ ] = RhoK_Ptr[dSIdx];
+         SendBuf[ Counter ++ ] = VarS_Ptr[dSIdx];
       }
    }
 
@@ -522,7 +527,7 @@ void Slab2Patch_Pot( const real *RhoK, real *SendBuf, real *RecvBuf, const int S
 #  endif
 
 
-// 3. store the received potential data to different patch objects
+// 3. store the received data to different patch objects
    int   PID, k, NRecvSlice;
    real *RecvPtr = RecvBuf;
 
@@ -535,7 +540,12 @@ void Slab2Patch_Pot( const real *RhoK, real *SendBuf, real *RecvBuf, const int S
          PID = List_PID[r][t];
          k   = List_k  [r][t];
 
-         memcpy( amr->patch[SaveSg][0][PID]->pot[k], RecvPtr, PSSize*sizeof(real) );
+#        ifdef GRAVITY
+         if ( TVar == _POTE )
+            memcpy( amr->patch[SaveSg][0][PID]->pot[k], RecvPtr, PSSize*sizeof(real) );
+         else
+#        endif
+            Aux_Error( ERROR_INFO, "incorrect target variable %s = %d !!\n", "TVar", TVar );
 
          RecvPtr += PSSize;
       }
@@ -549,8 +559,7 @@ void Slab2Patch_Pot( const real *RhoK, real *SendBuf, real *RecvBuf, const int S
       free( List_k  [r] );
    }
 
-} // FUNCTION : Slab2Patch_Pot
-#endif // #ifdef GRAVITY
+} // FUNCTION : Slab2Patch
 
 
 

--- a/src/Init/Init_FFTW.cpp
+++ b/src/Init/Init_FFTW.cpp
@@ -299,7 +299,7 @@ void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf
 //          subtract the background density (which is assumed to be UNITY) for the isolated BC in the comoving frame
 //          --> to be consistent with the comoving-frame Poisson eq.
 #           ifdef COMOVING
-            if ( For_Poisson  &&  OPT__BC_POT == BC_POT_ISOLATED )
+            if ( ForPoisson  &&  OPT__BC_POT == BC_POT_ISOLATED )
             {
                for (int t=0; t<PSSize; t++)  TempBuf_Var_Ptr[t] -= (real)1.0;
             }

--- a/src/Init/Init_FFTW.cpp
+++ b/src/Init/Init_FFTW.cpp
@@ -128,8 +128,8 @@ void End_FFTW()
 // Description :  Patch-based data --> slab domain decomposition
 //
 // Parameter   :  VarS           : Arrary of target variable for FFT
-//                SendBuf_Var    : Sending MPI buffer of data
-//                RecvBuf_Var    : Receiving MPI buffer of data
+//                SendBuf_Var    : Sending MPI buffer of the target field
+//                RecvBuf_Var    : Receiving MPI buffer of the target field
 //                SendBuf_SIdx   : Sending MPI buffer of 1D coordinate in slab
 //                RecvBuf_SIdx   : Receiving MPI buffer of 1D coordinate in slab
 //                List_PID       : PID of each patch slice sent to each rank
@@ -142,7 +142,7 @@ void End_FFTW()
 //                NRecvSlice     : Total number of z slices received from other ranks (could be zero in the isolated BC)
 //                PrepTime       : Physical time for preparing the target variable field
 //                TVar           : Target variable to be prepared
-//                InPlacePad     : Whether padded the array size for in-place real-to-complex FFT
+//                InPlacePad     : Whether or not to pad the array size for in-place real-to-complex FFT
 //                AddExtraMass   : Adding an extra density field for computing gravitational potential only
 //-------------------------------------------------------------------------------------------------------
 void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf_SIdx, long *RecvBuf_SIdx,
@@ -153,7 +153,7 @@ void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf
 
 #  ifdef GRAVITY
 // check
-   if ( ( TVar == _TOTAL_DENS )  &&  AddExtraMass  &&  Poi_AddExtraMassForGravity_Ptr == NULL )
+   if ( TVar == _TOTAL_DENS  &&  AddExtraMass  &&  Poi_AddExtraMassForGravity_Ptr == NULL )
       Aux_Error( ERROR_INFO, "Poi_AddExtraMassForGravity_Ptr == NULL for AddExtraMass !!\n" );
 #  endif // GRAVITY
 
@@ -354,7 +354,7 @@ void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf
       SendPtr_SIdx += List_NSend_SIdx[r];
    }
 
-// 3.4 prepare the send buffer of data
+// 3.4 prepare the send buffer of the target field
    SendPtr_Var = SendBuf_Var;
    for (int r=0; r<MPI_NRank; r++)
    {
@@ -466,8 +466,8 @@ int ZIndex2Rank( const int IndexZ, const int *List_z_start, const int TRank_Gues
 // Description :  Slab domain decomposition --> patch-based data
 //
 // Parameter   :  VarS       : Arrary of target variable after FFT
-//                SendBuf    : Sending MPI buffer of data
-//                RecvBuf    : Receiving MPI buffer of data
+//                SendBuf    : Sending MPI buffer of the target field
+//                RecvBuf    : Receiving MPI buffer of the target field
 //                SaveSg     : Sandglass to store the updated data
 //                List_SIdx  : 1D coordinate in slab
 //                List_PID   : PID of each patch slice sent to each rank
@@ -478,7 +478,7 @@ int ZIndex2Rank( const int IndexZ, const int *List_z_start, const int TRank_Gues
 //                FFT_Size   : Size of the FFT operation including the zero-padding regions
 //                NSendSlice : Total number of z slices need to be sent to other ranks (could be zero in the isolated BC)
 //                TVar       : Target variable to be prepared
-//                InPlacePad : Whether padded the array size for in-place real-to-complex FFT
+//                InPlacePad : Whether or not to pad the array size for in-place real-to-complex FFT
 //-------------------------------------------------------------------------------------------------------
 void Slab2Patch( const real *VarS, real *SendBuf, real *RecvBuf, const int SaveSg, const long *List_SIdx,
                  int **List_PID, int **List_k, int *List_NSend, int *List_NRecv, const int local_nz, const int FFT_Size[],

--- a/src/Init/Init_FFTW.cpp
+++ b/src/Init/Init_FFTW.cpp
@@ -175,11 +175,11 @@ void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf
 #  endif // GAMER_DEBUG
 
 
-   const int SSize[2]   = { ( ( InPlacePad ) ? 2*(FFT_Size[0]/2+1) : FFT_Size[0]), FFT_Size[1] };     // padded slab size in the x and y directions
+   const int SSize[2]   = { ( InPlacePad ? 2*(FFT_Size[0]/2+1) : FFT_Size[0] ), FFT_Size[1] };     // padded slab size in the x and y directions
    const int PSSize     = PS1*PS1;                                // patch slice size
 // const int MemUnit    = amr->NPatchComma[0][1]*PS1/MPI_NRank;   // set arbitrarily
    const int MemUnit    = amr->NPatchComma[0][1]*PS1;             // set arbitrarily
-   const int AveNz      = FFT_Size[2]/MPI_NRank + ( (FFT_Size[2]%MPI_NRank == 0 ) ? 0 : 1 );    // average slab thickness
+   const int AveNz      = FFT_Size[2]/MPI_NRank + ( ( FFT_Size[2]%MPI_NRank == 0 ) ? 0 : 1 );    // average slab thickness
    const int Scale0     = amr->scale[0];
 
    int   Cr[3];                        // corner coordinates of each patch normalized to the base-level grid size
@@ -234,7 +234,7 @@ void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf
 
 #     ifdef GRAVITY
 //    add extra mass source for gravity if required
-      if ( ( TVar == _TOTAL_DENS )  &&  AddExtraMass )
+      if ( TVar == _TOTAL_DENS  &&  AddExtraMass )
       {
          const double dh = amr->dh[0];
 
@@ -301,7 +301,7 @@ void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf
 //          subtract the background density (which is assumed to be UNITY) for the isolated BC in the comoving frame
 //          --> to be consistent with the comoving-frame Poisson eq.
 #           ifdef COMOVING
-            if ( ( TVar == _TOTAL_DENS )  &&  OPT__BC_POT == BC_POT_ISOLATED )
+            if ( TVar == _TOTAL_DENS  &&  OPT__BC_POT == BC_POT_ISOLATED )
             {
                for (int t=0; t<PSSize; t++)  TempBuf_Var_Ptr[t] -= (real)1.0;
             }
@@ -525,7 +525,7 @@ void Slab2Patch( const real *VarS, real *SendBuf, real *RecvBuf, const int SaveS
 
 
 // 1. store the evaluated data to the send buffer
-   const int   SSize[2]   = { ( ( InPlacePad ) ? 2*(FFT_Size[0]/2+1) : FFT_Size[0]), FFT_Size[1] };  // padded slab size in the x and y directions
+   const int   SSize[2]   = { ( InPlacePad ? 2*(FFT_Size[0]/2+1) : FFT_Size[0] ), FFT_Size[1] };  // padded slab size in the x and y directions
    const int   PSSize     = PS1*PS1;                                          // patch slice size
    const long  NPSlice    = (long)NX0_TOT[0]*NX0_TOT[1]*NSendSlice/PSSize;    // total number of patch slices to be sent
    const real *VarS_Ptr   = NULL;

--- a/src/Init/Init_TestProb.cpp
+++ b/src/Init/Init_TestProb.cpp
@@ -25,6 +25,7 @@ void Init_TestProb_Hydro_BarredPot();
 void Init_TestProb_Hydro_ParticleTest();
 void Init_TestProb_Hydro_CDM_LSS();
 void Init_TestProb_Hydro_Zeldovich();
+void Init_TestProb_Hydro_EnergyPowerSpectrum();
 
 void Init_TestProb_ELBDM_ExtPot();
 
@@ -73,6 +74,7 @@ void Init_TestProb()
       case TESTPROB_HYDRO_PARTICLE_TEST :                Init_TestProb_Hydro_ParticleTest();                break;
       case TESTPROB_HYDRO_CDM_LSS :                      Init_TestProb_Hydro_CDM_LSS();                     break;
       case TESTPROB_HYDRO_ZELDOVICH :                    Init_TestProb_Hydro_Zeldovich();                   break;
+      case TESTPROB_HYDRO_ENERGY_POWER_SPECTRUM :        Init_TestProb_Hydro_EnergyPowerSpectrum();         break;
 
       case TESTPROB_ELBDM_EXTPOT :                       Init_TestProb_ELBDM_ExtPot();                      break;
 

--- a/src/Output/Output_BasePowerSpectrum.cpp
+++ b/src/Output/Output_BasePowerSpectrum.cpp
@@ -82,26 +82,26 @@ void Output_BasePowerSpectrum( const char *FileName, const long TVar )
 
 
 // 3. initialize the particle density array (rho_ext) and collect particles to the target level
-   if ( TVar == _TOTAL_DENS ) {
-#     ifdef PARTICLE
-      const bool TimingSendPar_No = false;
-      const bool JustCountNPar_No = false;
-#     ifdef LOAD_BALANCE
-      const bool PredictPos       = amr->Par->PredictPos;
-      const bool SibBufPatch      = true;
-      const bool FaSibBufPatch    = true;
-#     else
-      const bool PredictPos       = false;
-      const bool SibBufPatch      = NULL_BOOL;
-      const bool FaSibBufPatch    = NULL_BOOL;
-#     endif
+#  ifdef MASSIVE_PARTICLES
+   const bool TimingSendPar_No = false;
+   const bool JustCountNPar_No = false;
+#  ifdef LOAD_BALANCE
+   const bool PredictPos       = amr->Par->PredictPos;
+   const bool SibBufPatch      = true;
+   const bool FaSibBufPatch    = true;
+#  else
+   const bool PredictPos       = false;
+   const bool SibBufPatch      = NULL_BOOL;
+   const bool FaSibBufPatch    = NULL_BOOL;
+#  endif
 
+   if ( TVar == _TOTAL_DENS ) {
       Prepare_PatchData_InitParticleDensityArray( 0 );
 
       Par_CollectParticle2OneLevel( 0, _PAR_MASS|_PAR_POSX|_PAR_POSY|_PAR_POSZ|_PAR_TYPE, PredictPos, Time[0],
                                     SibBufPatch, FaSibBufPatch, JustCountNPar_No, TimingSendPar_No );
-#     endif // #ifdef PARTICLE
    } // if ( TVar == _TOTAL_DENS )
+#  endif // #ifdef PARTICLE
 
 
 // 4. rearrange data from patch to slab
@@ -144,14 +144,14 @@ void Output_BasePowerSpectrum( const char *FileName, const long TVar )
    delete [] RecvBuf_SIdx;
    if ( MPI_Rank == 0 )    delete [] PS_total;
 
+// free memory for collecting particles from other ranks and levels, and free density arrays with ghost zones (rho_ext)
+#  ifdef MASSIVE_PARTICLES
    if ( TVar == _TOTAL_DENS ) {
-//    free memory for collecting particles from other ranks and levels, and free density arrays with ghost zones (rho_ext)
-#     ifdef PARTICLE
       Par_CollectParticle2OneLevel_FreeMemory( 0, SibBufPatch, FaSibBufPatch );
 
       Prepare_PatchData_FreeParticleDensityArray( 0 );
-#     endif
    }
+#  endif
 
 
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d) ... done\n", __FUNCTION__, DumpID );

--- a/src/Output/Output_BasePowerSpectrum.cpp
+++ b/src/Output/Output_BasePowerSpectrum.cpp
@@ -87,6 +87,7 @@ void Output_BasePowerSpectrum( const char *FileName, const long TVar )
    int  *List_k      [MPI_NRank];   // local z coordinate of each patch slice sent to each rank
    int   List_NSend  [MPI_NRank];   // size of data sent to each rank
    int   List_NRecv  [MPI_NRank];   // size of data received from each rank
+   const bool ForPoisson  = false;  // preparing the density field for the Poisson solver
    const bool InPlacePad  = true;   // pad the array for in-place real-to-complex FFT
 
    if ( MPI_Rank == 0 )    PS_total = new double [Nx_Padded];
@@ -117,7 +118,7 @@ void Output_BasePowerSpectrum( const char *FileName, const long TVar )
 
 // 4. rearrange data from patch to slab
    Patch2Slab( VarK, SendBuf, RecvBuf, SendBuf_SIdx, RecvBuf_SIdx, List_PID, List_k, List_NSend, List_NRecv, List_z_start,
-               local_nz, FFT_Size, NRecvSlice, Time[0], TVar, InPlacePad, false );
+               local_nz, FFT_Size, NRecvSlice, Time[0], TVar, InPlacePad, ForPoisson, false );
 
 
 // 5. evaluate the base-level power spectrum by FFT

--- a/src/Output/Output_BasePowerSpectrum.cpp
+++ b/src/Output/Output_BasePowerSpectrum.cpp
@@ -107,7 +107,7 @@ void Output_BasePowerSpectrum( const char *FileName, const long TVar )
       Par_CollectParticle2OneLevel( 0, _PAR_MASS|_PAR_POSX|_PAR_POSY|_PAR_POSZ|_PAR_TYPE, PredictPos, Time[0],
                                     SibBufPatch, FaSibBufPatch, JustCountNPar_No, TimingSendPar_No );
    } // if ( TVar == _TOTAL_DENS )
-#  endif // #ifdef PARTICLE
+#  endif // #ifdef MASSIVE_PARTICLES
 
 
 // 4. rearrange data from patch to slab

--- a/src/Output/Output_BasePowerSpectrum.cpp
+++ b/src/Output/Output_BasePowerSpectrum.cpp
@@ -31,7 +31,7 @@ void Output_BasePowerSpectrum( const char *FileName, const long TVar )
 
 // check
 // check only single field
-   if ( TVar == 0  ||  ( TVar & (TVar-1) ) != 0 )
+   if ( TVar == 0  ||  TVar & (TVar-1) )
       Aux_Error( ERROR_INFO, "number of target variables is not one !!\n" );
 
 

--- a/src/Output/Output_BasePowerSpectrum.cpp
+++ b/src/Output/Output_BasePowerSpectrum.cpp
@@ -101,8 +101,8 @@ void Output_BasePowerSpectrum( const char *FileName )
 
 
 // 4. rearrange data from patch to slab
-   Patch2Slab_Rho( RhoK, SendBuf, RecvBuf, SendBuf_SIdx, RecvBuf_SIdx, List_PID, List_k, List_NSend, List_NRecv, List_z_start,
-                   local_nz, FFT_Size, NRecvSlice, Time[0], false );
+   Patch2Slab( RhoK, SendBuf, RecvBuf, SendBuf_SIdx, RecvBuf_SIdx, List_PID, List_k, List_NSend, List_NRecv, List_z_start,
+               local_nz, FFT_Size, NRecvSlice, Time[0], _TOTAL_DENS, true, false );
 
 
 // 5. evaluate the base-level power spectrum by FFT

--- a/src/Output/Output_BasePowerSpectrum.cpp
+++ b/src/Output/Output_BasePowerSpectrum.cpp
@@ -31,13 +31,7 @@ void Output_BasePowerSpectrum( const char *FileName, const long TVar )
 
 // check
 // check only single field
-   int NVar = 0;  // record number of target variables
-   int NMax = NCOMP_TOTAL + NDERIVE + 3; // all possible fields ( _TOTAL | _DERIVED | _POTE | _PAR_DENS | _TOTAL_DENS )
-
-   for (int v=0; v<NMax; v++)
-      if ( TVar & (1L<<v) )  NVar++;
-
-   if ( NVar != 1 )
+   if ( TVar == 0  ||  ( TVar & (TVar-1) ) != 0 )
       Aux_Error( ERROR_INFO, "number of target variables is not one !!\n" );
 
 

--- a/src/Output/Output_BasePowerSpectrum.cpp
+++ b/src/Output/Output_BasePowerSpectrum.cpp
@@ -29,6 +29,17 @@ void Output_BasePowerSpectrum( const char *FileName, const long TVar )
 
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d) ...\n", __FUNCTION__, DumpID );
 
+// check
+// check only single field
+   int NVar = 0;  // record number of target variables
+   int NMax = NCOMP_TOTAL + NDERIVE + 3; // all possible fields ( _TOTAL | _DERIVED | _POTE | _PAR_DENS | _TOTAL_DENS )
+
+   for (int v=0; v<NMax; v++)
+      if ( TVar & (1L<<v) )  NVar++;
+
+   if ( NVar != 1 )
+      Aux_Error( ERROR_INFO, "number of target variables is not one !!\n" );
+
 
 // 1. determine the FFT size
    const int Nx_Padded   = NX0_TOT[0]/2+1;

--- a/src/Output/Output_BasePowerSpectrum.cpp
+++ b/src/Output/Output_BasePowerSpectrum.cpp
@@ -76,7 +76,7 @@ void Output_BasePowerSpectrum( const char *FileName, const long TVar )
    int  *List_k      [MPI_NRank];   // local z coordinate of each patch slice sent to each rank
    int   List_NSend  [MPI_NRank];   // size of data sent to each rank
    int   List_NRecv  [MPI_NRank];   // size of data received from each rank
-   const bool InPlacePad  = true;   // padded the array for in-place real-to-complex FFT
+   const bool InPlacePad  = true;   // pad the array for in-place real-to-complex FFT
 
    if ( MPI_Rank == 0 )    PS_total = new double [Nx_Padded];
 

--- a/src/Output/Output_BasePowerSpectrum.cpp
+++ b/src/Output/Output_BasePowerSpectrum.cpp
@@ -6,7 +6,7 @@
 //#define DIMENSIONLESS_FORM
 
 
-static void GetBasePowerSpectrum( real *RhoK, const int j_start, const int dj, double *PS_total, double *NormDC );
+static void GetBasePowerSpectrum( real *VarK, const int j_start, const int dj, double *PS_total, double *NormDC );
 
 #ifdef SERIAL
 extern rfftwnd_plan     FFTW_Plan_PS;
@@ -19,11 +19,12 @@ extern rfftwnd_mpi_plan FFTW_Plan_PS;
 
 //-------------------------------------------------------------------------------------------------------
 // Function    :  Output_BasePowerSpectrum
-// Description :  Evaluate and output the base-level power spectrum by FFT
+// Description :  Evaluate and output the base-level power spectrum of the target variable by FFT
 //
 // Parameter   :  FileName : Name of the output file
+//                TVar     : Target variable
 //-------------------------------------------------------------------------------------------------------
-void Output_BasePowerSpectrum( const char *FileName )
+void Output_BasePowerSpectrum( const char *FileName, const long TVar )
 {
 
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d) ...\n", __FUNCTION__, DumpID );
@@ -65,49 +66,52 @@ void Output_BasePowerSpectrum( const char *FileName )
    const int NRecvSlice = MIN( List_z_start[MPI_Rank]+local_nz, NX0_TOT[2] ) - MIN( List_z_start[MPI_Rank], NX0_TOT[2] );
 
    double *PS_total     = NULL;
-   real   *RhoK         = new real [ total_local_size ];                         // array storing density
-   real   *SendBuf      = new real [ amr->NPatchComma[0][1]*CUBE(PS1) ];         // MPI send buffer for density
-   real   *RecvBuf      = new real [ NX0_TOT[0]*NX0_TOT[1]*NRecvSlice ];         // MPI recv buffer for density
+   real   *VarK         = new real [ total_local_size ];                         // array storing data
+   real   *SendBuf      = new real [ amr->NPatchComma[0][1]*CUBE(PS1) ];         // MPI send buffer for data
+   real   *RecvBuf      = new real [ NX0_TOT[0]*NX0_TOT[1]*NRecvSlice ];         // MPI recv buffer for data
    long   *SendBuf_SIdx = new long [ amr->NPatchComma[0][1]*PS1 ];               // MPI send buffer for 1D coordinate in slab
    long   *RecvBuf_SIdx = new long [ NX0_TOT[0]*NX0_TOT[1]*NRecvSlice/SQR(PS1) ];// MPI recv buffer for 1D coordinate in slab
 
    int  *List_PID    [MPI_NRank];   // PID of each patch slice sent to each rank
    int  *List_k      [MPI_NRank];   // local z coordinate of each patch slice sent to each rank
-   int   List_NSend  [MPI_NRank];   // size of data (density) sent to each rank
-   int   List_NRecv  [MPI_NRank];   // size of data (density) received from each rank
+   int   List_NSend  [MPI_NRank];   // size of data sent to each rank
+   int   List_NRecv  [MPI_NRank];   // size of data received from each rank
+   const bool InPlacePad  = true;   // padded the array for in-place real-to-complex FFT
 
    if ( MPI_Rank == 0 )    PS_total = new double [Nx_Padded];
 
 
 // 3. initialize the particle density array (rho_ext) and collect particles to the target level
-#  ifdef PARTICLE
-   const bool TimingSendPar_No = false;
-   const bool JustCountNPar_No = false;
-#  ifdef LOAD_BALANCE
-   const bool PredictPos       = amr->Par->PredictPos;
-   const bool SibBufPatch      = true;
-   const bool FaSibBufPatch    = true;
-#  else
-   const bool PredictPos       = false;
-   const bool SibBufPatch      = NULL_BOOL;
-   const bool FaSibBufPatch    = NULL_BOOL;
-#  endif
+   if ( TVar == _TOTAL_DENS ) {
+#     ifdef PARTICLE
+      const bool TimingSendPar_No = false;
+      const bool JustCountNPar_No = false;
+#     ifdef LOAD_BALANCE
+      const bool PredictPos       = amr->Par->PredictPos;
+      const bool SibBufPatch      = true;
+      const bool FaSibBufPatch    = true;
+#     else
+      const bool PredictPos       = false;
+      const bool SibBufPatch      = NULL_BOOL;
+      const bool FaSibBufPatch    = NULL_BOOL;
+#     endif
 
-   Prepare_PatchData_InitParticleDensityArray( 0 );
+      Prepare_PatchData_InitParticleDensityArray( 0 );
 
-   Par_CollectParticle2OneLevel( 0, _PAR_MASS|_PAR_POSX|_PAR_POSY|_PAR_POSZ|_PAR_TYPE, PredictPos, Time[0],
-                                 SibBufPatch, FaSibBufPatch, JustCountNPar_No, TimingSendPar_No );
-#  endif // #ifdef PARTICLE
+      Par_CollectParticle2OneLevel( 0, _PAR_MASS|_PAR_POSX|_PAR_POSY|_PAR_POSZ|_PAR_TYPE, PredictPos, Time[0],
+                                    SibBufPatch, FaSibBufPatch, JustCountNPar_No, TimingSendPar_No );
+#     endif // #ifdef PARTICLE
+   } // if ( TVar == _TOTAL_DENS )
 
 
 // 4. rearrange data from patch to slab
-   Patch2Slab( RhoK, SendBuf, RecvBuf, SendBuf_SIdx, RecvBuf_SIdx, List_PID, List_k, List_NSend, List_NRecv, List_z_start,
-               local_nz, FFT_Size, NRecvSlice, Time[0], _TOTAL_DENS, true, false );
+   Patch2Slab( VarK, SendBuf, RecvBuf, SendBuf_SIdx, RecvBuf_SIdx, List_PID, List_k, List_NSend, List_NRecv, List_z_start,
+               local_nz, FFT_Size, NRecvSlice, Time[0], TVar, InPlacePad, false );
 
 
 // 5. evaluate the base-level power spectrum by FFT
    double NormDC;  // to record the FFT DC value used for normalization
-   GetBasePowerSpectrum( RhoK, local_y_start_after_transpose, local_ny_after_transpose, PS_total, &NormDC );
+   GetBasePowerSpectrum( VarK, local_y_start_after_transpose, local_ny_after_transpose, PS_total, &NormDC );
 
 
 // 6. output the power spectrum
@@ -121,7 +125,7 @@ void Output_BasePowerSpectrum( const char *FileName )
       const double WaveK0 = 2.0*M_PI/amr->BoxSize[0];
       FILE *File = fopen( FileName, "w" );
 
-      fprintf( File, "# average density (DC) used for normalization = %13.7e\n", NormDC );
+      fprintf( File, "# average value (DC) used for normalization = %13.7e\n", NormDC );
       fprintf( File, "\n" );
       fprintf( File, "#%12s%4s%13s\n", "k", "", "Power" );
 
@@ -133,19 +137,21 @@ void Output_BasePowerSpectrum( const char *FileName )
 
 
 // 7. free memory
-   delete [] RhoK;
+   delete [] VarK;
    delete [] SendBuf;
    delete [] RecvBuf;
    delete [] SendBuf_SIdx;
    delete [] RecvBuf_SIdx;
    if ( MPI_Rank == 0 )    delete [] PS_total;
 
-// free memory for collecting particles from other ranks and levels, and free density arrays with ghost zones (rho_ext)
-#  ifdef PARTICLE
-   Par_CollectParticle2OneLevel_FreeMemory( 0, SibBufPatch, FaSibBufPatch );
+   if ( TVar == _TOTAL_DENS ) {
+//    free memory for collecting particles from other ranks and levels, and free density arrays with ghost zones (rho_ext)
+#     ifdef PARTICLE
+      Par_CollectParticle2OneLevel_FreeMemory( 0, SibBufPatch, FaSibBufPatch );
 
-   Prepare_PatchData_FreeParticleDensityArray( 0 );
-#  endif
+      Prepare_PatchData_FreeParticleDensityArray( 0 );
+#     endif
+   }
 
 
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d) ... done\n", __FUNCTION__, DumpID );
@@ -160,7 +166,7 @@ void Output_BasePowerSpectrum( const char *FileName )
 //
 // Note        :  Invoked by the function "Output_BasePowerSpectrum"
 //
-// Parameter   :  RhoK        : Array storing the input density
+// Parameter   :  VarK        : Array storing the input data
 //                j_start     : Starting j index
 //                dj          : Size of array in the j (y) direction after the forward FFT
 //                PS_total    : Power spectrum summed over all MPI ranks
@@ -168,7 +174,7 @@ void Output_BasePowerSpectrum( const char *FileName )
 //
 // Return      :  PS_total, NormDC
 //-------------------------------------------------------------------------------------------------------
-void GetBasePowerSpectrum( real *RhoK, const int j_start, const int dj, double *PS_total, double *NormDC )
+void GetBasePowerSpectrum( real *VarK, const int j_start, const int dj, double *PS_total, double *NormDC )
 {
 
 // check
@@ -188,14 +194,14 @@ void GetBasePowerSpectrum( real *RhoK, const int j_start, const int dj, double *
 
 // forward FFT
 #  ifdef SERIAL
-   rfftwnd_one_real_to_complex( FFTW_Plan_PS, RhoK, NULL );
+   rfftwnd_one_real_to_complex( FFTW_Plan_PS, VarK, NULL );
 #  else
-   rfftwnd_mpi( FFTW_Plan_PS, 1, RhoK, NULL, FFTW_TRANSPOSED_ORDER );
+   rfftwnd_mpi( FFTW_Plan_PS, 1, VarK, NULL, FFTW_TRANSPOSED_ORDER );
 #  endif
 
 
 // the data are now complex, so typecast a pointer
-   cdata = (fftw_complex*) RhoK;
+   cdata = (fftw_complex*) VarK;
 
 
 // set up the dimensionless wave number coefficients according to the FFTW data format
@@ -260,7 +266,7 @@ void GetBasePowerSpectrum( real *RhoK, const int j_start, const int dj, double *
 
 // normalization
    double Coeff;
-   double AveRho;
+   double AveVar;
    double Norm;
 
 #  ifdef DIMENSIONLESS_FORM
@@ -270,9 +276,9 @@ void GetBasePowerSpectrum( real *RhoK, const int j_start, const int dj, double *
 
    if ( MPI_Rank == 0 )
    {
-//    normalization: SQR(AveRho) accounts for Delta=Rho/AveRho
-      AveRho = SQRT(PS_total[0]/(double)Count_total[0]) / ( (double)Nx*(double)Ny*(double)Nz );  // from DC mode of FFT
-      Coeff  = amr->BoxSize[0]*amr->BoxSize[1]*amr->BoxSize[2] / SQR( (double)Nx*(double)Ny*(double)Nz*AveRho );
+//    normalization: SQR(AveVar) accounts for Delta=Var/AveVar
+      AveVar = SQRT(PS_total[0]/(double)Count_total[0]) / ( (double)Nx*(double)Ny*(double)Nz );  // from DC mode of FFT
+      Coeff  = amr->BoxSize[0]*amr->BoxSize[1]*amr->BoxSize[2] / SQR( (double)Nx*(double)Ny*(double)Nz*AveVar );
 
       for (int b=0; b<Nx_Padded; b++)
       {
@@ -289,7 +295,7 @@ void GetBasePowerSpectrum( real *RhoK, const int j_start, const int dj, double *
          PS_total[b] *= Norm;
       }
 
-      *NormDC = AveRho;
+      *NormDC = AveVar;
    }
 
 } // FUNCTION : GetBasePowerSpectrum

--- a/src/Output/Output_DumpData.cpp
+++ b/src/Output/Output_DumpData.cpp
@@ -265,7 +265,7 @@ void Output_DumpData( const int Stage )
             Aux_Error( ERROR_INFO, "Output_User_Ptr == NULL for OPT__OUTPUT_USER !!\n" );
       }
 #     ifdef SUPPORT_FFTW
-      if ( OPT__OUTPUT_BASEPS )           Output_BasePowerSpectrum( FileName_PS );
+      if ( OPT__OUTPUT_BASEPS )           Output_BasePowerSpectrum( FileName_PS, _TOTAL_DENS );
 #     endif
 #     ifdef PARTICLE
       if ( OPT__OUTPUT_PAR_MODE == OUTPUT_PAR_TEXT )  Par_Output_TextFile( FileName_Particle );

--- a/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_FFT.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_FFT.cpp
@@ -259,8 +259,8 @@ void CPU_PoissonSolver_FFT( const real Poi_Coeff, const int SaveSg, const double
 
 
 // rearrange data from patch to slab
-   Patch2Slab_Rho( RhoK, SendBuf, RecvBuf, SendBuf_SIdx, RecvBuf_SIdx, List_PID, List_k, List_NSend, List_NRecv, List_z_start,
-                   local_nz, FFT_Size, NRecvSlice, PrepTime, OPT__GRAVITY_EXTRA_MASS );
+   Patch2Slab( RhoK, SendBuf, RecvBuf, SendBuf_SIdx, RecvBuf_SIdx, List_PID, List_k, List_NSend, List_NRecv, List_z_start,
+               local_nz, FFT_Size, NRecvSlice, PrepTime, _TOTAL_DENS, true, OPT__GRAVITY_EXTRA_MASS );
 
 
 // evaluate potential by FFT
@@ -275,8 +275,8 @@ void CPU_PoissonSolver_FFT( const real Poi_Coeff, const int SaveSg, const double
 
 
 // rearrange data from slab back to patch
-   Slab2Patch_Pot( RhoK, RecvBuf, SendBuf, SaveSg, RecvBuf_SIdx, List_PID, List_k, List_NRecv, List_NSend,
-                   local_nz, FFT_Size, NRecvSlice );
+   Slab2Patch( RhoK, RecvBuf, SendBuf, SaveSg, RecvBuf_SIdx, List_PID, List_k, List_NRecv, List_NSend,
+               local_nz, FFT_Size, NRecvSlice, _POTE, true );
 
 
    delete [] RhoK;

--- a/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_FFT.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_FFT.cpp
@@ -251,6 +251,7 @@ void CPU_PoissonSolver_FFT( const real Poi_Coeff, const int SaveSg, const double
    int  *List_k      [MPI_NRank];   // local z coordinate of each patch slice sent to each rank
    int   List_NSend  [MPI_NRank];   // size of data (density/potential) sent to each rank
    int   List_NRecv  [MPI_NRank];   // size of data (density/potential) received from each rank
+   const bool InPlacePad  = true;   // padded the array for in-place real-to-complex FFT
 
 
 // initialize RhoK as zeros for the isolated BC where the zero-padding method is adopted
@@ -260,7 +261,7 @@ void CPU_PoissonSolver_FFT( const real Poi_Coeff, const int SaveSg, const double
 
 // rearrange data from patch to slab
    Patch2Slab( RhoK, SendBuf, RecvBuf, SendBuf_SIdx, RecvBuf_SIdx, List_PID, List_k, List_NSend, List_NRecv, List_z_start,
-               local_nz, FFT_Size, NRecvSlice, PrepTime, _TOTAL_DENS, true, OPT__GRAVITY_EXTRA_MASS );
+               local_nz, FFT_Size, NRecvSlice, PrepTime, _TOTAL_DENS, InPlacePad, OPT__GRAVITY_EXTRA_MASS );
 
 
 // evaluate potential by FFT

--- a/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_FFT.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_FFT.cpp
@@ -251,7 +251,7 @@ void CPU_PoissonSolver_FFT( const real Poi_Coeff, const int SaveSg, const double
    int  *List_k      [MPI_NRank];   // local z coordinate of each patch slice sent to each rank
    int   List_NSend  [MPI_NRank];   // size of data (density/potential) sent to each rank
    int   List_NRecv  [MPI_NRank];   // size of data (density/potential) received from each rank
-   const bool InPlacePad  = true;   // padded the array for in-place real-to-complex FFT
+   const bool InPlacePad  = true;   // pad the array for in-place real-to-complex FFT
 
 
 // initialize RhoK as zeros for the isolated BC where the zero-padding method is adopted

--- a/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_FFT.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_FFT.cpp
@@ -277,7 +277,7 @@ void CPU_PoissonSolver_FFT( const real Poi_Coeff, const int SaveSg, const double
 
 // rearrange data from slab back to patch
    Slab2Patch( RhoK, RecvBuf, SendBuf, SaveSg, RecvBuf_SIdx, List_PID, List_k, List_NRecv, List_NSend,
-               local_nz, FFT_Size, NRecvSlice, _POTE, true );
+               local_nz, FFT_Size, NRecvSlice, _POTE, InPlacePad );
 
 
    delete [] RhoK;

--- a/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_FFT.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_FFT.cpp
@@ -251,6 +251,7 @@ void CPU_PoissonSolver_FFT( const real Poi_Coeff, const int SaveSg, const double
    int  *List_k      [MPI_NRank];   // local z coordinate of each patch slice sent to each rank
    int   List_NSend  [MPI_NRank];   // size of data (density/potential) sent to each rank
    int   List_NRecv  [MPI_NRank];   // size of data (density/potential) received from each rank
+   const bool ForPoisson  = true;   // preparing the density field for the Poisson solver
    const bool InPlacePad  = true;   // pad the array for in-place real-to-complex FFT
 
 
@@ -261,7 +262,7 @@ void CPU_PoissonSolver_FFT( const real Poi_Coeff, const int SaveSg, const double
 
 // rearrange data from patch to slab
    Patch2Slab( RhoK, SendBuf, RecvBuf, SendBuf_SIdx, RecvBuf_SIdx, List_PID, List_k, List_NSend, List_NRecv, List_z_start,
-               local_nz, FFT_Size, NRecvSlice, PrepTime, _TOTAL_DENS, InPlacePad, OPT__GRAVITY_EXTRA_MASS );
+               local_nz, FFT_Size, NRecvSlice, PrepTime, _TOTAL_DENS, InPlacePad, ForPoisson, OPT__GRAVITY_EXTRA_MASS );
 
 
 // evaluate potential by FFT

--- a/src/TestProblem/Hydro/EnergyPowerSpectrum/Init_TestProb_Hydro_EnergyPowerSpectrum.cpp
+++ b/src/TestProblem/Hydro/EnergyPowerSpectrum/Init_TestProb_Hydro_EnergyPowerSpectrum.cpp
@@ -80,7 +80,7 @@ void Validate()
 
 
 
-#if ( MODEL == HYDRO )
+#if ( MODEL == HYDRO  &&  defined SUPPORT_FFTW )
 //-------------------------------------------------------------------------------------------------------
 // Function    :  SetParameter
 // Description :  Load and set the problem-specific runtime parameters
@@ -209,7 +209,7 @@ void OutputEnergyPowerSpectrum()
    Output_BasePowerSpectrum( FileName_EnergyPS, _ENGY );
 
 } // FUNCTION : OutputEnergyPowerSpectrum
-#endif // #if ( MODEL == HYDRO )
+#endif // #if ( MODEL == HYDRO  &&  defined SUPPORT_FFTW )
 
 
 
@@ -233,7 +233,7 @@ void Init_TestProb_Hydro_EnergyPowerSpectrum()
    Validate();
 
 
-#  if ( MODEL == HYDRO )
+#  if ( MODEL == HYDRO  &&  defined SUPPORT_FFTW )
 // set the problem-specific runtime parameters
    SetParameter();
 
@@ -241,7 +241,7 @@ void Init_TestProb_Hydro_EnergyPowerSpectrum()
 // set the function pointers of various problem-specific routines
    Init_Function_User_Ptr = SetGridIC;
    Output_User_Ptr        = OutputEnergyPowerSpectrum;
-#  endif // #if ( MODEL == HYDRO )
+#  endif // #if ( MODEL == HYDRO  &&  defined SUPPORT_FFTW )
 
 
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ... done\n", __FUNCTION__ );

--- a/src/TestProblem/Hydro/EnergyPowerSpectrum/Init_TestProb_Hydro_EnergyPowerSpectrum.cpp
+++ b/src/TestProblem/Hydro/EnergyPowerSpectrum/Init_TestProb_Hydro_EnergyPowerSpectrum.cpp
@@ -58,10 +58,6 @@ void Validate()
    if ( amr->BoxSize[0] != amr->BoxSize[1] || amr->BoxSize[0] != amr->BoxSize[2] )
       Aux_Error( ERROR_INFO, "simulation domain must be cubic !!\n" );
 
-   for (int f=0; f<6; f++)
-   if ( OPT__BC_FLU[f] != BC_FLU_PERIODIC )
-      Aux_Error( ERROR_INFO, "please set \"OPT__BC_FLU_* = 1\" (i.e., periodic BC) !!\n" );
-
    if ( !OPT__OUTPUT_USER )
       Aux_Error( ERROR_INFO, "please set \"OPT__OUTPUT_USER = 1\" !!\n" );
 

--- a/src/TestProblem/Hydro/EnergyPowerSpectrum/Init_TestProb_Hydro_EnergyPowerSpectrum.cpp
+++ b/src/TestProblem/Hydro/EnergyPowerSpectrum/Init_TestProb_Hydro_EnergyPowerSpectrum.cpp
@@ -1,0 +1,249 @@
+#include "GAMER.h"
+#include "TestProb.h"
+
+
+
+static void OutputEnergyPowerSpectrum();
+
+
+// problem-specific global variables
+// =======================================================================================
+static double Energy_GauWidth;           // width of gaussian distribution
+// =======================================================================================
+
+
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  Validate
+// Description :  Validate the compilation flags and runtime parameters for this test problem
+//
+// Note        :  None
+//
+// Parameter   :  None
+//
+// Return      :  None
+//-------------------------------------------------------------------------------------------------------
+void Validate()
+{
+
+   if ( MPI_Rank == 0 )    Aux_Message( stdout, "   Validating test problem %d ...\n", TESTPROB_ID );
+
+
+// errors
+#  if ( MODEL != HYDRO )
+   Aux_Error( ERROR_INFO, "MODEL != HYDRO !!\n" );
+#  endif
+
+#  ifndef SUPPORT_FFTW
+   Aux_Error( ERROR_INFO, "SUPPORT_FFTW must be enabled !!\n" );
+#  endif
+
+#  ifdef GRAVITY
+   Aux_Error( ERROR_INFO, "GRAVITY must be disabled !!\n" );
+#  endif
+
+#  ifdef COMOVING
+   Aux_Error( ERROR_INFO, "COMOVING must be disabled !!\n" );
+#  endif
+
+#  ifdef PARTICLE
+   Aux_Error( ERROR_INFO, "PARTICLE must be disabled !!\n" );
+#  endif
+
+#  ifdef MHD
+   Aux_Error( ERROR_INFO, "MHD must be disabled !!\n" );
+#  endif
+
+#  if ( EOS != EOS_GAMMA )
+   Aux_Error( ERROR_INFO, "EOS != EOS_GAMMA !!\n" );
+#  endif
+
+   if ( amr->BoxSize[0] != amr->BoxSize[1] || amr->BoxSize[0] != amr->BoxSize[2] )
+      Aux_Error( ERROR_INFO, "simulation domain must be cubic !!\n" );
+
+   for (int f=0; f<6; f++)
+   if ( OPT__BC_FLU[f] != BC_FLU_PERIODIC )
+      Aux_Error( ERROR_INFO, "please set \"OPT__BC_FLU_* = 1\" (i.e., periodic BC) !!\n" );
+
+
+// warnings
+   if ( MPI_Rank == 0 )
+   {
+      if ( !OPT__OUTPUT_USER )   Aux_Message( stdout, "WARNING : OPT__OUTPUT_USER is off !!\n" );
+   }
+
+
+   if ( MPI_Rank == 0 )    Aux_Message( stdout, "   Validating test problem %d ... done\n", TESTPROB_ID );
+
+} // FUNCTION : Validate
+
+
+
+#if ( MODEL == HYDRO )
+//-------------------------------------------------------------------------------------------------------
+// Function    :  SetParameter
+// Description :  Load and set the problem-specific runtime parameters
+//
+// Note        :  1. Filename is set to "Input__TestProb" by default
+//                2. Major tasks in this function:
+//                   (1) load the problem-specific runtime parameters
+//                   (2) set the problem-specific derived parameters
+//                   (3) reset other general-purpose parameters if necessary
+//                   (4) make a note of the problem-specific parameters
+//
+// Parameter   :  None
+//
+// Return      :  None
+//-------------------------------------------------------------------------------------------------------
+void SetParameter()
+{
+
+   if ( MPI_Rank == 0 )    Aux_Message( stdout, "   Setting runtime parameters ...\n" );
+
+
+// (1) load the problem-specific runtime parameters
+   const char FileName[] = "Input__TestProb";
+   ReadPara_t *ReadPara  = new ReadPara_t;
+
+// add parameters in the following format:
+// --> note that VARIABLE, DEFAULT, MIN, and MAX must have the same data type
+// --> some handy constants (e.g., NoMin_int, Eps_float, ...) are defined in "include/ReadPara.h"
+// ********************************************************************************************************************************
+// ReadPara->Add( "KEY_IN_THE_FILE",   &VARIABLE,              DEFAULT,       MIN,              MAX               );
+// ********************************************************************************************************************************
+   ReadPara->Add( "Energy_GauWidth",   &Energy_GauWidth,          0.01,       Eps_double,       NoMax_double      );
+
+   ReadPara->Read( FileName );
+
+   delete ReadPara;
+
+
+// (2) set the problem-specific derived parameters
+
+
+// (3) reset other general-purpose parameters
+//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+   const double End_T_Default    = 0.0;
+   const long   End_Step_Default = __INT_MAX__;
+
+   if ( END_STEP < 0 ) {
+      END_STEP = End_Step_Default;
+      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+   }
+
+   if ( END_T < 0.0 ) {
+      END_T = End_T_Default;
+      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+   }
+
+
+// (4) make a note
+   if ( MPI_Rank == 0 )
+   {
+      Aux_Message( stdout, "=============================================================================\n" );
+      Aux_Message( stdout, "  test problem ID         = %d\n",      TESTPROB_ID );
+      Aux_Message( stdout, "  energy gaussian width   = %14.7e\n",  Energy_GauWidth );
+      Aux_Message( stdout, "=============================================================================\n" );
+   }
+
+
+   if ( MPI_Rank == 0 )    Aux_Message( stdout, "   Setting runtime parameters ... done\n" );
+
+} // FUNCTION : SetParameter
+
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  SetGridIC
+// Description :  Set the problem-specific initial condition on grids
+//
+// Note        :  1. This function may also be used to estimate the numerical errors when OPT__OUTPUT_USER is enabled
+//                   --> In this case, it should provide the analytical solution at the given "Time"
+//                2. This function will be invoked by multiple OpenMP threads when OPENMP is enabled
+//                   --> Please ensure that everything here is thread-safe
+//                3. Even when DUAL_ENERGY is adopted for HYDRO, one does NOT need to set the dual-energy variable here
+//                   --> It will be calculated automatically
+//
+// Parameter   :  fluid    : Fluid field to be initialized
+//                x/y/z    : Physical coordinates
+//                Time     : Physical time
+//                lv       : Target refinement level
+//                AuxArray : Auxiliary array
+//
+// Return      :  fluid
+//-------------------------------------------------------------------------------------------------------
+void SetGridIC( real fluid[], const double x, const double y, const double z, const double Time,
+                const int lv, double AuxArray[] )
+{
+
+   const double r = SQRT( SQR(x-0.5*amr->BoxSize[0]) + SQR(y-0.5*amr->BoxSize[1]) + SQR(z-0.5*amr->BoxSize[2]) );
+
+// set the output array
+   fluid[DENS] = 1.0;
+   fluid[MOMX] = 0.0;
+   fluid[MOMY] = 0.0;
+   fluid[MOMZ] = 0.0;
+   fluid[ENGY] = CUBE(1.0/SQRT(2.0*M_PI*SQR(Energy_GauWidth)))*exp(-0.5*SQR(r/Energy_GauWidth));
+
+} // FUNCTION : SetGridIC
+
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  OutputEnergyPowerSpectrum
+// Description :  Output the energy power spectrum
+//
+// Note        :  1. Invoke Output_BasePowerSpectrum()
+//
+// Parameter   :  None
+//
+// Return      :  None
+//-------------------------------------------------------------------------------------------------------
+void OutputEnergyPowerSpectrum()
+{
+
+   char FileName_EnergyPS[50];
+   sprintf( FileName_EnergyPS, "EnergyPowerSpectrum_%06d", DumpID );
+
+   Output_BasePowerSpectrum( FileName_EnergyPS, _ENGY );
+
+} // FUNCTION : OutputEnergyPowerSpectrum
+#endif // #if ( MODEL == HYDRO )
+
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  Init_TestProb_Hydro_EnergyPowerSpectrum
+// Description :  Test problem initializer
+//
+// Note        :  None
+//
+// Parameter   :  None
+//
+// Return      :  None
+//-------------------------------------------------------------------------------------------------------
+void Init_TestProb_Hydro_EnergyPowerSpectrum()
+{
+
+   if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ...\n", __FUNCTION__ );
+
+
+// validate the compilation flags and runtime parameters
+   Validate();
+
+
+#  if ( MODEL == HYDRO )
+// set the problem-specific runtime parameters
+   SetParameter();
+
+
+// set the function pointers of various problem-specific routines
+   Init_Function_User_Ptr = SetGridIC;
+   Output_User_Ptr        = OutputEnergyPowerSpectrum;
+#  endif // #if ( MODEL == HYDRO )
+
+
+   if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ... done\n", __FUNCTION__ );
+
+} // FUNCTION : Init_TestProb_Hydro_EnergyPowerSpectrum

--- a/src/TestProblem/Hydro/EnergyPowerSpectrum/Init_TestProb_Hydro_EnergyPowerSpectrum.cpp
+++ b/src/TestProblem/Hydro/EnergyPowerSpectrum/Init_TestProb_Hydro_EnergyPowerSpectrum.cpp
@@ -39,10 +39,6 @@ void Validate()
    Aux_Error( ERROR_INFO, "SUPPORT_FFTW must be enabled !!\n" );
 #  endif
 
-#  ifdef GRAVITY
-   Aux_Error( ERROR_INFO, "GRAVITY must be disabled !!\n" );
-#  endif
-
 #  ifdef COMOVING
    Aux_Error( ERROR_INFO, "COMOVING must be disabled !!\n" );
 #  endif
@@ -66,12 +62,11 @@ void Validate()
    if ( OPT__BC_FLU[f] != BC_FLU_PERIODIC )
       Aux_Error( ERROR_INFO, "please set \"OPT__BC_FLU_* = 1\" (i.e., periodic BC) !!\n" );
 
+   if ( !OPT__OUTPUT_USER )
+      Aux_Error( ERROR_INFO, "please set \"OPT__OUTPUT_USER = 1\" !!\n" );
+
 
 // warnings
-   if ( MPI_Rank == 0 )
-   {
-      if ( !OPT__OUTPUT_USER )   Aux_Message( stdout, "WARNING : OPT__OUTPUT_USER is off !!\n" );
-   }
 
 
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "   Validating test problem %d ... done\n", TESTPROB_ID );
@@ -125,7 +120,7 @@ void SetParameter()
 // (3) reset other general-purpose parameters
 //     --> a helper macro PRINT_WARNING is defined in TestProb.h
    const double End_T_Default    = 0.0;
-   const long   End_Step_Default = __INT_MAX__;
+   const long   End_Step_Default = 0;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
@@ -177,14 +172,14 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
                 const int lv, double AuxArray[] )
 {
 
-   const double r = SQRT( SQR(x-0.5*amr->BoxSize[0]) + SQR(y-0.5*amr->BoxSize[1]) + SQR(z-0.5*amr->BoxSize[2]) );
+   const double r = sqrt( SQR(x-amr->BoxCenter[0]) + SQR(y-amr->BoxCenter[1]) + SQR(z-0.5*amr->BoxCenter[2]) );
 
 // set the output array
    fluid[DENS] = 1.0;
    fluid[MOMX] = 0.0;
    fluid[MOMY] = 0.0;
    fluid[MOMZ] = 0.0;
-   fluid[ENGY] = CUBE(1.0/SQRT(2.0*M_PI*SQR(Energy_GauWidth)))*exp(-0.5*SQR(r/Energy_GauWidth));
+   fluid[ENGY] = CUBE(1.0/sqrt(2.0*M_PI*SQR(Energy_GauWidth)))*exp(-0.5*SQR(r/Energy_GauWidth));
 
 } // FUNCTION : SetGridIC
 
@@ -203,7 +198,7 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
 void OutputEnergyPowerSpectrum()
 {
 
-   char FileName_EnergyPS[50];
+   char FileName_EnergyPS[MAX_STRING];
    sprintf( FileName_EnergyPS, "EnergyPowerSpectrum_%06d", DumpID );
 
    Output_BasePowerSpectrum( FileName_EnergyPS, _ENGY );


### PR DESCRIPTION
- Generalize the `Patch2Slab()` and `Slab2Patch()` for variables other than density for future use (For example, to prepare the wave function fields for FFT).

     - Add a argument `TVar` to decide the target variable.

    - Add a new argument  `InPlacePad`, in case there are complex fields (like wave function), which don't need the in-place array padding for real-to-complex FFT, .

- Generalize the `Output_BasePowerSpectrum()` for other variables like energy.

- Add a new test problem `EnergyPowerSpectrum` to demo the output power spectrum of a Gaussian energy distribution is the same as analytical solution.
