### PR TITLE
Remove including `libyt_interactive_mode.h` lines

### DIFF
--- a/include/GAMER.h
+++ b/include/GAMER.h
@@ -65,9 +65,6 @@ extern "C" {
 
 #ifdef SUPPORT_LIBYT
 #  include <libyt.h>
-# ifdef LIBYT_INTERACTIVE
-#  include <libyt_interactive_mode.h>
-# endif
 #endif
 
 #include "Macro.h"


### PR DESCRIPTION
Remove including `libyt_interactive_mode.h` since it has been moved into `libyt.h`.