### PR TITLE
Support initializing the magnetic field by vector potential from functions

### DIFF
--- a/example/test_problem/Hydro/Bondi/Input__Parameter
+++ b/example/test_problem/Hydro/Bondi/Input__Parameter
@@ -155,8 +155,8 @@ OPT__EXT_POT                  0           # add external potential    (0=off, 1=
 
 # initialization
 OPT__INIT                     1           # initialization option: (1=FUNCTION, 2=RESTART, 3=FILE->"UM_IC")
-OPT__INIT_BFIELD_BYFILE       0           # initialize the magnetic field from a vector potential disk file named "B_IC"
-                                          # (example python script: tool/inits/gen_vec_pot.py) [0] ##MHD ONLY##
+OPT__INIT_BFIELD_BYVECPOT     0           # initialize the magnetic field from vector potential
+                                          # (0=off, 1=external disk file named "B_IC", see tool/inits/gen_vec_pot.py for example, 2=function) [0] ##MHD ONLY##
 RESTART_LOAD_NRANK            1           # number of parallel I/O (i.e., number of MPI ranks) for restart [1]
 OPT__RESTART_RESET            0           # reset some simulation status parameters (e.g., current step and time) during restart [0]
 OPT__UM_IC_LEVEL              0           # starting AMR level in UM_IC [0]

--- a/example/test_problem/Hydro/CMZ/Input__Parameter
+++ b/example/test_problem/Hydro/CMZ/Input__Parameter
@@ -219,8 +219,8 @@ EXT_POT_TABLE_EDGEL_Z         -0.13125
 
 # initialization
 OPT__INIT                     1           # initialization option: (1=FUNCTION, 2=RESTART, 3=FILE->"UM_IC")
-OPT__INIT_BFIELD_BYFILE       0           # initialize the magnetic field from a vector potential disk file named "B_IC"
-                                          # (example python script: tool/inits/gen_vec_pot.py) [0] ##MHD ONLY##
+OPT__INIT_BFIELD_BYVECPOT     0           # initialize the magnetic field from vector potential
+                                          # (0=off, 1=external disk file named "B_IC", see tool/inits/gen_vec_pot.py for example, 2=function) [0] ##MHD ONLY##
 RESTART_LOAD_NRANK            256         # number of parallel I/O (i.e., number of MPI ranks) for restart [1]
 OPT__RESTART_RESET            0           # reset some simulation status parameters (e.g., current step and time) during restart [0]
 OPT__INIT_RESTRICT            1           # restrict all data during the initialization [1]

--- a/example/test_problem/Hydro/ClusterMerger/Input__Parameter
+++ b/example/test_problem/Hydro/ClusterMerger/Input__Parameter
@@ -168,7 +168,8 @@ RESTART_LOAD_NRANK            1           # number of parallel I/O (i.e., number
 OPT__INIT_RESTRICT            1           # restrict all data during the initialization [1]
 OPT__GPUID_SELECT            -1           # GPU ID selection mode: (-3=Laohu, -2=CUDA, -1=MPI rank, >=0=input) [-1]
 INIT_SUBSAMPLING_NCELL        3           # perform sub-sampling during initialization: (0=off, >0=# of sub-sampling cells) [0]
-OPT__INIT_BFIELD_BYFILE       1
+OPT__INIT_BFIELD_BYVECPOT     1           # initialize the magnetic field from vector potential
+                                          # (0=off, 1=external disk file named "B_IC", see tool/inits/gen_vec_pot.py for example, 2=function) [0] ##MHD ONLY##
 
 
 # interpolation schemes: (-1=auto, 1=MinMod-3D, 2=MinMod-1D, 3=vanLeer, 4=CQuad, 5=Quad, 6=CQuar, 7=Quar)

--- a/example/test_problem/Template/Input__Parameter
+++ b/example/test_problem/Template/Input__Parameter
@@ -286,8 +286,8 @@ OPT__GRAVITY_EXTRA_MASS       0           # add extra mass source when computing
 
 # initialization
 OPT__INIT                     1           # initialization option: (1=FUNCTION, 2=RESTART, 3=FILE->"UM_IC")
-OPT__INIT_BFIELD_BYFILE       0           # initialize the magnetic field from a vector potential disk file named "B_IC"
-                                          # (example python script: tool/inits/gen_vec_pot.py) [0] ##MHD ONLY##
+OPT__INIT_BFIELD_BYVECPOT     0           # initialize the magnetic field from vector potential
+                                          # (0=off, 1=external disk file named "B_IC", see tool/inits/gen_vec_pot.py for example, 2=function) [0] ##MHD ONLY##
 RESTART_LOAD_NRANK            1           # number of parallel I/O (i.e., number of MPI ranks) for restart [1]
 OPT__RESTART_RESET            0           # reset some simulation status parameters (e.g., current step and time) during restart [0]
 OPT__UM_IC_LEVEL              0           # starting AMR level in UM_IC [0]

--- a/include/Global.h
+++ b/include/Global.h
@@ -111,9 +111,9 @@ extern double           FlagTable_Current[NLEVEL-1], INT_MONO_COEFF_B;
 extern IntScheme_t      OPT__MAG_INT_SCHEME, OPT__REF_MAG_INT_SCHEME;
 extern bool             OPT__FIXUP_ELECTRIC, OPT__CK_INTERFACE_B, OPT__OUTPUT_CC_MAG, OPT__FLAG_CURRENT;
 extern bool             OPT__OUTPUT_DIVMAG;
-extern int              OPT__CK_DIVERGENCE_B;
+extern int              OPT__CK_DIVERGENCE_B, OPT__INIT_BFIELD_BYVECPOT;
 extern double           UNIT_B;
-extern bool             OPT__INIT_BFIELD_BYFILE, OPT__SAME_INTERFACE_B;
+extern bool             OPT__SAME_INTERFACE_B;
 #endif
 
 #elif ( MODEL == ELBDM )

--- a/include/Global.h
+++ b/include/Global.h
@@ -111,9 +111,11 @@ extern double           FlagTable_Current[NLEVEL-1], INT_MONO_COEFF_B;
 extern IntScheme_t      OPT__MAG_INT_SCHEME, OPT__REF_MAG_INT_SCHEME;
 extern bool             OPT__FIXUP_ELECTRIC, OPT__CK_INTERFACE_B, OPT__OUTPUT_CC_MAG, OPT__FLAG_CURRENT;
 extern bool             OPT__OUTPUT_DIVMAG;
-extern int              OPT__CK_DIVERGENCE_B, OPT__INIT_BFIELD_BYVECPOT;
+extern int              OPT__CK_DIVERGENCE_B;
 extern double           UNIT_B;
 extern bool             OPT__SAME_INTERFACE_B;
+
+extern OptInitMagByVecPot_t OPT__INIT_BFIELD_BYVECPOT;
 #endif
 
 #elif ( MODEL == ELBDM )

--- a/include/HDF5_Typedef.h
+++ b/include/HDF5_Typedef.h
@@ -634,7 +634,7 @@ struct InputPara_t
    int    Opt__GPUID_Select;
    int    Init_Subsampling_NCell;
 #  ifdef MHD
-   int    Opt__InitBFieldByFile;
+   int    Opt__InitBFieldByVecPot;
 #  endif
 #  ifdef SUPPORT_FFTW
    int    Opt__FFTW_Startup;

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -524,6 +524,7 @@ void MHD_BoundaryCondition_User( real **Array, const int BC_Face, const int NVar
                                  const int Idx_Start[], const int Idx_End[], const int TVarIdxList[],
                                  const double Time, const double dh, const double *Corner, const int lv );
 void MHD_Init_BField_ByVecPot_File( const int B_lv );
+void MHD_Init_BField_ByVecPot_Function( const int B_lv );
 #ifdef LOAD_BALANCE
 void MHD_LB_EnsureBFieldConsistencyAfterRestrict( const int lv );
 void MHD_LB_AllocateElectricArray( const int FaLv );

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -523,7 +523,7 @@ void MHD_BoundaryCondition_User( real **Array, const int BC_Face, const int NVar
                                  const int ArraySizeX, const int ArraySizeY, const int ArraySizeZ,
                                  const int Idx_Start[], const int Idx_End[], const int TVarIdxList[],
                                  const double Time, const double dh, const double *Corner, const int lv );
-void MHD_Init_BField_ByFile( const int B_lv );
+void MHD_Init_BField_ByVecPot_File( const int B_lv );
 #ifdef LOAD_BALANCE
 void MHD_LB_EnsureBFieldConsistencyAfterRestrict( const int lv );
 void MHD_LB_AllocateElectricArray( const int FaLv );

--- a/include/TestProb.h
+++ b/include/TestProb.h
@@ -24,8 +24,8 @@ extern void (*Init_Function_User_Ptr)( real fluid[], const double x, const doubl
 #ifdef MHD
 extern void (*Init_Function_BField_User_Ptr)( real magnetic[], const double x, const double y, const double z, const double Time,
                                               const int lv, double AuxArray[] );
-extern void (*Init_BField_ByVecPot_User_Ptr)( double *mag_vecpot, const double x, const double y, const double z, const double Time,
-                                              const int lv, const char Axis, double AuxArray[] );
+extern double (*Init_BField_ByVecPot_User_Ptr)( const double x, const double y, const double z, const double Time,
+                                                const int lv, const char Axis, double AuxArray[] );
 #endif
 extern void (*Init_ByFile_User_Ptr)( real fluid_out[], const real fluid_in[], const int nvar_in,
                                      const double x, const double y, const double z, const double Time,

--- a/include/TestProb.h
+++ b/include/TestProb.h
@@ -24,6 +24,8 @@ extern void (*Init_Function_User_Ptr)( real fluid[], const double x, const doubl
 #ifdef MHD
 extern void (*Init_Function_BField_User_Ptr)( real magnetic[], const double x, const double y, const double z, const double Time,
                                               const int lv, double AuxArray[] );
+extern void (*Init_BField_ByVecPot_User_Ptr)( double *mag_vecpot, const double x, const double y, const double z, const double Time,
+                                              const int lv, const char Axis, double AuxArray[] );
 #endif
 extern void (*Init_ByFile_User_Ptr)( real fluid_out[], const real fluid_in[], const int nvar_in,
                                      const double x, const double y, const double z, const double Time,

--- a/include/TestProb.h
+++ b/include/TestProb.h
@@ -25,7 +25,7 @@ extern void (*Init_Function_User_Ptr)( real fluid[], const double x, const doubl
 extern void (*Init_Function_BField_User_Ptr)( real magnetic[], const double x, const double y, const double z, const double Time,
                                               const int lv, double AuxArray[] );
 extern double (*Init_BField_ByVecPot_User_Ptr)( const double x, const double y, const double z, const double Time,
-                                                const int lv, const char Axis, double AuxArray[] );
+                                                const int lv, const char Component, double AuxArray[] );
 #endif
 extern void (*Init_ByFile_User_Ptr)( real fluid_out[], const real fluid_in[], const int nvar_in,
                                      const double x, const double y, const double z, const double Time,

--- a/include/Typedef.h
+++ b/include/Typedef.h
@@ -67,6 +67,14 @@ const OptInit_t
    INIT_BY_FILE     = 3;
 
 
+// program initialization options for the magnetic field by vector potential
+typedef int OptInitMagByVecPot_t;
+const OptInitMagByVecPot_t
+   INIT_MAG_BYVECPOT_NONE = 0,
+   INIT_MAG_BYVECPOT_FILE = 1,
+   INIT_MAG_BYVECPOT_FUNC = 2;
+
+
 // data format for OPT__INIT=INIT_BY_FILE
 typedef int UM_IC_Format_t;
 const UM_IC_Format_t

--- a/src/Auxiliary/Aux_TakeNote.cpp
+++ b/src/Auxiliary/Aux_TakeNote.cpp
@@ -1184,22 +1184,22 @@ void Aux_TakeNote()
 //    record the parameters of initialization
       fprintf( Note, "Parameters of Initialization\n" );
       fprintf( Note, "***********************************************************************************\n" );
-      fprintf( Note, "OPT__INIT                       %d\n",      OPT__INIT               );
-      fprintf( Note, "RESTART_LOAD_NRANK              %d\n",      RESTART_LOAD_NRANK      );
-      fprintf( Note, "OPT__RESTART_RESET              %d\n",      OPT__RESTART_RESET      );
-      fprintf( Note, "OPT__UM_IC_LEVEL                %d\n",      OPT__UM_IC_LEVEL        );
-      fprintf( Note, "OPT__UM_IC_NLEVEL               %d\n",      OPT__UM_IC_NLEVEL       );
-      fprintf( Note, "OPT__UM_IC_NVAR                 %d\n",      OPT__UM_IC_NVAR         );
-      fprintf( Note, "OPT__UM_IC_FORMAT               %d\n",      OPT__UM_IC_FORMAT       );
-      fprintf( Note, "OPT__UM_IC_DOWNGRADE            %d\n",      OPT__UM_IC_DOWNGRADE    );
-      fprintf( Note, "OPT__UM_IC_REFINE               %d\n",      OPT__UM_IC_REFINE       );
-      fprintf( Note, "OPT__UM_IC_LOAD_NRANK           %d\n",      OPT__UM_IC_LOAD_NRANK   );
-      fprintf( Note, "OPT__INIT_RESTRICT              %d\n",      OPT__INIT_RESTRICT      );
-      fprintf( Note, "OPT__INIT_GRID_WITH_OMP         %d\n",      OPT__INIT_GRID_WITH_OMP );
-      fprintf( Note, "OPT__GPUID_SELECT               %d\n",      OPT__GPUID_SELECT       );
-      fprintf( Note, "INIT_SUBSAMPLING_NCELL          %d\n",      INIT_SUBSAMPLING_NCELL  );
+      fprintf( Note, "OPT__INIT                       %d\n",      OPT__INIT                 );
+      fprintf( Note, "RESTART_LOAD_NRANK              %d\n",      RESTART_LOAD_NRANK        );
+      fprintf( Note, "OPT__RESTART_RESET              %d\n",      OPT__RESTART_RESET        );
+      fprintf( Note, "OPT__UM_IC_LEVEL                %d\n",      OPT__UM_IC_LEVEL          );
+      fprintf( Note, "OPT__UM_IC_NLEVEL               %d\n",      OPT__UM_IC_NLEVEL         );
+      fprintf( Note, "OPT__UM_IC_NVAR                 %d\n",      OPT__UM_IC_NVAR           );
+      fprintf( Note, "OPT__UM_IC_FORMAT               %d\n",      OPT__UM_IC_FORMAT         );
+      fprintf( Note, "OPT__UM_IC_DOWNGRADE            %d\n",      OPT__UM_IC_DOWNGRADE      );
+      fprintf( Note, "OPT__UM_IC_REFINE               %d\n",      OPT__UM_IC_REFINE         );
+      fprintf( Note, "OPT__UM_IC_LOAD_NRANK           %d\n",      OPT__UM_IC_LOAD_NRANK     );
+      fprintf( Note, "OPT__INIT_RESTRICT              %d\n",      OPT__INIT_RESTRICT        );
+      fprintf( Note, "OPT__INIT_GRID_WITH_OMP         %d\n",      OPT__INIT_GRID_WITH_OMP   );
+      fprintf( Note, "OPT__GPUID_SELECT               %d\n",      OPT__GPUID_SELECT         );
+      fprintf( Note, "INIT_SUBSAMPLING_NCELL          %d\n",      INIT_SUBSAMPLING_NCELL    );
 #     ifdef MHD
-      fprintf( Note, "OPT__INIT_BFIELD_BYFILE         %d\n",      OPT__INIT_BFIELD_BYFILE );
+      fprintf( Note, "OPT__INIT_BFIELD_BYVECPOT       %d\n",      OPT__INIT_BFIELD_BYVECPOT );
 #     endif
 #     ifdef SUPPORT_FFTW
       fprintf( Note, "OPT__FFTW_STARTUP               " );

--- a/src/Init/Init_ByRestart_HDF5.cpp
+++ b/src/Init/Init_ByRestart_HDF5.cpp
@@ -2050,7 +2050,7 @@ void Check_InputPara( const char *FileName, const int FormatVersion )
    LoadField( "Opt__GPUID_Select",       &RS.Opt__GPUID_Select,       SID, TID, NonFatal, &RT.Opt__GPUID_Select,        1, NonFatal );
    LoadField( "Init_Subsampling_NCell",  &RS.Init_Subsampling_NCell,  SID, TID, NonFatal, &RT.Init_Subsampling_NCell,   1, NonFatal );
 #  ifdef MHD
-   LoadField( "Opt__InitBFieldByFile",   &RS.Opt__InitBFieldByFile,   SID, TID, NonFatal, &RT.Opt__InitBFieldByFile,    1, NonFatal );
+   LoadField( "Opt__InitBFieldByVecPot", &RS.Opt__InitBFieldByVecPot, SID, TID, NonFatal, &RT.Opt__InitBFieldByVecPot,  1, NonFatal );
 #  endif
 #  ifdef SUPPORT_FFTW
    LoadField( "Opt__FFTW_Startup",       &RS.Opt__FFTW_Startup,       SID, TID, NonFatal, &RT.Opt__FFTW_Startup,        1, NonFatal );

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -376,7 +376,7 @@ void Init_Load_Parameter()
    ReadPara->Add( "OPT__GPUID_SELECT",          &OPT__GPUID_SELECT,              -1,              -3,             NoMax_int      );
    ReadPara->Add( "INIT_SUBSAMPLING_NCELL",     &INIT_SUBSAMPLING_NCELL,          0,               0,             NoMax_int      );
 #  ifdef MHD
-   ReadPara->Add( "OPT__INIT_BFIELD_BYFILE",    &OPT__INIT_BFIELD_BYFILE,         false,           Useless_bool,  Useless_bool   );
+   ReadPara->Add( "OPT__INIT_BFIELD_BYVECPOT",  &OPT__INIT_BFIELD_BYVECPOT,       0,               0,             2              );
 #  endif
 #  ifdef SUPPORT_FFTW
 #  if ( SUPPORT_FFTW == FFTW2 )

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -376,7 +376,7 @@ void Init_Load_Parameter()
    ReadPara->Add( "OPT__GPUID_SELECT",          &OPT__GPUID_SELECT,              -1,              -3,             NoMax_int      );
    ReadPara->Add( "INIT_SUBSAMPLING_NCELL",     &INIT_SUBSAMPLING_NCELL,          0,               0,             NoMax_int      );
 #  ifdef MHD
-   ReadPara->Add( "OPT__INIT_BFIELD_BYVECPOT",  &OPT__INIT_BFIELD_BYVECPOT,       0,               0,             2              );
+   ReadPara->Add( "OPT__INIT_BFIELD_BYVECPOT", &OPT__INIT_BFIELD_BYVECPOT, INIT_MAG_BYVECPOT_NONE, 0,             2              );
 #  endif
 #  ifdef SUPPORT_FFTW
 #  if ( SUPPORT_FFTW == FFTW2 )

--- a/src/Main/Main.cpp
+++ b/src/Main/Main.cpp
@@ -103,9 +103,11 @@ double               FlagTable_Current[NLEVEL-1], INT_MONO_COEFF_B;
 IntScheme_t          OPT__MAG_INT_SCHEME, OPT__REF_MAG_INT_SCHEME;
 bool                 OPT__FIXUP_ELECTRIC, OPT__CK_INTERFACE_B, OPT__OUTPUT_CC_MAG, OPT__FLAG_CURRENT;
 bool                 OPT__OUTPUT_DIVMAG;
-int                  OPT__CK_DIVERGENCE_B, OPT__INIT_BFIELD_BYVECPOT;
+int                  OPT__CK_DIVERGENCE_B;
 double               UNIT_B;
 bool                 OPT__SAME_INTERFACE_B;
+
+OptInitMagByVecPot_t OPT__INIT_BFIELD_BYVECPOT;
 #endif
 
 #elif ( MODEL == ELBDM )

--- a/src/Main/Main.cpp
+++ b/src/Main/Main.cpp
@@ -103,9 +103,9 @@ double               FlagTable_Current[NLEVEL-1], INT_MONO_COEFF_B;
 IntScheme_t          OPT__MAG_INT_SCHEME, OPT__REF_MAG_INT_SCHEME;
 bool                 OPT__FIXUP_ELECTRIC, OPT__CK_INTERFACE_B, OPT__OUTPUT_CC_MAG, OPT__FLAG_CURRENT;
 bool                 OPT__OUTPUT_DIVMAG;
-int                  OPT__CK_DIVERGENCE_B;
+int                  OPT__CK_DIVERGENCE_B, OPT__INIT_BFIELD_BYVECPOT;
 double               UNIT_B;
-bool                 OPT__INIT_BFIELD_BYFILE, OPT__SAME_INTERFACE_B;
+bool                 OPT__SAME_INTERFACE_B;
 #endif
 
 #elif ( MODEL == ELBDM )

--- a/src/Makefile
+++ b/src/Makefile
@@ -549,7 +549,7 @@ CPU_FILE    += MHD_GetCellCenteredBInPatch.cpp  MHD_InterpolateBField.cpp  MHD_A
                MHD_Aux_Check_InterfaceB.cpp  MHD_FixUp_Electric.cpp  MHD_Aux_Check_DivergenceB.cpp \
                MHD_BoundaryCondition_Outflow.cpp  MHD_BoundaryCondition_Reflecting.cpp  MHD_BoundaryCondition_User.cpp \
                MHD_BoundaryCondition_Diode.cpp  MHD_CopyPatchInterfaceBField.cpp  MHD_Init_BField_ByVecPot_File.cpp \
-               MHD_SameInterfaceB.cpp
+               MHD_SameInterfaceB.cpp  MHD_Init_BField_ByVecPot_Function.cpp
 
 CPU_FILE    += CPU_Shared_ConstrainedTransport.cpp  CPU_Shared_RiemannSolver_HLLD.cpp
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -548,7 +548,7 @@ ifeq "$(filter -DMHD, $(SIMU_OPTION))" "-DMHD"
 CPU_FILE    += MHD_GetCellCenteredBInPatch.cpp  MHD_InterpolateBField.cpp  MHD_AllocateElectricArray.cpp \
                MHD_Aux_Check_InterfaceB.cpp  MHD_FixUp_Electric.cpp  MHD_Aux_Check_DivergenceB.cpp \
                MHD_BoundaryCondition_Outflow.cpp  MHD_BoundaryCondition_Reflecting.cpp  MHD_BoundaryCondition_User.cpp \
-               MHD_BoundaryCondition_Diode.cpp  MHD_CopyPatchInterfaceBField.cpp  MHD_Init_BField_ByFile.cpp \
+               MHD_BoundaryCondition_Diode.cpp  MHD_CopyPatchInterfaceBField.cpp  MHD_Init_BField_ByVecPot_File.cpp \
                MHD_SameInterfaceB.cpp
 
 CPU_FILE    += CPU_Shared_ConstrainedTransport.cpp  CPU_Shared_RiemannSolver_HLLD.cpp

--- a/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
+++ b/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
@@ -179,8 +179,13 @@ void Hydro_Init_ByFunction_AssignData( const int lv )
 
 
 #  ifdef MHD
-   if      ( OPT__INIT_BFIELD_BYVECPOT == 1 )   MHD_Init_BField_ByVecPot_File( lv );
-   else if ( OPT__INIT_BFIELD_BYVECPOT == 2 )   MHD_Init_BField_ByVecPot_Function( lv );
+   switch ( OPT__INIT_BFIELD_BYVECPOT )
+   {
+      case 0 :                                            break;
+      case 1 : MHD_Init_BField_ByVecPot_File( lv );       break;
+      case 2 : MHD_Init_BField_ByVecPot_Function( lv );   break;
+      default: Aux_Error( ERROR_INFO, "unsupported OPT__INIT_BFIELD_BYVECPOT (%d) !!\n", OPT__INIT_BFIELD_BYVECPOT );
+   }
 #  endif
 
 

--- a/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
+++ b/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
@@ -156,7 +156,7 @@ void Hydro_Init_ByFunction_AssignData( const int lv )
    if ( Init_Function_User_Ptr == NULL )  Aux_Error( ERROR_INFO, "Init_Function_User_Ptr == NULL !!\n" );
 
 #  ifdef MHD
-   if ( Init_Function_BField_User_Ptr == NULL  &&  !OPT__INIT_BFIELD_BYFILE )
+   if ( Init_Function_BField_User_Ptr == NULL  &&  !OPT__INIT_BFIELD_BYVECPOT )
       Aux_Error( ERROR_INFO, "Init_Function_BField_User_Ptr == NULL !!\n" );
 #  endif
 
@@ -179,7 +179,7 @@ void Hydro_Init_ByFunction_AssignData( const int lv )
 
 
 #  ifdef MHD
-   if ( OPT__INIT_BFIELD_BYFILE )   MHD_Init_BField_ByFile( lv );
+   if ( OPT__INIT_BFIELD_BYVECPOT )   MHD_Init_BField_ByFile( lv );
 #  endif
 
 
@@ -189,7 +189,7 @@ void Hydro_Init_ByFunction_AssignData( const int lv )
 //    1. set the magnetic field
 #     ifdef MHD
 
-      if ( !OPT__INIT_BFIELD_BYFILE ) {
+      if ( !OPT__INIT_BFIELD_BYVECPOT ) {
 
          real magnetic_1v, magnetic_sub[NCOMP_MAG];
 
@@ -226,7 +226,7 @@ void Hydro_Init_ByFunction_AssignData( const int lv )
                amr->patch[ amr->MagSg[lv] ][lv][PID]->magnetic[v][ idx ++ ] = magnetic_1v*_NSub2;
             }}} // i,j,k
          } // for (int v=0; v<NCOMP_MAG; v++)
-      } // if ( !OPT__INIT_BFIELD_BYFILE )
+      } // if ( !OPT__INIT_BFIELD_BYVECPOT )
 
 #     endif // #ifdef MHD
 

--- a/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
+++ b/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
@@ -179,7 +179,7 @@ void Hydro_Init_ByFunction_AssignData( const int lv )
 
 
 #  ifdef MHD
-   if ( OPT__INIT_BFIELD_BYVECPOT )   MHD_Init_BField_ByFile( lv );
+   if ( OPT__INIT_BFIELD_BYVECPOT )   MHD_Init_BField_ByVecPot_File( lv );
 #  endif
 
 

--- a/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
+++ b/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
@@ -179,7 +179,8 @@ void Hydro_Init_ByFunction_AssignData( const int lv )
 
 
 #  ifdef MHD
-   if ( OPT__INIT_BFIELD_BYVECPOT )   MHD_Init_BField_ByVecPot_File( lv );
+   if      ( OPT__INIT_BFIELD_BYVECPOT == 1 )   MHD_Init_BField_ByVecPot_File( lv );
+   else if ( OPT__INIT_BFIELD_BYVECPOT == 2 )   MHD_Init_BField_ByVecPot_Function( lv );
 #  endif
 
 

--- a/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
+++ b/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
@@ -181,10 +181,10 @@ void Hydro_Init_ByFunction_AssignData( const int lv )
 #  ifdef MHD
    switch ( OPT__INIT_BFIELD_BYVECPOT )
    {
-      case 0 :                                            break;
-      case 1 : MHD_Init_BField_ByVecPot_File( lv );       break;
-      case 2 : MHD_Init_BField_ByVecPot_Function( lv );   break;
-      default: Aux_Error( ERROR_INFO, "unsupported OPT__INIT_BFIELD_BYVECPOT (%d) !!\n", OPT__INIT_BFIELD_BYVECPOT );
+      case INIT_MAG_BYVECPOT_NONE :                                            break;
+      case INIT_MAG_BYVECPOT_FILE : MHD_Init_BField_ByVecPot_File( lv );       break;
+      case INIT_MAG_BYVECPOT_FUNC : MHD_Init_BField_ByVecPot_Function( lv );   break;
+      default                     : Aux_Error( ERROR_INFO, "unsupported OPT__INIT_BFIELD_BYVECPOT (%d) !!\n", OPT__INIT_BFIELD_BYVECPOT );
    }
 #  endif
 

--- a/src/Model_Hydro/MHD_Init_BField_ByVecPot_File.cpp
+++ b/src/Model_Hydro/MHD_Init_BField_ByVecPot_File.cpp
@@ -19,7 +19,7 @@ void VecPot_ReadField( hid_t mag_file_id, const int ibegin, const int jbegin,
 #endif
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  MHD_Init_BField_ByFile
+// Function    :  MHD_Init_BField_ByVecPot_File
 // Description :  Use the input uniform-mesh array stored in the file "B_Filename"
 //                to assign a magnetic vector potential to all real patches on level
 //                "B_lv" and take the curl of this potential to compute the magnetic field
@@ -30,7 +30,7 @@ void VecPot_ReadField( hid_t mag_file_id, const int ibegin, const int jbegin,
 //
 // Return      :  amr->patch->magnetic
 //-------------------------------------------------------------------------------------------------------
-void MHD_Init_BField_ByFile( const int B_lv )
+void MHD_Init_BField_ByVecPot_File( const int B_lv )
 {
 
 #  ifndef MHD
@@ -287,7 +287,7 @@ void MHD_Init_BField_ByFile( const int B_lv )
 
    if ( MPI_Rank == 0 ) Aux_Message( stdout, "   Loading the magnetic field from the input file ... done\n" );
 
-} // FUNCTION : Hydro_Init_BField_ByFile
+} // FUNCTION : MHD_Init_BField_ByVecPot_File
 
 //-------------------------------------------------------------------------------------------------------
 // Function    :  VecPot_Interp

--- a/src/Model_Hydro/MHD_Init_BField_ByVecPot_Function.cpp
+++ b/src/Model_Hydro/MHD_Init_BField_ByVecPot_Function.cpp
@@ -5,11 +5,11 @@
 
 // declare as static so that other functions cannot invoke it directly and must use the function pointer
 static double Init_BField_ByVecPot_User_Template( const double x, const double y, const double z, const double Time,
-                                                  const int lv, const char Axis, double AuxArray[] );
+                                                  const int lv, const char Component, double AuxArray[] );
 
 // this function pointer must be set by a test problem initializer
 double (*Init_BField_ByVecPot_User_Ptr)( const double x, const double y, const double z, const double Time,
-                                         const int lv, const char Axis, double AuxArray[] ) = NULL;
+                                         const int lv, const char Component, double AuxArray[] ) = NULL;
 
 
 
@@ -24,17 +24,18 @@ double (*Init_BField_ByVecPot_User_Ptr)( const double x, const double y, const d
 //                   (unless OPT__INIT_GRID_WITH_OMP is disabled)
 //                   --> Please ensure that everything here is thread-safe
 //
-// Parameter   :  x/y/z      : Target physical coordinates
-//                Time       : Target physical time
-//                lv         : Target refinement level
-//                Axis       : Axis of the output magnetic vector potential
-//                AuxArray   : Auxiliary array
-//                             --> useless since it is currently fixed to NULL
+// Parameter   :  x/y/z     : Target physical coordinates
+//                Time      : Target physical time
+//                lv        : Target refinement level
+//                Component : Component of the output magnetic vector potential
+//                            --> Supported components: 'x', 'y', 'z'
+//                AuxArray  : Auxiliary array
+//                            --> Useless since it is currently fixed to NULL
 //
 // Return      :  "XYZ" component of the magnetic vector potential at (x, y, z, Time)
 //-------------------------------------------------------------------------------------------------------
 double Init_BField_ByVecPot_User_Template( const double x, const double y, const double z, const double Time,
-                                           const int lv, const char Axis, double AuxArray[] )
+                                           const int lv, const char Component, double AuxArray[] )
 {
 
    const double BoxCenter[3] = { amr->BoxCenter[0], amr->BoxCenter[1], amr->BoxCenter[2] };
@@ -46,12 +47,12 @@ double Init_BField_ByVecPot_User_Template( const double x, const double y, const
    double mag_vecpot;
 
 
-   switch ( Axis )
+   switch ( Component )
    {
       case 'x' :   mag_vecpot = 0.0;           break;
       case 'y' :   mag_vecpot = 0.0;           break;
       case 'z' :   mag_vecpot = 1.0 / varpi;   break;
-      default  :   Aux_Error( ERROR_INFO, "unsupported Axis (%c) !!\n", Axis );
+      default  :   Aux_Error( ERROR_INFO, "unsupported component (%c) !!\n", Component );
    }
 
 

--- a/src/Model_Hydro/MHD_Init_BField_ByVecPot_Function.cpp
+++ b/src/Model_Hydro/MHD_Init_BField_ByVecPot_Function.cpp
@@ -81,8 +81,8 @@ void MHD_Init_BField_ByVecPot_Function( const int B_lv )
    Aux_Error( ERROR_INFO, "MHD must be enabled !!\n" );
 #  endif
 
-   if ( OPT__INIT_BFIELD_BYVECPOT =! 2 )
-      Aux_Error( ERROR_INFO, "OPT__INIT_BFIELD_BYVECPOT != 2 !!\n" );
+   if ( OPT__INIT_BFIELD_BYVECPOT != INIT_MAG_BYVECPOT_FUNC )
+      Aux_Error( ERROR_INFO, "OPT__INIT_BFIELD_BYVECPOT != %d !!\n", INIT_MAG_BYVECPOT_FUNC );
 
    if ( Init_BField_ByVecPot_User_Ptr == NULL )
       Aux_Error( ERROR_INFO, "Init_BField_ByVecPot_User_Ptr == NULL !!\n" );

--- a/src/Model_Hydro/MHD_Init_BField_ByVecPot_Function.cpp
+++ b/src/Model_Hydro/MHD_Init_BField_ByVecPot_Function.cpp
@@ -1,0 +1,132 @@
+#include "GAMER.h"
+
+
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  MHD_Init_BField_ByVecPot_Function
+// Description :  Use the function pointer "Init_BField_ByVecPot_User_Ptr"
+//                to assign a magnetic vector potential to all real patches on level
+//                "B_lv" and take the curl of this potential to compute the magnetic field
+//
+// Note        :
+//
+// Parameter   :  B_lv : Target AMR level
+//
+// Return      :  amr->patch->magnetic
+//-------------------------------------------------------------------------------------------------------
+void MHD_Init_BField_ByVecPot_Function( const int B_lv )
+{
+
+// check
+#  ifndef MHD
+   Aux_Error( ERROR_INFO, "MHD must be enabled !!\n" );
+#  endif
+
+   if ( Init_BField_ByVecPot_User_Ptr == NULL  &&  OPT__INIT_BFIELD_BYVECPOT == 2 )
+      Aux_Error( ERROR_INFO, "Init_BField_ByVecPot_User_Ptr == NULL !!\n" );
+
+
+   if ( MPI_Rank == 0 )   Aux_Message( stdout, "   Constructing the magnetic field from vector potential ...\n" );
+
+
+// set the number of OpenMP threads
+#  ifdef OPENMP
+   const int OMP_NThread = ( OPT__INIT_GRID_WITH_OMP ) ? OMP_NTHREAD : 1;
+#  else
+   const int OMP_NThread = 1;
+#  endif
+
+
+// allocate memory for per-thread arrays
+   double **Ax = NULL, **Ay = NULL, **Az = NULL;
+
+   Aux_AllocateArray2D( Ax, OMP_NThread, CUBE(PS1+1) );
+   Aux_AllocateArray2D( Ay, OMP_NThread, CUBE(PS1+1) );
+   Aux_AllocateArray2D( Az, OMP_NThread, CUBE(PS1+1) );
+
+
+// loop over the patches on the target AMR level
+   const double dh = amr->dh[B_lv];
+
+#  pragma omp parallel for schedule( runtime ) num_threads( OMP_NThread )
+   for (int PID=0; PID<amr->NPatchComma[B_lv][1]; PID++)
+   {
+
+#     ifdef OPENMP
+      const int TID = omp_get_thread_num();
+#     else
+      const int TID = 0;
+#     endif
+
+      const double EdgeL[3] = { amr->patch[0][B_lv][PID]->EdgeL[0],
+                                amr->patch[0][B_lv][PID]->EdgeL[1],
+                                amr->patch[0][B_lv][PID]->EdgeL[2] };
+
+
+//    set the magnetic vector potential from function
+      for (int k=0; k<PS1+1; k++) {  const double z0 = EdgeL[2] + k*dh;  const double zc = z0 + 0.5*dh;
+      for (int j=0; j<PS1+1; j++) {  const double y0 = EdgeL[1] + j*dh;  const double yc = y0 + 0.5*dh;
+      for (int i=0; i<PS1+1; i++) {  const double x0 = EdgeL[0] + i*dh;  const double xc = x0 + 0.5*dh;
+
+         int idx = IDX321( i, j, k, PS1+1, PS1+1 );
+
+         Ax[TID][idx] = 0.0;
+         Ay[TID][idx] = 0.0;
+         Az[TID][idx] = 0.0;
+
+         if ( i != PS1 )   Init_BField_ByVecPot_User_Ptr( &Ax[TID][idx], xc, y0, z0, Time[B_lv], B_lv, 'x', NULL );
+         if ( j != PS1 )   Init_BField_ByVecPot_User_Ptr( &Ay[TID][idx], x0, yc, z0, Time[B_lv], B_lv, 'y', NULL );
+         if ( k != PS1 )   Init_BField_ByVecPot_User_Ptr( &Az[TID][idx], x0, y0, zc, Time[B_lv], B_lv, 'z', NULL );
+
+      }}}
+
+
+//    calculate Bx from vector potential
+      for (int k=0; k<PS1;   k++) {
+      for (int j=0; j<PS1;   j++) {
+      for (int i=0; i<PS1+1; i++) {
+         int idx  = IDX321   ( i, j,   k,   PS1+1, PS1+1 );
+         int idxj = IDX321   ( i, j+1, k,   PS1+1, PS1+1 );
+         int idxk = IDX321   ( i, j,   k+1, PS1+1, PS1+1 );
+         int idxB = IDX321_BX( i, j,   k,   PS1,   PS1   );
+         real Bx = ( Az[TID][idxj] - Az[TID][idx] - Ay[TID][idxk] + Ay[TID][idx] ) / dh;
+         amr->patch[ amr->MagSg[B_lv] ][B_lv][PID]->magnetic[0][idxB] = Bx;
+      }}}
+
+//    calculate By from vector potential
+      for (int k=0; k<PS1;   k++) {
+      for (int j=0; j<PS1+1; j++) {
+      for (int i=0; i<PS1;   i++) {
+         int idx  = IDX321   ( i,   j, k,   PS1+1, PS1+1 );
+         int idxi = IDX321   ( i+1, j, k,   PS1+1, PS1+1 );
+         int idxk = IDX321   ( i,   j, k+1, PS1+1, PS1+1 );
+         int idxB = IDX321_BY( i,   j, k,   PS1,   PS1   );
+         real By = ( Ax[TID][idxk] - Ax[TID][idx] - Az[TID][idxi] + Az[TID][idx] ) / dh;
+         amr->patch[ amr->MagSg[B_lv] ][B_lv][PID]->magnetic[1][idxB] = By;
+      }}}
+
+//    calculate Bz from vector potential
+      for (int k=0; k<PS1+1; k++) {
+      for (int j=0; j<PS1;   j++) {
+      for (int i=0; i<PS1;   i++) {
+         int idx  = IDX321   ( i,   j,   k, PS1+1, PS1+1 );
+         int idxi = IDX321   ( i+1, j,   k, PS1+1, PS1+1 );
+         int idxj = IDX321   ( i,   j+1, k, PS1+1, PS1+1 );
+         int idxB = IDX321_BZ( i,   j,   k, PS1,   PS1   );
+         real Bz = ( Ay[TID][idxi] - Ay[TID][idx] - Ax[TID][idxj] + Ax[TID][idx] ) / dh;
+         amr->patch[ amr->MagSg[B_lv] ][B_lv][PID]->magnetic[2][idxB] = Bz;
+      }}}
+
+   } // for (int PID=0; PID<amr->NPatchComma[B_lv][1]; PID++)
+
+
+// free memory
+   Aux_DeallocateArray2D( Ax );
+   Aux_DeallocateArray2D( Ay );
+   Aux_DeallocateArray2D( Az );
+
+
+   if ( MPI_Rank == 0 )   Aux_Message( stdout, "   Constructing the magnetic field from vector potential ... done\n" );
+
+} // FUNCTION : MHD_Init_BField_ByVecPot_Function

--- a/src/Model_Hydro/MHD_Init_BField_ByVecPot_Function.cpp
+++ b/src/Model_Hydro/MHD_Init_BField_ByVecPot_Function.cpp
@@ -1,6 +1,61 @@
 #include "GAMER.h"
 
 
+#ifdef MHD
+// declare as static so that other functions cannot invoke it directly and must use the function pointer
+static void Init_BField_ByVecPot_User_Template( double *mag_vecpot, const double x, const double y, const double z, const double Time,
+                                                const int lv, const char Axis, double AuxArray[] );
+
+// this function pointer must be set by a test problem initializer
+void (*Init_BField_ByVecPot_User_Ptr)( double *mag_vecpot, const double x, const double y, const double z, const double Time,
+                                       const int lv, const char Axis, double AuxArray[] ) = NULL;
+#endif
+
+
+
+
+#ifdef MHD
+//-------------------------------------------------------------------------------------------------------
+// Function    :  Init_BField_ByVecPot_User_Template
+// Description :  Function template to initialize the magnetic vector potential
+//
+// Note        :  1. Invoked by MHD_Init_BField_ByVecPot_Function() using the function pointer
+//                   "Init_BField_ByVecPot_User_Ptr", which must be set by a test problem initializer
+//                2. This function will be invoked by multiple OpenMP threads when OPENMP is enabled
+//                   (unless OPT__INIT_GRID_WITH_OMP is disabled)
+//                   --> Please ensure that everything here is thread-safe
+//
+// Parameter   :  mag_vecpot : Output magnetic vector potential
+//                x/y/z      : Target physical coordinates
+//                Time       : Target physical time
+//                lv         : Target refinement level
+//                Axis       : Axis of the output magnetic vector potential
+//                AuxArray   : Auxiliary array
+//
+// Return      :  magnetic vector potential
+//-------------------------------------------------------------------------------------------------------
+void Init_BField_ByVecPot_User_Template( double *mag_vecpot, const double x, const double y, const double z, const double Time,
+                                         const int lv, const char Axis, double AuxArray[] )
+{
+
+   const double BoxCenter[3] = { amr->BoxCenter[0], amr->BoxCenter[1], amr->BoxCenter[2] };
+
+   const double x0    = x - BoxCenter[0];
+   const double y0    = y - BoxCenter[1];
+   const double varpi = sqrt(  SQR( x0 ) + SQR( y0 )  );
+
+
+   switch ( Axis )
+   {
+      case 'x' :   *mag_vecpot = 0.0;           break;
+      case 'y' :   *mag_vecpot = 0.0;           break;
+      case 'z' :   *mag_vecpot = 1.0 / varpi;   break;
+      default  :   Aux_Error( ERROR_INFO, "unsupported Axis (%d) !!\n", Axis );
+   }
+
+} // FUNCTION : Init_BField_ByVecPot_User_Template
+#endif // #ifdef MHD
+
 
 
 //-------------------------------------------------------------------------------------------------------

--- a/src/Output/Output_DumpData_Total_HDF5.cpp
+++ b/src/Output/Output_DumpData_Total_HDF5.cpp
@@ -69,7 +69,7 @@ Procedure for outputting new variables:
 
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  Output_DumpData_Total_HDF5 (FormatVersion = 2466)
+// Function    :  Output_DumpData_Total_HDF5 (FormatVersion = 2467)
 // Description :  Output all simulation data in the HDF5 format, which can be used as a restart file
 //                or loaded by YT
 //
@@ -239,6 +239,7 @@ Procedure for outputting new variables:
 //                2464 : 2023/04/27 --> output LIBYT_INTERACTIVE
 //                2465 : 2023/04/29 --> output MU_NORM
 //                2466 : 2023/05/08 --> output OPT__FFTW_STARTUP
+//                2467 : 2023/05/18 --> replace OPT__INIT_BFIELD_BYFILE by OPT__INIT_BFIELD_BYVECPOT
 //-------------------------------------------------------------------------------------------------------
 void Output_DumpData_Total_HDF5( const char *FileName )
 {
@@ -1412,7 +1413,7 @@ void FillIn_KeyInfo( KeyInfo_t &KeyInfo, const int NFieldStored )
 
    const time_t CalTime = time( NULL );   // calendar time
 
-   KeyInfo.FormatVersion        = 2466;
+   KeyInfo.FormatVersion        = 2467;
    KeyInfo.Model                = MODEL;
    KeyInfo.NLevel               = NLEVEL;
    KeyInfo.NCompFluid           = NCOMP_FLUID;
@@ -2351,7 +2352,7 @@ void FillIn_InputPara( InputPara_t &InputPara, const int NFieldStored, char Fiel
    InputPara.Opt__GPUID_Select       = OPT__GPUID_SELECT;
    InputPara.Init_Subsampling_NCell  = INIT_SUBSAMPLING_NCELL;
 #  ifdef MHD
-   InputPara.Opt__InitBFieldByFile   = OPT__INIT_BFIELD_BYFILE;
+   InputPara.Opt__InitBFieldByVecPot = OPT__INIT_BFIELD_BYVECPOT;
 #  endif
 #  ifdef SUPPORT_FFTW
    InputPara.Opt__FFTW_Startup       = OPT__FFTW_STARTUP;
@@ -3214,28 +3215,28 @@ void GetCompound_InputPara( hid_t &H5_TypeID, const int NFieldStored )
 #  endif
 
 // initialization
-   H5Tinsert( H5_TypeID, "Opt__Init",               HOFFSET(InputPara_t,Opt__Init              ), H5T_NATIVE_INT              );
-   H5Tinsert( H5_TypeID, "RestartLoadNRank",        HOFFSET(InputPara_t,RestartLoadNRank       ), H5T_NATIVE_INT              );
-   H5Tinsert( H5_TypeID, "Opt__RestartReset",       HOFFSET(InputPara_t,Opt__RestartReset      ), H5T_NATIVE_INT              );
-   H5Tinsert( H5_TypeID, "Opt__UM_IC_Level",        HOFFSET(InputPara_t,Opt__UM_IC_Level       ), H5T_NATIVE_INT              );
-   H5Tinsert( H5_TypeID, "Opt__UM_IC_NLevel",       HOFFSET(InputPara_t,Opt__UM_IC_NLevel      ), H5T_NATIVE_INT              );
-   H5Tinsert( H5_TypeID, "Opt__UM_IC_NVar",         HOFFSET(InputPara_t,Opt__UM_IC_NVar        ), H5T_NATIVE_INT              );
-   H5Tinsert( H5_TypeID, "Opt__UM_IC_Format",       HOFFSET(InputPara_t,Opt__UM_IC_Format      ), H5T_NATIVE_INT              );
-   H5Tinsert( H5_TypeID, "Opt__UM_IC_Downgrade",    HOFFSET(InputPara_t,Opt__UM_IC_Downgrade   ), H5T_NATIVE_INT              );
-   H5Tinsert( H5_TypeID, "Opt__UM_IC_Refine",       HOFFSET(InputPara_t,Opt__UM_IC_Refine      ), H5T_NATIVE_INT              );
-   H5Tinsert( H5_TypeID, "Opt__UM_IC_LoadNRank",    HOFFSET(InputPara_t,Opt__UM_IC_LoadNRank   ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "Opt__Init",               HOFFSET(InputPara_t,Opt__Init               ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "RestartLoadNRank",        HOFFSET(InputPara_t,RestartLoadNRank        ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "Opt__RestartReset",       HOFFSET(InputPara_t,Opt__RestartReset       ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "Opt__UM_IC_Level",        HOFFSET(InputPara_t,Opt__UM_IC_Level        ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "Opt__UM_IC_NLevel",       HOFFSET(InputPara_t,Opt__UM_IC_NLevel       ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "Opt__UM_IC_NVar",         HOFFSET(InputPara_t,Opt__UM_IC_NVar         ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "Opt__UM_IC_Format",       HOFFSET(InputPara_t,Opt__UM_IC_Format       ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "Opt__UM_IC_Downgrade",    HOFFSET(InputPara_t,Opt__UM_IC_Downgrade    ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "Opt__UM_IC_Refine",       HOFFSET(InputPara_t,Opt__UM_IC_Refine       ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "Opt__UM_IC_LoadNRank",    HOFFSET(InputPara_t,Opt__UM_IC_LoadNRank    ), H5T_NATIVE_INT              );
 #  if ( NLEVEL > 1 )
-   H5Tinsert( H5_TypeID, "UM_IC_RefineRegion",      HOFFSET(InputPara_t,UM_IC_RefineRegion     ), H5_TypeID_Arr_NLvM1_6Int    );
+   H5Tinsert( H5_TypeID, "UM_IC_RefineRegion",      HOFFSET(InputPara_t,UM_IC_RefineRegion      ), H5_TypeID_Arr_NLvM1_6Int    );
 #  endif
-   H5Tinsert( H5_TypeID, "Opt__InitRestrict",       HOFFSET(InputPara_t,Opt__InitRestrict      ), H5T_NATIVE_INT              );
-   H5Tinsert( H5_TypeID, "Opt__InitGridWithOMP",    HOFFSET(InputPara_t,Opt__InitGridWithOMP   ), H5T_NATIVE_INT              );
-   H5Tinsert( H5_TypeID, "Opt__GPUID_Select",       HOFFSET(InputPara_t,Opt__GPUID_Select      ), H5T_NATIVE_INT              );
-   H5Tinsert( H5_TypeID, "Init_Subsampling_NCell",  HOFFSET(InputPara_t,Init_Subsampling_NCell ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "Opt__InitRestrict",       HOFFSET(InputPara_t,Opt__InitRestrict       ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "Opt__InitGridWithOMP",    HOFFSET(InputPara_t,Opt__InitGridWithOMP    ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "Opt__GPUID_Select",       HOFFSET(InputPara_t,Opt__GPUID_Select       ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "Init_Subsampling_NCell",  HOFFSET(InputPara_t,Init_Subsampling_NCell  ), H5T_NATIVE_INT              );
 #  ifdef MHD
-   H5Tinsert( H5_TypeID, "Opt__InitBFieldByFile",   HOFFSET(InputPara_t,Opt__InitBFieldByFile  ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "Opt__InitBFieldByVecPot", HOFFSET(InputPara_t,Opt__InitBFieldByVecPot ), H5T_NATIVE_INT              );
 #  endif
 #  ifdef SUPPORT_FFTW
-   H5Tinsert( H5_TypeID, "Opt__FFTW_Startup",       HOFFSET(InputPara_t,Opt__FFTW_Startup      ), H5T_NATIVE_INT              );
+   H5Tinsert( H5_TypeID, "Opt__FFTW_Startup",       HOFFSET(InputPara_t,Opt__FFTW_Startup       ), H5T_NATIVE_INT              );
 #  endif
 
 // interpolation schemes

--- a/src/TestProblem/Template/Init_TestProb_Template.cpp
+++ b/src/TestProblem/Template/Init_TestProb_Template.cpp
@@ -274,46 +274,47 @@ void Init_TestProb_Template()
    Init_Function_User_Ptr            = SetGridIC;
 #  ifdef MHD
    Init_Function_BField_User_Ptr     = SetBFieldIC;
+   Init_BField_ByVecPot_User_Ptr     = NULL; // option: OPT__INIT_BFIELD_BYVECPOT=2;  example: Model_Hydro/MHD_Init_BField_ByVecPot_Function.cpp
 #  endif
 // comment out Init_ByFile_User_Ptr to use the default
-// Init_ByFile_User_Ptr              = NULL; // option: OPT__INIT=3;             example: Init/Init_ByFile.cpp -> Init_ByFile_Default()
-   Init_Field_User_Ptr               = NULL; // set NCOMP_PASSIVE_USER;          example: TestProblem/Hydro/Plummer/Init_TestProb_Hydro_Plummer.cpp --> AddNewField()
-   Flag_Region_Ptr                   = NULL; // option: OPT__FLAG_REGION;        example: Refing/Flag_Region.cpp
-   Flag_User_Ptr                     = NULL; // option: OPT__FLAG_USER;          example: Refine/Flag_User.cpp
-   Mis_GetTimeStep_User_Ptr          = NULL; // option: OPT__DT_USER;            example: Miscellaneous/Mis_GetTimeStep_User.cpp
-   Mis_UserWorkBeforeNextLevel_Ptr   = NULL; //                                  example: Miscellaneous/Mis_UserWorkBeforeNextLevel.cpp
-   Mis_UserWorkBeforeNextSubstep_Ptr = NULL; //                                  example: Miscellaneous/Mis_UserWorkBeforeNextSubstep.cpp
-   BC_User_Ptr                       = NULL; // option: OPT__BC_FLU_*=4;         example: TestProblem/ELBDM/ExtPot/Init_TestProb_ELBDM_ExtPot.cpp --> BC()
+// Init_ByFile_User_Ptr              = NULL; // option: OPT__INIT=3;                  example: Init/Init_ByFile.cpp -> Init_ByFile_Default()
+   Init_Field_User_Ptr               = NULL; // set NCOMP_PASSIVE_USER;               example: TestProblem/Hydro/Plummer/Init_TestProb_Hydro_Plummer.cpp --> AddNewField()
+   Flag_Region_Ptr                   = NULL; // option: OPT__FLAG_REGION;             example: Refing/Flag_Region.cpp
+   Flag_User_Ptr                     = NULL; // option: OPT__FLAG_USER;               example: Refine/Flag_User.cpp
+   Mis_GetTimeStep_User_Ptr          = NULL; // option: OPT__DT_USER;                 example: Miscellaneous/Mis_GetTimeStep_User.cpp
+   Mis_UserWorkBeforeNextLevel_Ptr   = NULL; //                                       example: Miscellaneous/Mis_UserWorkBeforeNextLevel.cpp
+   Mis_UserWorkBeforeNextSubstep_Ptr = NULL; //                                       example: Miscellaneous/Mis_UserWorkBeforeNextSubstep.cpp
+   BC_User_Ptr                       = NULL; // option: OPT__BC_FLU_*=4;              example: TestProblem/ELBDM/ExtPot/Init_TestProb_ELBDM_ExtPot.cpp --> BC()
 #  ifdef MHD
    BC_BField_User_Ptr                = NULL; // option: OPT__BC_FLU_*=4;
 #  endif
-   Flu_ResetByUser_Func_Ptr          = NULL; // option: OPT__RESET_FLUID;        example: Fluid/Flu_ResetByUser.cpp
-   Init_DerivedField_User_Ptr        = NULL; // option: OPT__OUTPUT_USER_FIELD;  example: Fluid/Flu_DerivedField_User.cpp
-   Output_User_Ptr                   = NULL; // option: OPT__OUTPUT_USER;        example: TestProblem/Hydro/AcousticWave/Init_TestProb_Hydro_AcousticWave.cpp --> OutputError()
-   Output_UserWorkBeforeOutput_Ptr   = NULL; // option: none;                    example: Output/Output_UserWorkBeforeOutput.cpp
-   Aux_Record_User_Ptr               = NULL; // option: OPT__RECORD_USER;        example: Auxiliary/Aux_Record_User.cpp
-   Init_User_Ptr                     = NULL; // option: none;                    example: none
-   End_User_Ptr                      = NULL; // option: none;                    example: TestProblem/Hydro/ClusterMerger_vs_Flash/Init_TestProb_ClusterMerger_vs_Flash.cpp --> End_ClusterMerger()
+   Flu_ResetByUser_Func_Ptr          = NULL; // option: OPT__RESET_FLUID;             example: Fluid/Flu_ResetByUser.cpp
+   Init_DerivedField_User_Ptr        = NULL; // option: OPT__OUTPUT_USER_FIELD;       example: Fluid/Flu_DerivedField_User.cpp
+   Output_User_Ptr                   = NULL; // option: OPT__OUTPUT_USER;             example: TestProblem/Hydro/AcousticWave/Init_TestProb_Hydro_AcousticWave.cpp --> OutputError()
+   Output_UserWorkBeforeOutput_Ptr   = NULL; // option: none;                         example: Output/Output_UserWorkBeforeOutput.cpp
+   Aux_Record_User_Ptr               = NULL; // option: OPT__RECORD_USER;             example: Auxiliary/Aux_Record_User.cpp
+   Init_User_Ptr                     = NULL; // option: none;                         example: none
+   End_User_Ptr                      = NULL; // option: none;                         example: TestProblem/Hydro/ClusterMerger_vs_Flash/Init_TestProb_ClusterMerger_vs_Flash.cpp --> End_ClusterMerger()
 #  ifdef GRAVITY
-   Init_ExtAcc_Ptr                   = NULL; // option: OPT__EXT_ACC;            example: SelfGravity/CPU_Gravity/CPU_ExtAcc_PointMass.cpp
+   Init_ExtAcc_Ptr                   = NULL; // option: OPT__EXT_ACC;                 example: SelfGravity/CPU_Gravity/CPU_ExtAcc_PointMass.cpp
    End_ExtAcc_Ptr                    = NULL;
-   Init_ExtPot_Ptr                   = NULL; // option: OPT__EXT_POT;            example: SelfGravity/CPU_Poisson/CPU_ExtPot_PointMass.cpp
+   Init_ExtPot_Ptr                   = NULL; // option: OPT__EXT_POT;                 example: SelfGravity/CPU_Poisson/CPU_ExtPot_PointMass.cpp
    End_ExtPot_Ptr                    = NULL;
-   Poi_AddExtraMassForGravity_Ptr    = NULL; // option: OPT__GRAVITY_EXTRA_MASS; example: none
-   Poi_UserWorkBeforePoisson_Ptr     = NULL; // option: none;                    example: SelfGravity/Poi_UserWorkBeforePoisson.cpp
+   Poi_AddExtraMassForGravity_Ptr    = NULL; // option: OPT__GRAVITY_EXTRA_MASS;      example: none
+   Poi_UserWorkBeforePoisson_Ptr     = NULL; // option: none;                         example: SelfGravity/Poi_UserWorkBeforePoisson.cpp
 #  endif
 #  ifdef PARTICLE
-   Par_Init_ByFunction_Ptr           = NULL; // option: PAR_INIT=1;              example: Particle/Par_Init_ByFunction.cpp
-   Par_Init_Attribute_User_Ptr       = NULL; // set PAR_NATT_USER;               example: TestProblem/Hydro/AGORA_IsolatedGalaxy/Init_TestProb_Hydro_AGORA_IsolatedGalaxy.cpp --> AddNewParticleAttribute()
+   Par_Init_ByFunction_Ptr           = NULL; // option: PAR_INIT=1;                   example: Particle/Par_Init_ByFunction.cpp
+   Par_Init_Attribute_User_Ptr       = NULL; // set PAR_NATT_USER;                    example: TestProblem/Hydro/AGORA_IsolatedGalaxy/Init_TestProb_Hydro_AGORA_IsolatedGalaxy.cpp --> AddNewParticleAttribute()
 #  endif
 #  if ( EOS == EOS_USER )
-   EoS_Init_Ptr                      = NULL; // option: EOS in the Makefile;     example: EoS/User_Template/CPU_EoS_User_Template.cpp
+   EoS_Init_Ptr                      = NULL; // option: EOS in the Makefile;          example: EoS/User_Template/CPU_EoS_User_Template.cpp
    EoS_End_Ptr                       = NULL;
 #  endif
 #  endif // #if ( MODEL == HYDRO )
-   Src_Init_User_Ptr                 = NULL; // option: SRC_USER;                example: SourceTerms/User_Template/CPU_Src_User_Template.cpp
+   Src_Init_User_Ptr                 = NULL; // option: SRC_USER;                     example: SourceTerms/User_Template/CPU_Src_User_Template.cpp
 #  ifdef FEEDBACK
-   FB_Init_User_Ptr                  = NULL; // option: FB_USER;                 example: TestProblem/Hydro/Plummer/FB_Plummer.cpp
+   FB_Init_User_Ptr                  = NULL; // option: FB_USER;                      example: TestProblem/Hydro/Plummer/FB_Plummer.cpp
 #  endif
 
 

--- a/tool/inits/gen_vec_pot.py
+++ b/tool/inits/gen_vec_pot.py
@@ -1,6 +1,6 @@
 """
 This file generates a toy vector potential for import into GAMER using the
-OPT__INIT_BFIELD_BYVECPOT parameter. It does the following:
+OPT__INIT_BFIELD_BYVECPOT=1 parameter. It does the following:
 
 1. Generates a uniform coordinate grid
 2. Defines a vector potential on the coordinate grid

--- a/tool/inits/gen_vec_pot.py
+++ b/tool/inits/gen_vec_pot.py
@@ -1,6 +1,6 @@
 """
 This file generates a toy vector potential for import into GAMER using the
-OPT__INIT_BFIELD_BYFILE parameter. It does the following:
+OPT__INIT_BFIELD_BYVECPOT parameter. It does the following:
 
 1. Generates a uniform coordinate grid
 2. Defines a vector potential on the coordinate grid


### PR DESCRIPTION
- Rename the runtime parameter `OPT__INIT_BFIELD_BYFILE` to `OPT__INIT_BFIELD_BYVECPOT`
  - `OPT__INIT_BFIELD_BYVECPOT = 1`: from `B_IC`
  - `OPT__INIT_BFIELD_BYVECPOT = 2`: from `Init_BField_ByVecPot_User_Ptr()` defined in test problem
- Rename `MHD_Init_BField_ByFile()` to `MHD_Init_BField_ByVecPot_File()`
- Add `MHD_Init_BField_ByVecPot_Function()`
- Add function pointer `Init_BField_ByVecPot_User_Ptr`
- Update the template `Input__Parameter` and `Init_TestProb_Template`

Related issue: #73 