### PR TITLE
Initialize source-term fields

### DIFF
--- a/src/Init/Init_GAMER.cpp
+++ b/src/Init/Init_GAMER.cpp
@@ -320,17 +320,17 @@ void Init_GAMER( int *argc, char ***argv )
 
 // initialize source-term fields (e.g., cooling time)
 // --> necessary for, for example, estimating the source-term time-step at the first step
-// --> must ensure each source term does not modify any fluid field (e.g., gas internal energy) when dt=0.0 
+// --> must ensure each source term does not modify any fluid field (e.g., gas internal energy) when dt=0.0
 //     --> source terms violating this criterion (e.g., deleptonization) must be temporarily disabled before calling Src_AdvanceDt()
    if ( OPT__INIT != INIT_BY_RESTART )
-   {  
+   {
       const bool OverlapMPI_No   = false;
       const bool Overlap_Sync_No = false;
 
       if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ...\n", "Initializing source-term fields" );
 
       for (int lv=0; lv<NLEVEL; lv++)
-      {  
+      {
          if ( MPI_Rank == 0 )    Aux_Message( stdout, "   Lv %2d ... ", lv );
 
 //       adopt dt=0.0 to prevent any update of the fluid fields

--- a/src/Init/Init_GAMER.cpp
+++ b/src/Init/Init_GAMER.cpp
@@ -318,4 +318,33 @@ void Init_GAMER( int *argc, char ***argv )
 #  endif // #ifdef PARTICLE
 
 
+// initialize source-term fields (e.g., cooling time)
+// --> necessary for, for example, estimating the source-term time-step at the first step
+// --> must ensure each source term does not modify any fluid field (e.g., gas internal energy) when dt=0.0 
+//     --> source terms violating this criterion (e.g., deleptonization) must be temporarily disabled before calling Src_AdvanceDt()
+   if ( OPT__INIT != INIT_BY_RESTART )
+   {  
+      const bool OverlapMPI_No   = false;
+      const bool Overlap_Sync_No = false;
+
+      if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ...\n", "Initializing source-term fields" );
+
+      for (int lv=0; lv<NLEVEL; lv++)
+      {  
+         if ( MPI_Rank == 0 )    Aux_Message( stdout, "   Lv %2d ... ", lv );
+
+//       adopt dt=0.0 to prevent any update of the fluid fields
+         Src_AdvanceDt( lv, Time[lv], Time[lv], 0.0, amr->FluSg[lv], amr->MagSg[lv], OverlapMPI_No, Overlap_Sync_No );
+
+//       must exchange all source-term fields since they are currently implemeted as passive scalars,
+//       which will be advected by the fluid solver (and then be overwritten by Src_AdvanceDt())
+//       --> here we exchange all _TOTAL and _MAG fields just for simplicity
+         Buf_GetBufferData( lv, amr->FluSg[lv], amr->MagSg[lv], NULL_INT, DATA_GENERAL, _TOTAL, _MAG, Flu_ParaBuf, USELB_YES );
+
+         if ( MPI_Rank == 0 )    Aux_Message( stdout, "done\n" );
+      } // for (int lv=0; lv<NLEVEL; lv++)
+
+      if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ... done\n", "Initializing source-term fields" );
+   } // if ( OPT__INIT != INIT_BY_RESTART )
+
 } // FUNCTION : Init_GAMER


### PR DESCRIPTION
Call `Src_AdvanceDt()` at the end of `Init_GAMER()` to initialize all source-term fields (e.g., cooling time).