### PR TITLE
Add function to find refined patches to LB_GatherTree

### DIFF
--- a/include/GatherTree.h
+++ b/include/GatherTree.h
@@ -112,6 +112,8 @@ struct LB_GlobalTree : private NonCopyable
    long FindRefinedCounterpart(int X, int Y, int Z, long GID, int MaxLv = NLEVEL) const;
    const LB_GlobalPatch* GetPatch(long GID) const;
    const LB_GlobalPatch& operator[](long) const;
+   const LB_PatchCount&  GetLBPatchCount() const;
+   long PID2GID(int PID, int lv) const;
 
 private:
    LB_PatchCount   PatchCount;

--- a/include/GatherTree.h
+++ b/include/GatherTree.h
@@ -112,7 +112,7 @@ struct LB_GlobalTree : private NonCopyable
 
    int  Local2Global(const int I, const int XYZ, const long GID) const;
    bool IsInsidePatch(const int X, const int Y, const int Z, const long GID) const;
-   long FindRefinedCounterpart(const int X, const int Y, const int Z, const long GID, const int MaxLv = NLEVEL) const;
+   long FindRefinedCounterpart(const int X, const int Y, const int Z, const long GID, const int MaxLv = TOP_LEVEL) const;
    const LB_GlobalPatch& GetPatch(const long GID) const;
    const LB_PatchCount&  GetLBPatchCount() const;
    long PID2GID(const int PID, const int lv) const;

--- a/include/GatherTree.h
+++ b/include/GatherTree.h
@@ -117,8 +117,6 @@ struct LB_GlobalTree : private NonCopyable
 
 private:
    LB_PatchCount   PatchCount;
-   LB_LocalPatchExchangeList*  LocalPatchExchangeList;
-   LB_GlobalPatchExchangeList* GlobalPatchExchangeList;
    LB_GlobalPatch* Patches;
    long            NPatch;
 }; // struct LB_GlobalTree

--- a/include/GatherTree.h
+++ b/include/GatherTree.h
@@ -107,15 +107,15 @@ struct LB_GlobalPatchExchangeList : private NonCopyable
 // global tree information can be accessed after construction via helper functions
 struct LB_GlobalTree : private NonCopyable
 {
-   LB_GlobalTree(int root = -1);
+   LB_GlobalTree(const int root = -1);
    ~LB_GlobalTree();
 
-   int  Local2Global(int I, int XYZ, long GID) const;
-   bool IsInsidePatch(int X, int Y, int Z, long GID) const;
-   long FindRefinedCounterpart(int X, int Y, int Z, long GID, int MaxLv = NLEVEL) const;
-   const LB_GlobalPatch& GetPatch(long GID) const;
+   int  Local2Global(const int I, const int XYZ, const long GID) const;
+   bool IsInsidePatch(const int X, const int Y, const int Z, const long GID) const;
+   long FindRefinedCounterpart(const int X, const int Y, const int Z, const long GID, const int MaxLv = NLEVEL) const;
+   const LB_GlobalPatch& GetPatch(const long GID) const;
    const LB_PatchCount&  GetLBPatchCount() const;
-   long PID2GID(int PID, int lv) const;
+   long PID2GID(const int PID, const int lv) const;
 
    const LB_GlobalPatch& operator[](long) const;
 

--- a/include/GatherTree.h
+++ b/include/GatherTree.h
@@ -110,13 +110,15 @@ struct LB_GlobalTree : private NonCopyable
    int  Local2Global(int I, int XYZ, long GID) const;
    bool IsInsidePatch(int X, int Y, int Z, long GID) const;
    long FindRefinedCounterpart(int X, int Y, int Z, long GID, int MaxLv = NLEVEL) const;
-   const LB_GlobalPatch* GetPatch(long GID) const;
+   const LB_GlobalPatch& GetPatch(long GID) const;
    const LB_GlobalPatch& operator[](long) const;
    const LB_PatchCount&  GetLBPatchCount() const;
    long PID2GID(int PID, int lv) const;
 
 private:
    LB_PatchCount   PatchCount;
+   LB_LocalPatchExchangeList*  LocalPatchExchangeList;
+   LB_GlobalPatchExchangeList* GlobalPatchExchangeList;
    LB_GlobalPatch* Patches;
    long            NPatch;
 }; // struct LB_GlobalTree

--- a/include/GatherTree.h
+++ b/include/GatherTree.h
@@ -110,6 +110,7 @@ struct LB_GlobalTree : private NonCopyable
    int  Local2Global(int I, int XYZ, long GID) const;
    bool IsInsidePatch(int X, int Y, int Z, long GID) const;
    long FindRefinedCounterpart(int X, int Y, int Z, long GID, int MaxLv = NLEVEL) const;
+   const LB_GlobalPatch* GetPatch(long GID)  const;
 
 private:
    LB_PatchCount   PatchCount;

--- a/include/GatherTree.h
+++ b/include/GatherTree.h
@@ -110,7 +110,8 @@ struct LB_GlobalTree : private NonCopyable
    int  Local2Global(int I, int XYZ, long GID) const;
    bool IsInsidePatch(int X, int Y, int Z, long GID) const;
    long FindRefinedCounterpart(int X, int Y, int Z, long GID, int MaxLv = NLEVEL) const;
-   const LB_GlobalPatch* GetPatch(long GID)  const;
+   const LB_GlobalPatch* GetPatch(long GID) const;
+   const LB_GlobalPatch& operator[](long) const;
 
 private:
    LB_PatchCount   PatchCount;

--- a/include/GatherTree.h
+++ b/include/GatherTree.h
@@ -102,18 +102,22 @@ struct LB_GlobalPatchExchangeList : private NonCopyable
    bool isInitialised;
 }; // struct LB_GlobalPatchExchangeList
 
+// class to manage LB_PatchCount and global tree consisting of LB_GlobalPatch
+// constructor calls LB_GatherTree
+// global tree information can be accessed after construction via helper functions
 struct LB_GlobalTree : private NonCopyable
 {
-   LB_GlobalTree(int root);
+   LB_GlobalTree(int root = -1);
    ~LB_GlobalTree();
 
    int  Local2Global(int I, int XYZ, long GID) const;
    bool IsInsidePatch(int X, int Y, int Z, long GID) const;
    long FindRefinedCounterpart(int X, int Y, int Z, long GID, int MaxLv = NLEVEL) const;
    const LB_GlobalPatch& GetPatch(long GID) const;
-   const LB_GlobalPatch& operator[](long) const;
    const LB_PatchCount&  GetLBPatchCount() const;
    long PID2GID(int PID, int lv) const;
+
+   const LB_GlobalPatch& operator[](long) const;
 
 private:
    LB_PatchCount   PatchCount;

--- a/include/GatherTree.h
+++ b/include/GatherTree.h
@@ -1,12 +1,7 @@
 #ifndef __GATHER_TREE_H__
 #define __GATHER_TREE_H__
 
-
-
-#include <stdio.h>
 #include "Macro.h"
-
-
 
 class NonCopyable
 {
@@ -107,6 +102,20 @@ struct LB_GlobalPatchExchangeList : private NonCopyable
    bool isInitialised;
 }; // struct LB_GlobalPatchExchangeList
 
+struct LB_GlobalTree : private NonCopyable
+{
+   LB_GlobalTree(int root);
+   ~LB_GlobalTree();
+
+   int  Local2Global(int I, int XYZ, long GID) const;
+   bool IsInsidePatch(int X, int Y, int Z, long GID) const;
+   long FindRefinedCounterpart(int X, int Y, int Z, long GID, int MaxLv = NLEVEL) const;
+
+private:
+   LB_PatchCount   PatchCount;
+   LB_GlobalPatch* Patches;
+   long            NPatch;
+}; // struct LB_GlobalTree
 
 
 #endif // #ifndef __GATHER_TREE_H__

--- a/src/LoadBalance/LB_GatherTree.cpp
+++ b/src/LoadBalance/LB_GatherTree.cpp
@@ -811,9 +811,13 @@ bool LB_GlobalTree::IsInsidePatch(const int X, const int Y, const int Z, const l
 
    int Coordinates[3] = {X, Y, Z};
 
-   for ( int l = 0; l < 3; ++l ) {
+   for ( int l = 0; l < 3; ++l )
+   {
       if (Coordinates[l] < Patches[GID].corner[l] || Coordinates[l] >=  Patches[GID].corner[l] + PS1 * amr->scale[Patches[GID].level])
+      {
          IsInside = false;
+         break;
+      }
    }
 
    return IsInside;
@@ -824,12 +828,12 @@ bool LB_GlobalTree::IsInsidePatch(const int X, const int Y, const int Z, const l
 // Description :  Convert local patch coordinates in direction XYZ to global coordinates
 //
 // Note        :  This function also works for I > PS1 and will return the global coordinate relative to GID.
-//                For patch groups, pass the GID of the root patch and I between (0 and PS2)
+//                For patch groups, pass the GID of the root patch and the local coordinate I between in {0, ..., PS2}
 //                int X = Local2Global(I, 0, GID0);
 //                int Y = Local2Global(I, 1, GID0);
 //                int Z = Local2Global(I, 2, GID0);
 //
-// Parameter   :  I   : local coordinate I in {0, ..., PS2} relative root patch GID
+// Parameter   :  I   : local coordinate I in {0, ..., PS2} relative to root patch GID
 //             : XYZ  : direction
 //             : GID  : root patch relative to local coordinate I
 //
@@ -854,7 +858,7 @@ int LB_GlobalTree::Local2Global(const int I, const int XYZ, const long GID) cons
 
 //-------------------------------------------------------------------------------------------------------
 // Function    :  LB_GlobalTree::FindRefinedCounterpart
-// Description :  Return GID of refined patch with maximum level MaxLv (default = NLEVEL)) that global integer coordinates [X, Y, Z] belong to
+// Description :  Return GID of refined patch with maximum level MaxLv (default = TOP_LEVEL) that global integer coordinates [X, Y, Z] belong to
 //
 //
 // Parameter   :  X   : global integer x coordinate, obtained by converting local coordinate with amr->scale

--- a/src/LoadBalance/LB_GatherTree.cpp
+++ b/src/LoadBalance/LB_GatherTree.cpp
@@ -1018,25 +1018,33 @@ const LB_PatchCount&  LB_GlobalTree::GetLBPatchCount() const
 //
 // Return      :  GID
 //-------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------------
+// Function    :  LB_GlobalTree::PID2GID
+// Description :  Given PID and lv, return GID
+//
+// Note        :  Does not support patches abroad
+//
+// Return      :  GID
+//-------------------------------------------------------------------------------------------------------
 long LB_GlobalTree::PID2GID(int PID, int lv) const
 {
-   if ( PID < 0 )
+   if ( PID == -1 )
    {
       return PID;
    }
 // patch is a real patch
-   else if ( PID < amr->NPatchComma[lv][1] )
+   else if ( -1 < PID && PID < amr->NPatchComma[lv][1] )
    {
       return PID + PatchCount.GID_Offset[lv];
    }
 
-// sibling patch is a buffer patch (which may lie outside the simulation domain)
+// patch is a buffer patch (which may lie outside the simulation domain)
    else
    {
 #     ifdef GAMER_DEBUG
-      Aux_Error( ERROR_INFO, "Lv %d, PID %d >= total number of patches on local MPI Rank %d !!\n",
-                 lv, PID, amr->num[lv] );
+      Aux_Error( ERROR_INFO, "Lv %d, NPatch %d, PID %d is buffer patch on local MPI Rank %d !!\n",
+                 lv, amr->NPatchComma[lv][1], PID, amr->num[lv] );
 #     endif
       return -1;
-   } // if ( SibPID >= amr->NPatchComma[lv][1] )
+   }
 } // FUNCTION : LB_GlobalTree::PID2GID

--- a/src/LoadBalance/LB_GatherTree.cpp
+++ b/src/LoadBalance/LB_GatherTree.cpp
@@ -994,3 +994,8 @@ const LB_GlobalPatch* LB_GlobalTree::GetPatch(long GID)  const
 
    return &Patches[GID];
 } // LB_GlobalTree::GetPatch
+
+const LB_GlobalPatch& LB_GlobalTree::operator[](long GID) const
+{
+   return *GetPatch(GID);
+}

--- a/src/LoadBalance/LB_GatherTree.cpp
+++ b/src/LoadBalance/LB_GatherTree.cpp
@@ -999,3 +999,13 @@ const LB_GlobalPatch& LB_GlobalTree::operator[](long GID) const
 {
    return *GetPatch(GID);
 }
+
+const LB_PatchCount&  LB_GlobalTree::GetLBPatchCount() const
+{
+   return PatchCount;
+}
+
+long LB_GlobalTree::PID2GID(int PID, int lv) const
+{
+   return PID + PatchCount.GID_Offset[lv];
+}

--- a/src/LoadBalance/LB_GatherTree.cpp
+++ b/src/LoadBalance/LB_GatherTree.cpp
@@ -1009,15 +1009,6 @@ const LB_PatchCount&  LB_GlobalTree::GetLBPatchCount() const
 {
    return PatchCount;
 } // FUNCTION : LB_GlobalTree::GetLBPatchCount
-
-//-------------------------------------------------------------------------------------------------------
-// Function    :  LB_GlobalTree::PID2GID
-// Description :  Given PID and lv, return GID
-//
-// Note        :  Does not support patches abroad
-//
-// Return      :  GID
-//-------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------
 // Function    :  LB_GlobalTree::PID2GID
 // Description :  Given PID and lv, return GID

--- a/src/LoadBalance/LB_GatherTree.cpp
+++ b/src/LoadBalance/LB_GatherTree.cpp
@@ -281,6 +281,57 @@ void LB_AllgatherLBIdx( LB_PatchCount& pc, LB_LocalPatchExchangeList& lel, LB_Gl
 } // FUNCTION : LB_AllgatherLBIdx
 
 
+//-------------------------------------------------------------------------------------------------------
+// Function    :  LB_PID2GID
+// Description :  Given PID and lv, return GID
+//
+// Parameter   :  PID  : PID to convert
+//             :  lv   : Level of PID
+//             :  pc   : Reference to LB_PatchCount object
+//             :  lel  : Reference to LB_LocalPatchExchangeList
+// Return      :  GID
+//-------------------------------------------------------------------------------------------------------
+long LB_PID2GID(int PID, int lv, const LB_PatchCount& pc, const LB_LocalPatchExchangeList& lel)
+{
+   if ( PID < 0 )
+   {
+      return PID;
+   }
+// patch is a real patch
+   else if ( PID < amr->NPatchComma[lv][1] )
+   {
+      return PID + pc.GID_Offset[lv];
+   }
+// sibling patch is a buffer patch (which may lie outside the simulation domain)
+   else
+   {
+      int   MatchIdx;
+      long  LBIdx;
+      int  *Cr=NULL;
+
+#     ifdef GAMER_DEBUG
+      if ( PID >= amr->num[lv] )
+      Aux_Error( ERROR_INFO, "Lv %d, PID %d >= total number of patches %d !!\n",
+                 lv, PID, amr->num[lv] );
+#     endif
+
+//    get the GID by "corner -> LB_Idx -> GID"
+      Cr    = amr->patch[0][lv][PID]->corner;
+      LBIdx = LB_Corner2Index( lv, Cr, CHECK_OFF );   // periodicity has been assumed here
+
+      Mis_Matching_int( NPatchTotal[lv], lel.LBIdxList_Sort[lv], 1, &LBIdx, &MatchIdx );
+
+#     ifdef GAMER_DEBUG
+      if ( MatchIdx < 0 )
+      Aux_Error( ERROR_INFO, "Lv %d, PID %d, LBIdx %ld, couldn't find a matching patch !!\n",
+                 lv, PID, LBIdx );
+#     endif
+
+      return lel.LBIdxList_Sort_IdxTable[lv][MatchIdx] + pc.GID_LvStart[lv];
+   } // if ( PID >= amr->NPatchComma[lv][1] )
+
+} // FUNCTION : LB_PID2GID
+
 
 //-------------------------------------------------------------------------------------------------------
 // Function    :  LB_FillLocalPatchExchangeList
@@ -302,9 +353,7 @@ void LB_FillLocalPatchExchangeList( LB_PatchCount& pc, LB_LocalPatchExchangeList
 #  endif
 
 // temporary variables
-   int   MyGID, FaPID, FaGID, FaLv, SonPID, SonGID, SonLv, SibPID, SibGID, MatchIdx;
-   long  FaLBIdx, SonLBIdx, SibLBIdx;
-   int  *SonCr=NULL, *SibCr=NULL;
+   int   MyGID, FaPID, FaLv, SonPID, SonLv, SibPID, SibLv;
 
 // store the local tree
    for (int lv=0; lv<NLEVEL; lv++)
@@ -331,99 +380,16 @@ void LB_FillLocalPatchExchangeList( LB_PatchCount& pc, LB_LocalPatchExchangeList
             if ( lv != 0 )       Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d < 0 !!\n", lv, PID, FaPID );
             if ( FaPID != -1 )   Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d < 0 but != -1 !!\n", lv, PID, FaPID );
 #           endif
-
-            FaGID = FaPID;
          }
 
-//       father patch is a real patch
-         else if ( FaPID < amr->NPatchComma[FaLv][1] )
-            FaGID = FaPID + pc.GID_Offset[FaLv];
-
-//       father patch is a buffer patch (only possible in LOAD_BALANCE)
-         else // (FaPID >= amr->NPatchComma[FaLv][1] )
-         {
-#           ifdef GAMER_DEBUG
-#           ifndef LOAD_BALANCE
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d >= NRealFaPatch %d (only possible in LOAD_BALANCE) !!\n",
-                       lv, PID, FaPID, amr->NPatchComma[FaLv][1] );
-#           endif
-
-            if ( FaPID >= amr->num[FaLv] )
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d >= total number of patches %d !!\n",
-                       lv, PID, FaPID, amr->num[FaLv] );
-#           endif // GAMER_DEBUG
-
-            FaLBIdx = amr->patch[0][FaLv][FaPID]->LB_Idx;
-
-            Mis_Matching_int( NPatchTotal[FaLv], lel.LBIdxList_Sort[FaLv], 1, &FaLBIdx, &MatchIdx );
-
-#           ifdef GAMER_DEBUG
-            if ( MatchIdx < 0 )
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d, FaLBIdx %ld, couldn't find a matching patch !!\n",
-                       lv, PID, FaPID, FaLBIdx );
-#           endif
-
-            FaGID = lel.LBIdxList_Sort_IdxTable[FaLv][MatchIdx] + pc.GID_LvStart[FaLv];
-         } // if ( FaPID >= amr->NPatchComma[FaLv][1] )
-
-         lel.FaList_Local[lv][PID] = FaGID;
+         lel.FaList_Local[lv][PID] = LB_PID2GID(FaPID, FaLv, pc, lel);
 
 
 //       4. son GID
          SonPID = amr->patch[0][lv][PID]->son;
          SonLv  = lv + 1;
 
-//       no son (must check this first since SonLv may be out of range --> == NLEVEL)
-         if      ( SonPID == -1 )
-            SonGID = SonPID;
-
-//       son patch is a real patch at home
-         else if ( SonPID >= 0  &&  SonPID < amr->NPatchComma[SonLv][1] )
-            SonGID = SonPID + pc.GID_Offset[SonLv];
-
-//       son patch lives abroad (only possible in LOAD_BALANCE)
-         else if ( SonPID < -1 )
-         {
-#           ifdef GAMER_DEBUG
-#           ifdef LOAD_BALANCE
-            const int SonRank = SON_OFFSET_LB - SonPID;
-            if ( SonRank < 0  ||  SonRank == MPI_Rank  ||  SonRank >= MPI_NRank )
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, SonPID %d, incorrect SonRank %d (MyRank %d, NRank %d) !!\n",
-                       lv, PID, SonPID, SonRank, MPI_Rank, MPI_NRank );
-#           else
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, SonPID %d < -1 (only possible in LOAD_BALANCE) !!\n",
-                       lv, PID, SonPID );
-#           endif // LOAD_BALANCE
-#           endif // GAMER_DEBUG
-
-//          get the SonGID by "father corner = son corner -> son LB_Idx -> son GID"
-//          --> for Hilbert curve we have "SonLBIdx-SonLBIdx%8 = 8*MyLBIdx"
-            SonCr    = amr->patch[0][lv][PID]->corner;
-            SonLBIdx = LB_Corner2Index( SonLv, SonCr, CHECK_ON );
-
-#           if ( defined GAMER_DEBUG  &&  LOAD_BALANCE == HILBERT )
-            if ( SonLBIdx - SonLBIdx%8 != 8*amr->patch[0][lv][PID]->LB_Idx )
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, SonPID %d, SonCr (%d,%d,%d), incorret SonLBIdx %ld, (MyLBIdx %ld) !!\n",
-                       lv, PID, SonPID, SonCr[0], SonCr[1], SonCr[2], SonLBIdx, amr->patch[0][lv][PID]->LB_Idx );
-#           endif
-
-            Mis_Matching_int( NPatchTotal[SonLv], lel.LBIdxList_Sort[SonLv], 1, &SonLBIdx, &MatchIdx );
-
-#           ifdef GAMER_DEBUG
-            if ( MatchIdx < 0 )
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, SonPID %d, SonLBIdx %ld, couldn't find a matching patch !!\n",
-                       lv, PID, SonPID, SonLBIdx );
-#           endif
-
-            SonGID = lel.LBIdxList_Sort_IdxTable[SonLv][MatchIdx] + pc.GID_LvStart[SonLv];
-         } // else if ( SonPID < -1 )
-
-//       son patch is a buffer patch (SonPID >= amr->NPatchComma[SonLv][1]) --> impossible
-         else // ( SonPID >= amr->NPatchComma[SonLv][1] )
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, SonPID %d is a buffer patch (NRealSonPatch %d) !!\n",
-                       lv, PID, SonPID, amr->NPatchComma[SonLv][1] );
-
-         lel.SonList_Local[lv][PID] = SonGID;
+         lel.SonList_Local[lv][PID] = LB_PID2GID(SonPID, SonLv, pc, lel);
 
 
 //       5. sibling GID
@@ -431,39 +397,7 @@ void LB_FillLocalPatchExchangeList( LB_PatchCount& pc, LB_LocalPatchExchangeList
          {
             SibPID = amr->patch[0][lv][PID]->sibling[s];
 
-//          no sibling (SibPID can be either -1 or SIB_OFFSET_NONPERIODIC-BoundaryDirection)
-            if      ( SibPID < 0 )
-               SibGID = SibPID;
-
-//          sibling patch is a real patch
-            else if ( SibPID < amr->NPatchComma[lv][1] )
-               SibGID = SibPID + pc.GID_Offset[lv];
-
-//          sibling patch is a buffer patch (which may lie outside the simulation domain)
-            else
-            {
-#              ifdef GAMER_DEBUG
-               if ( SibPID >= amr->num[lv] )
-               Aux_Error( ERROR_INFO, "Lv %d, PID %d, SibPID %d >= total number of patches %d !!\n",
-                          lv, PID, SibPID, amr->num[lv] );
-#              endif
-
-//             get the SibGID by "sibling corner -> sibling LB_Idx -> sibling GID"
-               SibCr    = amr->patch[0][lv][SibPID]->corner;
-               SibLBIdx = LB_Corner2Index( lv, SibCr, CHECK_OFF );   // periodicity has been assumed here
-
-               Mis_Matching_int( NPatchTotal[lv], lel.LBIdxList_Sort[lv], 1, &SibLBIdx, &MatchIdx );
-
-#              ifdef GAMER_DEBUG
-               if ( MatchIdx < 0 )
-               Aux_Error( ERROR_INFO, "Lv %d, PID %d, SibPID %d, SibLBIdx %ld, couldn't find a matching patch !!\n",
-                          lv, PID, SibPID, SibLBIdx );
-#              endif
-
-               SibGID = lel.LBIdxList_Sort_IdxTable[lv][MatchIdx] + pc.GID_LvStart[lv];
-            } // if ( SibPID >= amr->NPatchComma[lv][1] )
-
-            lel.SibList_Local[lv][PID][s] = SibGID;
+            lel.SibList_Local[lv][PID][s] = LB_PID2GID(SibPID, lv, pc, lel);
 
          } // for (int s=0; s<26; s++)
 
@@ -1039,42 +973,5 @@ const LB_PatchCount&  LB_GlobalTree::GetLBPatchCount() const
 //-------------------------------------------------------------------------------------------------------
 long LB_GlobalTree::PID2GID(int PID, int lv) const
 {
-   if ( PID < 0 )
-   {
-      return PID;
-   }
-// patch is a real patch
-   else if ( PID < amr->NPatchComma[lv][1] )
-   {
-      return PID + PatchCount.GID_Offset[lv];
-   }
-// sibling patch is a buffer patch (which may lie outside the simulation domain)
-   else
-   {
-      int   MatchIdx;
-      long  LBIdx;
-      int  *Cr=NULL;
-
-#     ifdef GAMER_DEBUG
-      if ( PID >= amr->num[lv] )
-      Aux_Error( ERROR_INFO, "Lv %d, PID %d >= total number of patches %d !!\n",
-                 lv, PID, amr->num[lv] );
-#     endif
-
-//    get the GID by "corner -> LB_Idx -> GID"
-      Cr    = amr->patch[0][lv][PID]->corner;
-      LBIdx = LB_Corner2Index( lv, Cr, CHECK_OFF );   // periodicity has been assumed here
-
-      Mis_Matching_int( NPatchTotal[lv], LocalPatchExchangeList->LBIdxList_Sort[lv], 1, &LBIdx, &MatchIdx );
-
-#     ifdef GAMER_DEBUG
-      if ( MatchIdx < 0 )
-      Aux_Error( ERROR_INFO, "Lv %d, PID %d, LBIdx %ld, couldn't find a matching patch !!\n",
-                 lv, PID, LBIdx );
-#     endif
-
-      return LocalPatchExchangeList->LBIdxList_Sort_IdxTable[lv][MatchIdx] + PatchCount.GID_LvStart[lv];
-   } // if ( PID >= amr->NPatchComma[lv][1] )
-
-   return PID + PatchCount.GID_Offset[lv];
+   return LB_PID2GID(PID, lv, PatchCount, *LocalPatchExchangeList);
 } // FUNCTION : LB_GlobalTree::PID2GID

--- a/src/LoadBalance/LB_GatherTree.cpp
+++ b/src/LoadBalance/LB_GatherTree.cpp
@@ -967,3 +967,30 @@ long LB_GlobalTree::FindRefinedCounterpart(int X, int Y, int Z, long GID, int Ma
 
    return FaGID;
 } // FUNCTION : LB_GlobalTree::FindRefinedCounterpart
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  LB_GlobalTree::GetPatch
+// Description :  Return pointer to local patch object with GID
+//
+// Parameter   :  GID  : global ID of patch
+//
+// Return      :  Constant pointer to LB_LocalPatch
+//-------------------------------------------------------------------------------------------------------
+const LB_GlobalPatch* LB_GlobalTree::GetPatch(long GID)  const
+{
+// sanity check
+#  ifdef GAMER_DEBUG
+   if (GID == -1)
+   {
+      Aux_Error(ERROR_INFO, "GID  == -1!\n");
+   }
+   if (GID >= NPatch)
+   {
+      Aux_Error(ERROR_INFO, "GID (%ld) >= NPatch (%ld)!\n", GID, NPatch);
+   }
+#  endif
+
+
+   return &Patches[GID];
+} // LB_GlobalTree::GetPatch

--- a/src/LoadBalance/LB_GatherTree.cpp
+++ b/src/LoadBalance/LB_GatherTree.cpp
@@ -871,20 +871,11 @@ long LB_GlobalTree::FindRefinedCounterpart(int X, int Y, int Z, long GID, int Ma
 
 #  ifdef GAMER_DEBUG
 // sanity check
-   if (GID0 == -1)
-   {
-      Aux_Error(ERROR_INFO, "GID0 == -1 !!\n");
-   }
    if (GID == -1)
    {
       Aux_Error(ERROR_INFO, "GID  == -1!\n");
    }
    if (GID >= NPatch)
-   {
-      Aux_Error(ERROR_INFO, "GID (%ld) >= NPatch (%ld)!\n", GID, NPatch);
-   }
-
-   if (GID0 >= NPatch)
    {
       Aux_Error(ERROR_INFO, "GID (%ld) >= NPatch (%ld)!\n", GID, NPatch);
    }


### PR DESCRIPTION
This pull request introduces the new class LB_GlobalTree to make managing the AMR structure returned by LB_GatherTree easier. It also offers a few convenience functions that allow users to find refined patches corresponding to cells on coarser patches. 