### PR TITLE
Add rpath in Makefile_base

### DIFF
--- a/src/Makefile_base
+++ b/src/Makefile_base
@@ -369,7 +369,7 @@ endif
 # -------------------------------------------------------------------------------
 ifeq "$(filter -DGPU, $(SIMU_OPTION))" "-DGPU"
 LIB += -L$(CUDA_PATH)/lib64
-#LIB += -L$(CUDA_PATH)/lib
+LIB += -Wl,-rpath=$(CUDA_PATH)/lib64
 LIB += -lcudart
 endif
 
@@ -379,6 +379,7 @@ endif
 
 ifeq "$(filter -DSUPPORT_FFTW=FFTW3, $(SIMU_OPTION))" "-DSUPPORT_FFTW=FFTW3"
    LIB += -L$(FFTW3_PATH)/lib
+   LIB += -Wl,-rpath=$(FFTW3_PATH)/lib
    ifeq "$(filter -DSERIAL, $(SIMU_OPTION))" "-DSERIAL"
       LIB += -lfftw3 -lfftw3f -lm
    else
@@ -392,6 +393,7 @@ endif
 
 ifeq "$(filter -DSUPPORT_FFTW=FFTW2, $(SIMU_OPTION))" "-DSUPPORT_FFTW=FFTW2"
    LIB += -L$(FFTW2_PATH)/lib
+   LIB += -Wl,-rpath=$(FFTW2_PATH)/lib
    ifeq "$(filter -DFLOAT8, $(SIMU_OPTION))" "-DFLOAT8"
       ifeq "$(filter -DSERIAL, $(SIMU_OPTION))" "-DSERIAL"
          LIB += -ldrfftw -ldfftw
@@ -409,18 +411,22 @@ endif
 
 ifeq "$(filter -DSUPPORT_GRACKLE, $(SIMU_OPTION))" "-DSUPPORT_GRACKLE"
 LIB += -L$(GRACKLE_PATH)/lib -lgrackle
+LIB += -Wl,-rpath=$(GRACKLE_PATH)/lib
 endif
 
 ifeq "$(filter -DSUPPORT_HDF5, $(SIMU_OPTION))" "-DSUPPORT_HDF5"
 LIB += -L$(HDF5_PATH)/lib -lhdf5
+LIB += -Wl,-rpath=$(HDF5_PATH)/lib
 endif
 
 ifeq "$(filter -DSUPPORT_GSL, $(SIMU_OPTION))" "-DSUPPORT_GSL"
 LIB += -L$(GSL_PATH)/lib -lgsl -lgslcblas
+LIB += -Wl,-rpath=$(GSL_PATH)/lib
 endif
 
 ifeq "$(filter -DSUPPORT_LIBYT, $(SIMU_OPTION))" "-DSUPPORT_LIBYT"
 LIB += -L$(LIBYT_PATH)/lib -lyt
+LIB += -Wl,-rpath=$(LIBYT_PATH)/lib
 endif
 
 


### PR DESCRIPTION
Add `rpath` in `Makefile_base` for all library paths so that users do not have to set `LD_LIBRARY_PATH` manually.

Note that it doesn't mean `rpath` has higher precedence than `LD_LIBRARY_PATH` since whether `rpath` sets `RPATH` or `RUNPATH` is system-dependent. See the following references for details. As a result, if users still set `LD_LIBRARY_PATH`, they must make sure that it is consistent with the paths in `MACHINE.config`. 

References:
- [OpenMPI manual](https://docs.open-mpi.org/en/v5.0.x/installing-open-mpi/configure-cli-options/installation.html#installation-options)
- [wiki](https://en.wikipedia.org/wiki/Rpath)