### PR TITLE
Support OPT__RESET_FLUID_INIT for OPT__INIT=3

### DIFF
--- a/src/Auxiliary/Aux_Check_Parameter.cpp
+++ b/src/Auxiliary/Aux_Check_Parameter.cpp
@@ -597,9 +597,6 @@ void Aux_Check_Parameter()
       Aux_Message( stderr, "WARNING : DT__FLUID_INIT (%14.7e) is not within the normal range [0...1] !!\n",
                    DT__FLUID_INIT );
 
-   if ( OPT__RESET_FLUID_INIT  &&  OPT__INIT == INIT_BY_FILE )
-      Aux_Message( stderr, "WARNING : \"%s\" will NOT be applied to the input uniform data !!\n", "OPT__RESET_FLUID_INIT" );
-
 #  ifdef MHD
    if ( OPT__RESET_FLUID_INIT  &&  MHD_ResetByUser_BField_Ptr != NULL  &&  INIT_SUBSAMPLING_NCELL > 1 )
       Aux_Message( stderr, "WARNING : \"%s\" will NOT be applied to resetting initial magnetic field !!\n", "INIT_SUBSAMPLING_NCELL" );

--- a/src/Auxiliary/Aux_Check_Parameter.cpp
+++ b/src/Auxiliary/Aux_Check_Parameter.cpp
@@ -249,7 +249,11 @@ void Aux_Check_Parameter()
       Aux_Error( ERROR_INFO, "must enable OPT__FIXUP_RESTRICT for BITWISE_REPRODUCIBILITY !!\n" );
 
    if ( ! OPT__SORT_PATCH_BY_LBIDX )
+#     ifdef SERIAL
+      Aux_Message( stderr, "WARNING : SERIAL does not support OPT__SORT_PATCH_BY_LBIDX, which may break BITWISE_REPRODUCIBILITY !!\n" );
+#     else
       Aux_Error( ERROR_INFO, "must enable OPT__SORT_PATCH_BY_LBIDX for BITWISE_REPRODUCIBILITY !!\n" );
+#     endif
 
 #  ifdef SUPPORT_FFTW
    if ( OPT__FFTW_STARTUP != FFTW_STARTUP_ESTIMATE )

--- a/src/Init/Init_ByFile.cpp
+++ b/src/Init/Init_ByFile.cpp
@@ -16,6 +16,8 @@ static void Init_ByFile_AssignData( const char UM_Filename[], const int UM_lv, c
 static void Load_RefineRegion( const char Filename[] );
 static void Flag_RefineRegion( const int lv, const int FlagPatch[6] );
 
+extern void (*Flu_ResetByUser_API_Ptr)( const int lv, const int FluSg, const int MagSg, const double TimeNew, const double dt );
+
 
 
 
@@ -159,6 +161,9 @@ void Init_ByFile()
       Aux_Error( ERROR_INFO, "OPT__UM_IC_LEVEL (%d) + OPT__UM_IC_NLEVEL (%d) - 1 = %d > MAX_LEVEL (%d) !!\n",
                  OPT__UM_IC_LEVEL, OPT__UM_IC_NLEVEL, OPT__UM_IC_LEVEL+OPT__UM_IC_NLEVEL-1, MAX_LEVEL );
 
+   if ( OPT__RESET_FLUID_INIT  &&  Flu_ResetByUser_API_Ptr == NULL )
+      Aux_Error( ERROR_INFO, "Flu_ResetByUser_API_Ptr == NULL for OPT__RESET_FLUID_INIT !!\n" );
+
 // check file size
    long FileSize, ExpectSize;
 
@@ -272,6 +277,10 @@ void Init_ByFile()
    Init_ByFile_AssignData( UM_Filename, OPT__UM_IC_LEVEL, OPT__UM_IC_LEVEL, OPT__UM_IC_NVAR, OPT__UM_IC_LOAD_NRANK,
                            OPT__UM_IC_FORMAT, UM_Size3D, FlagPatch );
 
+   if ( OPT__RESET_FLUID_INIT )
+      Flu_ResetByUser_API_Ptr( OPT__UM_IC_LEVEL, amr->FluSg[OPT__UM_IC_LEVEL], amr->MagSg[OPT__UM_IC_LEVEL],
+                               Time[OPT__UM_IC_LEVEL], 0.0 );
+
 #  ifdef LOAD_BALANCE
    Buf_GetBufferData( OPT__UM_IC_LEVEL, amr->FluSg[OPT__UM_IC_LEVEL], amr->MagSg[OPT__UM_IC_LEVEL], NULL_INT,
                       DATA_GENERAL, _TOTAL, _MAG, Flu_ParaBuf, USELB_YES );
@@ -319,6 +328,9 @@ void Init_ByFile()
 //    assign data on SonLv
       Init_ByFile_AssignData( UM_Filename, SonLv, OPT__UM_IC_LEVEL, OPT__UM_IC_NVAR, OPT__UM_IC_LOAD_NRANK,
                               OPT__UM_IC_FORMAT, UM_Size3D, FlagPatch );
+
+      if ( OPT__RESET_FLUID_INIT )
+         Flu_ResetByUser_API_Ptr( SonLv, amr->FluSg[SonLv], amr->MagSg[SonLv], Time[SonLv], 0.0 );
 
 //    fill the buffer patches on SonLv
 #     ifdef LOAD_BALANCE
@@ -381,6 +393,12 @@ void Init_ByFile()
 
 
 // 9. refine the uniform-mesh data from levels OPT__UM_IC_LEVEL to MAX_LEVEL-1
+//    --> we currently do not apply OPT__RESET_FLUID_INIT after Refine() because
+//        (1) the existing patches from level OPT__UM_IC_LEVEL to level OPT__UM_IC_LEVEL+OPT__UM_IC_NLEVEL-1
+//            already include the reset results (by Flu_ResetByUser_API_Ptr() directly),
+//        (2) the refined patches on levels higher than OPT__UM_IC_LEVEL+OPT__UM_IC_NLEVEL-1
+//            also include the reset results (by interpolation), and
+//        (3) to avoid double-counting the reset data when Flu_ResetByUser_API_Ptr() uses fluid[]+=... instead of fluid[]=...
    if ( OPT__UM_IC_REFINE )
    for (int lv=OPT__UM_IC_LEVEL; lv<MAX_LEVEL; lv++)
    {


### PR DESCRIPTION
- Support `OPT__RESET_FLUID_INIT` for `OPT__INIT=3`
- Raise a warning for `SERIAL+BITWISE_REPRODUCIBILITY` since it doesn't support `OPT__SORT_PATCH_BY_LBIDX`