### PR TITLE
Use heap instead of stack memory for large arrays in Refine()

### DIFF
--- a/src/Refine/Refine.cpp
+++ b/src/Refine/Refine.cpp
@@ -77,8 +77,14 @@ void Refine( const int lv, const UseLBFunc_t UseLBFunc )
    const int CStart_Flu[3] = { CGhost_Flu, CGhost_Flu, CGhost_Flu };
    const int CSize_Flu3[3] = { CSize_Flu, CSize_Flu, CSize_Flu };
 
-   real Flu_CData[NCOMP_TOTAL][CSize_Flu][CSize_Flu][CSize_Flu];  // coarse-grid fluid array for interpolation
-   real Flu_FData[NCOMP_TOTAL][FSize_CC ][FSize_CC ][FSize_CC ];  // fine-grid fluid array storing the interpolation result
+// coarse- and fine-grid fluid arrays for interpolation
+   real *Flu_CData1D = new real [ NCOMP_TOTAL*CUBE(CSize_Flu) ];
+   real *Flu_FData1D = new real [ NCOMP_TOTAL*CUBE(FSize_CC ) ];
+// 1D array -> 3D array
+   typedef real (*vla_FluC)[CSize_Flu][CSize_Flu][CSize_Flu];
+   typedef real (*vla_FluF)[FSize_CC ][FSize_CC ][FSize_CC ];
+   vla_FluC Flu_CData = ( vla_FluC )Flu_CData1D;
+   vla_FluF Flu_FData = ( vla_FluF )Flu_FData1D;
 
 #  ifdef GRAVITY
    int NSide_Pot, CGhost_Pot;
@@ -87,8 +93,14 @@ void Refine( const int lv, const UseLBFunc_t UseLBFunc )
    const int CSize_Pot     = PS1 + 2*CGhost_Pot;
    const int CStart_Pot[3] = { CGhost_Pot, CGhost_Pot, CGhost_Pot };
 
-   real Pot_CData[CSize_Pot][CSize_Pot][CSize_Pot];   // coarse-grid potential array for interpolation
-   real Pot_FData[FSize_CC ][FSize_CC ][FSize_CC ];   // fine-grid potential array storing the interpolation result
+// coarse- and fine-grid potential arrays for interpolation
+   real *Pot_CData1D = new real [ CUBE(CSize_Pot) ];
+   real *Pot_FData1D = new real [ CUBE(FSize_CC ) ];
+// 1D array -> 3D array
+   typedef real (*vla_PotC)[CSize_Pot][CSize_Pot];
+   typedef real (*vla_PotF)[FSize_CC ][FSize_CC ];
+   vla_PotC Pot_CData = ( vla_PotC )Pot_CData1D;
+   vla_PotF Pot_FData = ( vla_PotF )Pot_FData1D;
 #  endif
 
 #  ifdef MHD
@@ -110,8 +122,14 @@ void Refine( const int lv, const UseLBFunc_t UseLBFunc )
                                    { CSize_Mag_T, CSize_Mag_N, CSize_Mag_T },
                                    { CSize_Mag_T, CSize_Mag_T, CSize_Mag_N }  };
 
-   real Mag_CData[NCOMP_MAG][ CSize_Mag_N*SQR(CSize_Mag_T) ];  // coarse-grid B field array for interpolation
-   real Mag_FData[NCOMP_MAG][ PS2P1*SQR(PS2) ];                // fine-grid B field array storing the interpolation result
+// coarse- and fine-grid B field arrays for interpolation
+   real *Mag_CData1D = new real [ NCOMP_MAG*CSize_Mag_N*SQR(CSize_Mag_T) ];
+   real *Mag_FData1D = new real [ NCOMP_MAG*PS2P1*SQR(PS2) ];
+// 1D array -> 3D array
+   typedef real (*vla_MagC)[ CSize_Mag_N*SQR(CSize_Mag_T) ];
+   typedef real (*vla_MagF)[ PS2P1*SQR(PS2) ];
+   vla_MagC Mag_CData = ( vla_MagC )Mag_CData1D;
+   vla_MagF Mag_FData = ( vla_MagF )Mag_FData1D;
 
    real *Mag_FInterface_Ptr [6] = { NULL, NULL, NULL, NULL, NULL, NULL };
    real *Mag_FInterface_Data[6] = { NULL, NULL, NULL, NULL, NULL, NULL };
@@ -1012,7 +1030,15 @@ void Refine( const int lv, const UseLBFunc_t UseLBFunc )
 
 
 // free memory
+   delete [] Flu_CData1D;
+   delete [] Flu_FData1D;
+#  ifdef GRAVITY
+   delete [] Pot_CData1D;
+   delete [] Pot_FData1D;
+#  endif
 #  ifdef MHD
+   delete [] Mag_CData1D;
+   delete [] Mag_FData1D;
    for (int s=0; s<6; s++)    delete [] Mag_FInterface_Data[s];
    delete [] JustRefined;
    delete [] Mag_FDataCC_IntIter;


### PR DESCRIPTION
Use heap instead of stack memory for large arrays in `Refine()`. It is important for larger `PATCH_SIZE`. For example, the original code with `--gravity=true --mhd=true --patch_size=32 --double=true` will crash due to stack overflow in `Refine()` for both serial and parallel runs.

Thank @koarakawaii for reporting this issue! 