### PR TITLE
Force updating compilation time

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1013,6 +1013,7 @@ else
 	fi)
 endif
 	@rm -f ./*.linkinfo
+	$(ECHO)mv $(OBJ_PATH)/$(PREFIX_CPU)Aux_TakeNote.o $(OBJ_PATH)/$(PREFIX_CPU)Aux_TakeNote_backup.o
 
 
 # clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -1013,6 +1013,8 @@ else
 	fi)
 endif
 	@rm -f ./*.linkinfo
+
+# force re-compiling Aux_TakeNote.cpp to get the correct compilation time
 	$(ECHO)mv $(OBJ_PATH)/$(PREFIX_CPU)Aux_TakeNote.o $(OBJ_PATH)/$(PREFIX_CPU)Aux_TakeNote_backup.o
 
 

--- a/src/Makefile_base
+++ b/src/Makefile_base
@@ -665,6 +665,8 @@ else
 	fi)
 endif
 	@rm -f ./*.linkinfo
+
+# force re-compiling Aux_TakeNote.cpp to get the correct compilation time
 	$(ECHO)mv $(OBJ_PATH)/$(PREFIX_CPU)Aux_TakeNote.o $(OBJ_PATH)/$(PREFIX_CPU)Aux_TakeNote_backup.o
 
 

--- a/src/Makefile_base
+++ b/src/Makefile_base
@@ -665,6 +665,7 @@ else
 	fi)
 endif
 	@rm -f ./*.linkinfo
+	$(ECHO)mv $(OBJ_PATH)/$(PREFIX_CPU)Aux_TakeNote.o $(OBJ_PATH)/$(PREFIX_CPU)Aux_TakeNote_backup.o
 
 
 # clean


### PR DESCRIPTION
### Goal:
To solve the issue #236. 

### Description:
Force the compilation of `Aux_TakeNote.cpp` each time using `make` to get the correct compilation time by renaming `Aux_TakeNote.o` after compilation. See  issue #236  for details