### PR TITLE
Unify all the `PRINT_WARNING`

### DIFF
--- a/include/Macro.h
+++ b/include/Macro.h
@@ -1000,6 +1000,21 @@
 #define BIDX( idx )     ( 1L << (idx) )
 
 
+// helper macro for printing warning messages when resetting parameters
+#  define FORMAT_INT       %- 21d
+#  define FORMAT_LONG      %- 21ld
+#  define FORMAT_UINT      %- 21u
+#  define FORMAT_ULONG     %- 21lu
+#  define FORMAT_BOOL      %- 21d
+#  define FORMAT_REAL      %- 21.14e
+#  define PRINT_RESET_PARA( name, format, reason )                                                       \
+   {                                                                                                     \
+      if ( MPI_Rank == 0 )                                                                               \
+         Aux_Message( stderr, "WARNING : parameter [%-28s] is reset to [" EXPAND_AND_QUOTE(format) "] "  \
+                              "%s", #name, name, reason );                                               \
+   }
+
+
 // ################################
 // ## Remove useless definitions ##
 // ################################

--- a/include/Macro.h
+++ b/include/Macro.h
@@ -1010,8 +1010,8 @@
 #  define PRINT_RESET_PARA( name, format, reason )                                                       \
    {                                                                                                     \
       if ( MPI_Rank == 0 )                                                                               \
-         Aux_Message( stderr, "WARNING : parameter [%-28s] is reset to [" EXPAND_AND_QUOTE(format) "] "  \
-                              "%s\n", #name, name, reason );                                               \
+         Aux_Message( stderr, "WARNING : parameter [%-30s] is reset to [" EXPAND_AND_QUOTE(format) "] "  \
+                              "%s\n", #name, name, reason );                                             \
    }
 
 

--- a/include/Macro.h
+++ b/include/Macro.h
@@ -1011,7 +1011,7 @@
    {                                                                                                     \
       if ( MPI_Rank == 0 )                                                                               \
          Aux_Message( stderr, "WARNING : parameter [%-28s] is reset to [" EXPAND_AND_QUOTE(format) "] "  \
-                              "%s", #name, name, reason );                                               \
+                              "%s\n", #name, name, reason );                                               \
    }
 
 

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -380,8 +380,8 @@ void Init_ExtAccPot();
 void End_ExtAccPot();
 void Init_LoadExtPotTable();
 void Init_MemAllocate_PoissonGravity( const int Pot_NPatchGroup );
-void Init_Set_Default_MG_Parameter( int &Max_Iter, int &NPre_Smooth, int &NPost_Smooth, double &Tolerated_Error );
-void Init_Set_Default_SOR_Parameter( double &SOR_Omega, int &SOR_Max_Iter, int &SOR_Min_Iter );
+void Init_Set_Default_MG_Parameter();
+void Init_Set_Default_SOR_Parameter();
 void Output_PreparedPatch_Poisson( const int TLv, const int TPID, const int TComp,
                                    const real h_Rho_Array_P   [][RHO_NXT][RHO_NXT][RHO_NXT],
                                    const real h_Pot_Array_P_In[][POT_NXT][POT_NXT][POT_NXT],

--- a/include/TestProb.h
+++ b/include/TestProb.h
@@ -84,20 +84,5 @@ extern void (*FB_Init_User_Ptr)();
 #endif
 
 
-// helper macro for printing warning messages when resetting parameters
-#  define FORMAT_INT       %- 21d
-#  define FORMAT_LONG      %- 21ld
-#  define FORMAT_UINT      %- 21u
-#  define FORMAT_ULONG     %- 21lu
-#  define FORMAT_BOOL      %- 21d
-#  define FORMAT_REAL      %- 21.14e
-#  define PRINT_WARNING( name, var, format )                                                             \
-   {                                                                                                     \
-      if ( MPI_Rank == 0 )                                                                               \
-         Aux_Message( stderr, "WARNING : parameter [%-25s] is reset to [" EXPAND_AND_QUOTE(format) "] "  \
-                              "for the adopted test problem\n", name, var );                             \
-   }
-
-
 
 #endif // #ifndef __TESTPROB_H__

--- a/src/GPU_API/CUAPI_SetMemSize.cu
+++ b/src/GPU_API/CUAPI_SetMemSize.cu
@@ -83,7 +83,7 @@ void CUAPI_SetMemSize( int &GPU_NStream, int &Flu_GPU_NPGroup, int &Pot_GPU_NPGr
       else
          GPU_NStream = 1;
 
-      PRINT_RESET_PARA( GPU_NStream, FORMAT_INT, "--> might be further fine-tuned (GPU_NSTREAM in Input__Parameter)\n" );
+      PRINT_RESET_PARA( GPU_NStream, FORMAT_INT, "--> might be further fine-tuned (GPU_NSTREAM in Input__Parameter)" );
    } // if ( GPU_NStream <= 0 )
 
 
@@ -132,7 +132,7 @@ void CUAPI_SetMemSize( int &GPU_NStream, int &Flu_GPU_NPGroup, int &Pot_GPU_NPGr
 #        error : ERROR : UNKNOWN MODEL !!
 #     endif // MODEL
 
-      PRINT_RESET_PARA( Flu_GPU_NPGroup, FORMAT_INT, "--> might be further fine-tuned (FLU_GPU_NPGROUP in Input__Parameter)\n" );
+      PRINT_RESET_PARA( Flu_GPU_NPGroup, FORMAT_INT, "--> might be further fine-tuned (FLU_GPU_NPGROUP in Input__Parameter)" );
    } // if ( Flu_GPU_NPGroup <= 0 )
 
 // (2-2) POT_GPU_NPGROUP
@@ -157,7 +157,7 @@ void CUAPI_SetMemSize( int &GPU_NStream, int &Flu_GPU_NPGroup, int &Pot_GPU_NPGr
 #     error : UNKNOWN GPU_ARCH !!
 #     endif
 
-      PRINT_RESET_PARA( Pot_GPU_NPGroup, FORMAT_INT, "--> might be further fine-tuned (POT_GPU_NPGROUP in Input__Parameter)\n" );
+      PRINT_RESET_PARA( Pot_GPU_NPGroup, FORMAT_INT, "--> might be further fine-tuned (POT_GPU_NPGROUP in Input__Parameter)" );
    } // if ( Pot_GPU_NPGroup <= 0 )
 #  endif
 
@@ -183,7 +183,7 @@ void CUAPI_SetMemSize( int &GPU_NStream, int &Flu_GPU_NPGroup, int &Pot_GPU_NPGr
 #     error : UNKNOWN GPU_ARCH !!
 #     endif
 
-      PRINT_RESET_PARA( Che_GPU_NPGroup, FORMAT_INT, "--> might be further fine-tuned (CHE_GPU_NPGROUP in Input__Parameter)\n" );
+      PRINT_RESET_PARA( Che_GPU_NPGroup, FORMAT_INT, "--> might be further fine-tuned (CHE_GPU_NPGROUP in Input__Parameter)" );
    } // if ( Che_GPU_NPGroup <= 0 )
 #  endif
 
@@ -208,7 +208,7 @@ void CUAPI_SetMemSize( int &GPU_NStream, int &Flu_GPU_NPGroup, int &Pot_GPU_NPGr
 #     error : UNKNOWN GPU_ARCH !!
 #     endif
 
-      PRINT_RESET_PARA( Src_GPU_NPGroup, FORMAT_INT, "--> might be further fine-tuned (SRC_GPU_NPGROUP in Input__Parameter)\n" );
+      PRINT_RESET_PARA( Src_GPU_NPGroup, FORMAT_INT, "--> might be further fine-tuned (SRC_GPU_NPGROUP in Input__Parameter)" );
    } // if ( Src_GPU_NPGroup <= 0 )
 
 

--- a/src/GPU_API/CUAPI_SetMemSize.cu
+++ b/src/GPU_API/CUAPI_SetMemSize.cu
@@ -83,9 +83,7 @@ void CUAPI_SetMemSize( int &GPU_NStream, int &Flu_GPU_NPGroup, int &Pot_GPU_NPGr
       else
          GPU_NStream = 1;
 
-      if ( MPI_Rank == 0 )
-         Aux_Message( stdout, "NOTE : parameter \"%s\" is set to the default value = %d"
-                              " --> might be further fine-tuned\n", "GPU_NSTREAM", GPU_NSTREAM );
+      PRINT_RESET_PARA( GPU_NStream, FORMAT_INT, "--> might be further fine-tuned (GPU_NSTREAM in Input__Parameter)\n" );
    } // if ( GPU_NStream <= 0 )
 
 
@@ -134,9 +132,7 @@ void CUAPI_SetMemSize( int &GPU_NStream, int &Flu_GPU_NPGroup, int &Pot_GPU_NPGr
 #        error : ERROR : UNKNOWN MODEL !!
 #     endif // MODEL
 
-      if ( MPI_Rank == 0 )
-         Aux_Message( stdout, "NOTE : parameter \"%s\" is set to the default value = %d"
-                              " --> might be further fine-tuned\n", "FLU_GPU_NPGROUP", Flu_GPU_NPGroup );
+      PRINT_RESET_PARA( Flu_GPU_NPGroup, FORMAT_INT, "--> might be further fine-tuned (FLU_GPU_NPGROUP in Input__Parameter)\n" );
    } // if ( Flu_GPU_NPGroup <= 0 )
 
 // (2-2) POT_GPU_NPGROUP
@@ -161,9 +157,7 @@ void CUAPI_SetMemSize( int &GPU_NStream, int &Flu_GPU_NPGroup, int &Pot_GPU_NPGr
 #     error : UNKNOWN GPU_ARCH !!
 #     endif
 
-      if ( MPI_Rank == 0 )
-         Aux_Message( stdout, "NOTE : parameter \"%s\" is set to the default value = %d"
-                              " --> might be further fine-tuned\n", "POT_GPU_NPGROUP", Pot_GPU_NPGroup );
+      PRINT_RESET_PARA( Pot_GPU_NPGroup, FORMAT_INT, "--> might be further fine-tuned (POT_GPU_NPGROUP in Input__Parameter)\n" );
    } // if ( Pot_GPU_NPGroup <= 0 )
 #  endif
 
@@ -189,9 +183,7 @@ void CUAPI_SetMemSize( int &GPU_NStream, int &Flu_GPU_NPGroup, int &Pot_GPU_NPGr
 #     error : UNKNOWN GPU_ARCH !!
 #     endif
 
-      if ( MPI_Rank == 0 )
-         Aux_Message( stdout, "NOTE : parameter \"%s\" is set to the default value = %d"
-                              " --> might be further fine-tuned\n", "CHE_GPU_NPGROUP", Che_GPU_NPGroup );
+      PRINT_RESET_PARA( Che_GPU_NPGroup, FORMAT_INT, "--> might be further fine-tuned (CHE_GPU_NPGROUP in Input__Parameter)\n" );
    } // if ( Che_GPU_NPGroup <= 0 )
 #  endif
 
@@ -216,9 +208,7 @@ void CUAPI_SetMemSize( int &GPU_NStream, int &Flu_GPU_NPGroup, int &Pot_GPU_NPGr
 #     error : UNKNOWN GPU_ARCH !!
 #     endif
 
-      if ( MPI_Rank == 0 )
-         Aux_Message( stdout, "NOTE : parameter \"%s\" is set to the default value = %d"
-                              " --> might be further fine-tuned\n", "SRC_GPU_NPGROUP", Src_GPU_NPGroup );
+      PRINT_RESET_PARA( Src_GPU_NPGroup, FORMAT_INT, "--> might be further fine-tuned (SRC_GPU_NPGROUP in Input__Parameter)\n" );
    } // if ( Src_GPU_NPGroup <= 0 )
 
 

--- a/src/Init/Init_ResetParameter.cpp
+++ b/src/Init/Init_ResetParameter.cpp
@@ -74,14 +74,14 @@ void Init_ResetParameter()
 #     error : ERROR : unsupported MODEL !!
 #     endif // MODEL
 
-      PRINT_RESET_PARA( DT__FLUID, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( DT__FLUID, FORMAT_REAL, "" );
    } // if ( DT__FLUID < 0.0 )
 
    if ( DT__FLUID_INIT < 0.0 )
    {
       DT__FLUID_INIT = DT__FLUID;
 
-      PRINT_RESET_PARA( DT__FLUID_INIT, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( DT__FLUID_INIT, FORMAT_REAL, "" );
    }
 
 
@@ -97,7 +97,7 @@ void Init_ResetParameter()
 #     error : ERROR : unsupported MODEL !!
 #     endif // MODEL
 
-      PRINT_RESET_PARA( DT__GRAVITY, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( DT__GRAVITY, FORMAT_REAL, "" );
    } // if ( DT__GRAVITY < 0.0 )
 #  endif
 
@@ -108,7 +108,7 @@ void Init_ResetParameter()
    {
       DT__PARACC = 0.0;    // disable it
 
-      PRINT_RESET_PARA( DT__PARACC, FORMAT_FLT, "since STORE_PAR_ACC is disabled" );
+      PRINT_RESET_PARA( DT__PARACC, FORMAT_REAL, "since STORE_PAR_ACC is disabled" );
    }
 #  endif
 
@@ -248,7 +248,7 @@ void Init_ResetParameter()
 #  if ( MODEL == ELBDM )
    ELBDM_ETA = ELBDM_MASS / ELBDM_PLANCK_CONST;
 
-   PRINT_RESET_PARA( ELBDM_ETA, FORMAT_FLT, "" );
+   PRINT_RESET_PARA( ELBDM_ETA, FORMAT_REAL, "" );
 
 #  ifdef COMOVING
    if ( MPI_Rank == 0 )
@@ -263,7 +263,7 @@ void Init_ResetParameter()
    {
       ELBDM_TAYLOR3_COEFF = NULL_REAL;
 
-      PRINT_RESET_PARA( ELBDM_TAYLOR3_COEFF, FORMAT_FLT, "since ELBDM_TAYLOR3_AUTO is enabled" );
+      PRINT_RESET_PARA( ELBDM_TAYLOR3_COEFF, FORMAT_REAL, "since ELBDM_TAYLOR3_AUTO is enabled" );
    }
 #  endif // #if ( MODEL == ELBDM )
 
@@ -346,7 +346,7 @@ void Init_ResetParameter()
       }
 
       const double PAR_REMOVE_CELL = amr->Par->RemoveCell;
-      PRINT_RESET_PARA( PAR_REMOVE_CELL, FORMAT_FLT, "for the adopted PAR_INTERP scheme" );
+      PRINT_RESET_PARA( PAR_REMOVE_CELL, FORMAT_REAL, "for the adopted PAR_INTERP scheme" );
    }
 
 // RemoveCell is useless for the periodic B.C.
@@ -355,7 +355,7 @@ void Init_ResetParameter()
       amr->Par->RemoveCell = -1.0;
 
       const double PAR_REMOVE_CELL = amr->Par->RemoveCell;
-      PRINT_RESET_PARA( PAR_REMOVE_CELL, FORMAT_FLT, "since the periodic BC is adopted along all directions" );
+      PRINT_RESET_PARA( PAR_REMOVE_CELL, FORMAT_REAL, "since the periodic BC is adopted along all directions" );
    }
 
 // number of ghost zones for the particle interpolation scheme
@@ -408,7 +408,7 @@ void Init_ResetParameter()
 
       GFUNC_COEFF0 = 3.8;  // empirically determined value for minimizing the center-of-mass drift
 
-      PRINT_RESET_PARA( GFUNC_COEFF0, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( GFUNC_COEFF0, FORMAT_REAL, "" );
    }
 #  endif
 
@@ -848,14 +848,14 @@ void Init_ResetParameter()
    {
       MIN_EINT = MIN_PRES*1.5;
 
-      PRINT_RESET_PARA( MIN_EINT, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( MIN_EINT, FORMAT_REAL, "" );
    }
 
    else if ( MIN_EINT > 0.0  &&  MIN_PRES == 0.0 )
    {
       MIN_PRES = MIN_EINT/1.5;
 
-      PRINT_RESET_PARA( MIN_PRES, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( MIN_PRES, FORMAT_REAL, "" );
    }
 #  endif
 
@@ -886,14 +886,14 @@ void Init_ResetParameter()
    {
       MU_NORM = Const_mH;
 
-      PRINT_RESET_PARA( MU_NORM, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( MU_NORM, FORMAT_REAL, "" );
    }
 
    else if ( MU_NORM == 0.0 )
    {
       MU_NORM = Const_amu;
 
-      PRINT_RESET_PARA( MU_NORM, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( MU_NORM, FORMAT_REAL, "" );
    }
 #  endif
 
@@ -973,13 +973,13 @@ void Init_ResetParameter()
 // SF_CREATE_STAR_MIN_GAS_DENS: HI count/cm^3 --> mass density in code units
    SF_CREATE_STAR_MIN_GAS_DENS *= Const_mH / UNIT_D;
 
-   PRINT_RESET_PARA( SF_CREATE_STAR_MIN_GAS_DENS, FORMAT_FLT, "to be consistent with the code units" );
+   PRINT_RESET_PARA( SF_CREATE_STAR_MIN_GAS_DENS, FORMAT_REAL, "to be consistent with the code units" );
 
 
 // SF_CREATE_STAR_MIN_STAR_MASS: Msun --> code units
    SF_CREATE_STAR_MIN_STAR_MASS *= Const_Msun / UNIT_M;
 
-   PRINT_RESET_PARA( SF_CREATE_STAR_MIN_STAR_MASS, FORMAT_FLT, "to be consistent with the code units" );
+   PRINT_RESET_PARA( SF_CREATE_STAR_MIN_STAR_MASS, FORMAT_REAL, "to be consistent with the code units" );
 #  endif // #ifdef STAR_FORMATION
 
 

--- a/src/Init/Init_ResetParameter.cpp
+++ b/src/Init/Init_ResetParameter.cpp
@@ -74,14 +74,14 @@ void Init_ResetParameter()
 #     error : ERROR : unsupported MODEL !!
 #     endif // MODEL
 
-      PRINT_RESER_PARA( DT__FLUID, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( DT__FLUID, FORMAT_FLT, "" );
    } // if ( DT__FLUID < 0.0 )
 
    if ( DT__FLUID_INIT < 0.0 )
    {
       DT__FLUID_INIT = DT__FLUID;
 
-      PRINT_RESER_PARA( DT__FLUID_INIT, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( DT__FLUID_INIT, FORMAT_FLT, "" );
    }
 
 
@@ -97,7 +97,7 @@ void Init_ResetParameter()
 #     error : ERROR : unsupported MODEL !!
 #     endif // MODEL
 
-      PRINT_RESER_PARA( DT__GRAVITY, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( DT__GRAVITY, FORMAT_FLT, "" );
    } // if ( DT__GRAVITY < 0.0 )
 #  endif
 
@@ -108,7 +108,7 @@ void Init_ResetParameter()
    {
       DT__PARACC = 0.0;    // disable it
 
-      PRINT_RESER_PARA( DT__PARACC, FORMAT_FLT, "since STORE_PAR_ACC is disabled" );
+      PRINT_RESET_PARA( DT__PARACC, FORMAT_FLT, "since STORE_PAR_ACC is disabled" );
    }
 #  endif
 
@@ -134,7 +134,7 @@ void Init_ResetParameter()
       EXT_POT_TABLE_FLOAT8 = 0;
 #     endif
 
-      PRINT_RESER_PARA( EXT_POT_TABLE_FLOAT8, FORMAT_INT, "to be consistent with FLOAT8" );
+      PRINT_RESET_PARA( EXT_POT_TABLE_FLOAT8, FORMAT_INT, "to be consistent with FLOAT8" );
    }
 #  endif
 
@@ -143,7 +143,7 @@ void Init_ResetParameter()
 #  ifndef GPU
    GPU_NSTREAM = 1;
 
-   PRINT_RESER_PARA( GPU_NSTREAM, FORMAT_INT, "since GPU is disabled" );
+   PRINT_RESET_PARA( GPU_NSTREAM, FORMAT_INT, "since GPU is disabled" );
 
    if ( FLU_GPU_NPGROUP <= 0 )
    {
@@ -153,7 +153,7 @@ void Init_ResetParameter()
       FLU_GPU_NPGROUP = 1;
 #     endif
 
-      PRINT_RESER_PARA( FLU_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
+      PRINT_RESET_PARA( FLU_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
    }
 
 #  ifdef GRAVITY
@@ -165,7 +165,7 @@ void Init_ResetParameter()
       POT_GPU_NPGROUP = 1;
 #     endif
 
-      PRINT_RESER_PARA( POT_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
+      PRINT_RESET_PARA( POT_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
    }
 #  endif
 
@@ -178,7 +178,7 @@ void Init_ResetParameter()
       CHE_GPU_NPGROUP = 1;
 #     endif
 
-      PRINT_RESER_PARA( CHE_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
+      PRINT_RESET_PARA( CHE_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
    }
 #  endif
 
@@ -190,7 +190,7 @@ void Init_ResetParameter()
       SRC_GPU_NPGROUP = 1;
 #     endif
 
-      PRINT_RESER_PARA( SRC_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
+      PRINT_RESET_PARA( SRC_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
    }
 #  endif // #ifndef GPU
 
@@ -239,7 +239,7 @@ void Init_ResetParameter()
 #  if ( MODEL == ELBDM )
    ELBDM_ETA = ELBDM_MASS / ELBDM_PLANCK_CONST;
 
-   PRINT_RESER_PARA( ELBDM_ETA, FORMAT_FLT, "" );
+   PRINT_RESET_PARA( ELBDM_ETA, FORMAT_FLT, "" );
 
 #  ifdef COMOVING
    if ( MPI_Rank == 0 )
@@ -254,7 +254,7 @@ void Init_ResetParameter()
    {
       ELBDM_TAYLOR3_COEFF = NULL_REAL;
 
-      PRINT_RESER_PARA( ELBDM_TAYLOR3_COEFF, FORMAT_FLT, "since ELBDM_TAYLOR3_AUTO is enabled" );
+      PRINT_RESET_PARA( ELBDM_TAYLOR3_COEFF, FORMAT_FLT, "since ELBDM_TAYLOR3_AUTO is enabled" );
    }
 #  endif // #if ( MODEL == ELBDM )
 
@@ -265,14 +265,14 @@ void Init_ResetParameter()
    {
       OPT__FLU_INT_SCHEME = INT_CQUAD;
 
-      PRINT_RESER_PARA( OPT__FLU_INT_SCHEME, FORMAT_INT, "" );
+      PRINT_RESET_PARA( OPT__FLU_INT_SCHEME, FORMAT_INT, "" );
    }
 
    if ( OPT__REF_FLU_INT_SCHEME == INT_DEFAULT )
    {
       OPT__REF_FLU_INT_SCHEME = INT_CQUAD;
 
-      PRINT_RESER_PARA( OPT__REF_FLU_INT_SCHEME, FORMAT_INT, "" );
+      PRINT_RESET_PARA( OPT__REF_FLU_INT_SCHEME, FORMAT_INT, "" );
    }
 
 #  elif ( MODEL == ELBDM )
@@ -280,14 +280,14 @@ void Init_ResetParameter()
    {
       OPT__FLU_INT_SCHEME = INT_CQUAR;
 
-      PRINT_RESER_PARA( OPT__FLU_INT_SCHEME, FORMAT_INT, "" );
+      PRINT_RESET_PARA( OPT__FLU_INT_SCHEME, FORMAT_INT, "" );
    }
 
    if ( OPT__REF_FLU_INT_SCHEME == INT_DEFAULT )
    {
       OPT__REF_FLU_INT_SCHEME = INT_CQUAR;
 
-      PRINT_RESER_PARA( OPT__REF_FLU_INT_SCHEME, FORMAT_INT, "" );
+      PRINT_RESET_PARA( OPT__REF_FLU_INT_SCHEME, FORMAT_INT, "" );
    }
 
 #  else
@@ -337,7 +337,7 @@ void Init_ResetParameter()
       }
 
       const double PAR_REMOVE_CELL = amr->Par->RemoveCell;
-      PRINT_RESER_PARA( PAR_REMOVE_CELL, FORMAT_FLT, "for the adopted PAR_INTERP scheme" );
+      PRINT_RESET_PARA( PAR_REMOVE_CELL, FORMAT_FLT, "for the adopted PAR_INTERP scheme" );
    }
 
 // RemoveCell is useless for the periodic B.C.
@@ -346,7 +346,7 @@ void Init_ResetParameter()
       amr->Par->RemoveCell = -1.0;
 
       const double PAR_REMOVE_CELL = amr->Par->RemoveCell;
-      PRINT_RESER_PARA( PAR_REMOVE_CELL, FORMAT_FLT, "since the periodic BC is adopted along all directions" );
+      PRINT_RESET_PARA( PAR_REMOVE_CELL, FORMAT_FLT, "since the periodic BC is adopted along all directions" );
    }
 
 // number of ghost zones for the particle interpolation scheme
@@ -360,7 +360,7 @@ void Init_ResetParameter()
          default: Aux_Error( ERROR_INFO, "unsupported particle interpolation scheme !!\n" );
       }
 
-      PRINT_RESER_PARA( amr->Par->GhostSize, FORMAT_INT, "for the adopted PAR_INTERP scheme" );
+      PRINT_RESET_PARA( amr->Par->GhostSize, FORMAT_INT, "for the adopted PAR_INTERP scheme" );
    }
 
    if ( amr->Par->GhostSizeTracer < 0 )
@@ -373,7 +373,7 @@ void Init_ResetParameter()
          default: Aux_Error( ERROR_INFO, "unsupported particle interpolation scheme !!\n" );
       }
 
-      PRINT_RESER_PARA( amr->Par->GhostSizeTracer, FORMAT_INT, "for the adopted PAR_TR_INTERP scheme" );
+      PRINT_RESET_PARA( amr->Par->GhostSizeTracer, FORMAT_INT, "for the adopted PAR_TR_INTERP scheme" );
    }
 
 #  endif // #ifdef PARTICLE
@@ -399,7 +399,7 @@ void Init_ResetParameter()
 
       GFUNC_COEFF0 = 3.8;  // empirically determined value for minimizing the center-of-mass drift
 
-      PRINT_RESER_PARA( GFUNC_COEFF0, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( GFUNC_COEFF0, FORMAT_FLT, "" );
    }
 #  endif
 
@@ -411,7 +411,7 @@ void Init_ResetParameter()
 #     ifdef MHD
       OPT__1ST_FLUX_CORR = FIRST_FLUX_CORR_3D;
 
-      PRINT_RESER_PARA( OPT__1ST_FLUX_CORR, FORMAT_INT, "for MHD" );
+      PRINT_RESET_PARA( OPT__1ST_FLUX_CORR, FORMAT_INT, "for MHD" );
 
 #     else
 
@@ -421,7 +421,7 @@ void Init_ResetParameter()
       OPT__1ST_FLUX_CORR = FIRST_FLUX_CORR_3D1D;
 #     endif
 
-      PRINT_RESER_PARA( OPT__1ST_FLUX_CORR, FORMAT_INT, "for HYDRO" );
+      PRINT_RESET_PARA( OPT__1ST_FLUX_CORR, FORMAT_INT, "for HYDRO" );
 #     endif // #ifdef MHD ... else ...
    }
 
@@ -429,7 +429,7 @@ void Init_ResetParameter()
    {
       OPT__1ST_FLUX_CORR_SCHEME = RSOLVER_1ST_NONE;
 
-      PRINT_RESER_PARA( OPT__1ST_FLUX_CORR_SCHEME, FORMAT_INT, "since OPT__1ST_FLUX_CORR is disabled" );
+      PRINT_RESET_PARA( OPT__1ST_FLUX_CORR_SCHEME, FORMAT_INT, "since OPT__1ST_FLUX_CORR is disabled" );
    }
 
    else if ( OPT__1ST_FLUX_CORR != FIRST_FLUX_CORR_NONE  &&  OPT__1ST_FLUX_CORR_SCHEME == RSOLVER_1ST_DEFAULT )
@@ -440,7 +440,7 @@ void Init_ResetParameter()
       OPT__1ST_FLUX_CORR_SCHEME = RSOLVER_1ST_HLLE;
 #     endif
 
-      PRINT_RESER_PARA( OPT__1ST_FLUX_CORR_SCHEME, FORMAT_INT, "" );
+      PRINT_RESET_PARA( OPT__1ST_FLUX_CORR_SCHEME, FORMAT_INT, "" );
    }
 #  endif // if ( MODEL == HYDRO )
 
@@ -459,7 +459,7 @@ void Init_ResetParameter()
       OPT__TIMING_BARRIER = 1;
 #     endif
 
-      PRINT_RESER_PARA( OPT__TIMING_BARRIER, FORMAT_INT, "" );
+      PRINT_RESET_PARA( OPT__TIMING_BARRIER, FORMAT_INT, "" );
    }
 
 
@@ -496,7 +496,7 @@ void Init_ResetParameter()
    {
       OPT__CORR_AFTER_ALL_SYNC = CORR_AFTER_SYNC_BEFORE_DUMP;
 
-      PRINT_RESER_PARA( OPT__CORR_AFTER_ALL_SYNC, FORMAT_INT, "" );
+      PRINT_RESET_PARA( OPT__CORR_AFTER_ALL_SYNC, FORMAT_INT, "" );
    }
 
 
@@ -507,7 +507,7 @@ void Init_ResetParameter()
    {
       OPT__OVERLAP_MPI = false;
 
-      PRINT_RESER_PARA( OPT__OVERLAP_MPI, FORMAT_INT, "since OVERLAP_MPI is disabled in the makefile" );
+      PRINT_RESET_PARA( OPT__OVERLAP_MPI, FORMAT_INT, "since OVERLAP_MPI is disabled in the makefile" );
    }
 #  endif
 
@@ -516,7 +516,7 @@ void Init_ResetParameter()
    {
       OPT__OVERLAP_MPI = false;
 
-      PRINT_RESER_PARA( OPT__OVERLAP_MPI, FORMAT_INT, "since SERIAL is enabled" );
+      PRINT_RESET_PARA( OPT__OVERLAP_MPI, FORMAT_INT, "since SERIAL is enabled" );
    }
 #  endif // ifdef SERIAL
 
@@ -525,7 +525,7 @@ void Init_ResetParameter()
    {
       OPT__OVERLAP_MPI = false;
 
-      PRINT_RESER_PARA( OPT__OVERLAP_MPI, FORMAT_INT, "since LOAD_BALANCE is disabled" );
+      PRINT_RESET_PARA( OPT__OVERLAP_MPI, FORMAT_INT, "since LOAD_BALANCE is disabled" );
    }
 #  endif // #ifndef LOAD_BALANCE
 
@@ -534,7 +534,7 @@ void Init_ResetParameter()
    {
       OPT__OVERLAP_MPI = false;
 
-      PRINT_RESER_PARA( OPT__OVERLAP_MPI, FORMAT_INT, "since OPENMP is disabled" );
+      PRINT_RESET_PARA( OPT__OVERLAP_MPI, FORMAT_INT, "since OPENMP is disabled" );
    }
 #  endif
 
@@ -546,7 +546,7 @@ void Init_ResetParameter()
    {
       OPT__OVERLAP_MPI = false;
 
-      PRINT_RESER_PARA( OPT__OVERLAP_MPI, FORMAT_INT, "since the level of MPI thread support == MPI_THREAD_SINGLE" );
+      PRINT_RESET_PARA( OPT__OVERLAP_MPI, FORMAT_INT, "since the level of MPI thread support == MPI_THREAD_SINGLE" );
    }
 #  endif
 
@@ -556,7 +556,7 @@ void Init_ResetParameter()
    {
       OPT__CK_FLUX_ALLOCATE = false;
 
-      PRINT_RESER_PARA( OPT__CK_FLUX_ALLOCATE, FORMAT_INT, "since no flux is required" );
+      PRINT_RESET_PARA( OPT__CK_FLUX_ALLOCATE, FORMAT_INT, "since no flux is required" );
    }
 
 
@@ -565,7 +565,7 @@ void Init_ResetParameter()
    {
       OPT__INT_TIME = false;
 
-      PRINT_RESER_PARA( OPT__INT_TIME, FORMAT_INT, "since OPT__DT_LEVEL == DT_LEVEL_SHARED" );
+      PRINT_RESET_PARA( OPT__INT_TIME, FORMAT_INT, "since OPT__DT_LEVEL == DT_LEVEL_SHARED" );
    }
 
 
@@ -575,7 +575,7 @@ void Init_ResetParameter()
    {
       OPT__VERBOSE = true;
 
-      PRINT_RESER_PARA( OPT__VERBOSE, FORMAT_INT, "since GAMER_DEBUG is enabled" );
+      PRINT_RESET_PARA( OPT__VERBOSE, FORMAT_INT, "since GAMER_DEBUG is enabled" );
    }
 #  endif
 
@@ -586,14 +586,14 @@ void Init_ResetParameter()
    {
       OPT__FIXUP_FLUX = false;
 
-      PRINT_RESER_PARA( OPT__FIXUP_FLUX, FORMAT_INT, "since it's only supported in HYDRO/ELBDM" );
+      PRINT_RESET_PARA( OPT__FIXUP_FLUX, FORMAT_INT, "since it's only supported in HYDRO/ELBDM" );
    }
 
    if ( OPT__CK_FLUX_ALLOCATE )
    {
       OPT__CK_FLUX_ALLOCATE = false;
 
-      PRINT_RESER_PARA( OPT__CK_FLUX_ALLOCATE, FORMAT_INT, "since it's only supported in HYDRO/ELBDM" );
+      PRINT_RESET_PARA( OPT__CK_FLUX_ALLOCATE, FORMAT_INT, "since it's only supported in HYDRO/ELBDM" );
    }
 #  endif
 
@@ -604,21 +604,21 @@ void Init_ResetParameter()
    {
       OPT__FLAG_RHO = false;
 
-      PRINT_RESER_PARA( OPT__FLAG_RHO, FORMAT_INT, "since the symbolic constant DENS is not defined" );
+      PRINT_RESET_PARA( OPT__FLAG_RHO, FORMAT_INT, "since the symbolic constant DENS is not defined" );
    }
 
    if ( OPT__FLAG_RHO_GRADIENT )
    {
       OPT__FLAG_RHO_GRADIENT = false;
 
-      PRINT_RESER_PARA( OPT__FLAG_RHO_GRADIENT, FORMAT_INT, "since the symbolic constant DENS is not defined" );
+      PRINT_RESET_PARA( OPT__FLAG_RHO_GRADIENT, FORMAT_INT, "since the symbolic constant DENS is not defined" );
    }
 
    if ( OPT__CK_REFINE )
    {
       OPT__CK_REFINE = false;
 
-      PRINT_RESER_PARA( OPT__CK_REFINE, FORMAT_INT, "since the symbolic constant DENS is not defined" );
+      PRINT_RESET_PARA( OPT__CK_REFINE, FORMAT_INT, "since the symbolic constant DENS is not defined" );
    }
 #  endif // #ifndef DENS
 
@@ -629,7 +629,7 @@ void Init_ResetParameter()
    {
       OPT__CK_CONSERVATION = false;
 
-      PRINT_RESER_PARA( OPT__CK_CONSERVATION, FORMAT_INT, "since it's only supported in HYDRO/ELBDM" );
+      PRINT_RESET_PARA( OPT__CK_CONSERVATION, FORMAT_INT, "since it's only supported in HYDRO/ELBDM" );
    }
 #  endif
 
@@ -645,14 +645,14 @@ void Init_ResetParameter()
 //    OPT__LR_LIMITER = LR_LIMITER_VL_GMINMOD;
       OPT__LR_LIMITER = LR_LIMITER_GMINMOD;
 
-      PRINT_RESER_PARA( OPT__LR_LIMITER, FORMAT_INT, "for MHM_RP+PPM" );
+      PRINT_RESET_PARA( OPT__LR_LIMITER, FORMAT_INT, "for MHM_RP+PPM" );
    }
 #  else
    if ( OPT__LR_LIMITER == LR_LIMITER_DEFAULT )
    {
       OPT__LR_LIMITER = LR_LIMITER_VL_GMINMOD;
 
-      PRINT_RESER_PARA( OPT__LR_LIMITER, FORMAT_INT, "" );
+      PRINT_RESET_PARA( OPT__LR_LIMITER, FORMAT_INT, "" );
    }
 #  endif // #if ( FLU_SCHEME == MHM_RP  &&  LR_SCHEME == PPM ) ... else ...
 
@@ -662,7 +662,7 @@ void Init_ResetParameter()
    {
       OPT__LR_LIMITER = LR_LIMITER_NONE;
 
-      PRINT_RESER_PARA( OPT__LR_LIMITER, FORMAT_INT, "since it's only useful for the MHM/MHM_RP/CTU integrators" );
+      PRINT_RESET_PARA( OPT__LR_LIMITER, FORMAT_INT, "since it's only useful for the MHM/MHM_RP/CTU integrators" );
    }
 
 #  endif // #if ( FLU_SCHEME == MHM  ||  FLU_SCHEME == MHM_RP  ||  FLU_SCHEME == CTU ) ... else ...
@@ -675,7 +675,7 @@ void Init_ResetParameter()
    {
       OPT__FLAG_JEANS = false;
 
-      PRINT_RESER_PARA( OPT__FLAG_JEANS, FORMAT_INT, "since GRAVITY is disabled" );
+      PRINT_RESET_PARA( OPT__FLAG_JEANS, FORMAT_INT, "since GRAVITY is disabled" );
    }
 #  endif
 
@@ -686,14 +686,14 @@ void Init_ResetParameter()
    {
       OPT__FIXUP_FLUX = false;
 
-      PRINT_RESER_PARA( OPT__FIXUP_FLUX, FORMAT_INT, "since CONSERVE_MASS is disabled" );
+      PRINT_RESET_PARA( OPT__FIXUP_FLUX, FORMAT_INT, "since CONSERVE_MASS is disabled" );
    }
 
    if ( OPT__CK_FLUX_ALLOCATE )
    {
       OPT__CK_FLUX_ALLOCATE = false;
 
-      PRINT_RESER_PARA( OPT__CK_FLUX_ALLOCATE, FORMAT_INT, "since CONSERVE_MASS is disabled" );
+      PRINT_RESET_PARA( OPT__CK_FLUX_ALLOCATE, FORMAT_INT, "since CONSERVE_MASS is disabled" );
    }
 #  endif
 
@@ -704,7 +704,7 @@ void Init_ResetParameter()
    {
       OPT__OUTPUT_BASEPS = false;
 
-      PRINT_RESER_PARA( OPT__OUTPUT_BASEPS, FORMAT_INT, "since SUPPORT_FFTW is disabled" );
+      PRINT_RESET_PARA( OPT__OUTPUT_BASEPS, FORMAT_INT, "since SUPPORT_FFTW is disabled" );
    }
 #  endif
 
@@ -715,7 +715,7 @@ void Init_ResetParameter()
    if ( MPI_NRank_X[d] != 1 )
    {
       MPI_NRank_X[d] = 1;
-      PRINT_RESER_PARA( MPI_NRank_X[d], FORMAT_INT, "for SERIAL" );
+      PRINT_RESET_PARA( MPI_NRank_X[d], FORMAT_INT, "for SERIAL" );
    }
 #  endif
 
@@ -725,7 +725,7 @@ void Init_ResetParameter()
    {
       MPI_NRank_X[d] = -1;
 
-      PRINT_RESER_PARA( MPI_NRank_X[d], FORMAT_INT, "since it's useless" );
+      PRINT_RESET_PARA( MPI_NRank_X[d], FORMAT_INT, "since it's useless" );
    }
 #  endif
 
@@ -736,28 +736,28 @@ void Init_ResetParameter()
    {
       OPT__RECORD_PERFORMANCE = false;
 
-      PRINT_RESER_PARA( OPT__RECORD_PERFORMANCE, FORMAT_INT, "since TIMING is disabled" );
+      PRINT_RESET_PARA( OPT__RECORD_PERFORMANCE, FORMAT_INT, "since TIMING is disabled" );
    }
 
    if ( OPT__TIMING_BARRIER != 0 )
    {
       OPT__TIMING_BARRIER = 0;
 
-      PRINT_RESER_PARA( OPT__TIMING_BARRIER, FORMAT_INT, "since TIMING is disabled" );
+      PRINT_RESET_PARA( OPT__TIMING_BARRIER, FORMAT_INT, "since TIMING is disabled" );
    }
 
    if ( OPT__TIMING_BALANCE )
    {
       OPT__TIMING_BALANCE = false;
 
-      PRINT_RESER_PARA( OPT__TIMING_BALANCE, FORMAT_INT, "since TIMING is disabled" );
+      PRINT_RESET_PARA( OPT__TIMING_BALANCE, FORMAT_INT, "since TIMING is disabled" );
    }
 
    if ( OPT__TIMING_MPI )
    {
       OPT__TIMING_MPI = false;
 
-      PRINT_RESER_PARA( OPT__TIMING_MPI, FORMAT_INT, "since TIMING is disabled" );
+      PRINT_RESET_PARA( OPT__TIMING_MPI, FORMAT_INT, "since TIMING is disabled" );
    }
 #  endif // #ifndef TIMING
 
@@ -768,7 +768,7 @@ void Init_ResetParameter()
    {
       OPT__TIMING_MPI = false;
 
-      PRINT_RESER_PARA( OPT__TIMING_MPI, FORMAT_INT, "since LOAD_BALANCE is disabled" );
+      PRINT_RESET_PARA( OPT__TIMING_MPI, FORMAT_INT, "since LOAD_BALANCE is disabled" );
    }
 #  endif
 
@@ -786,7 +786,7 @@ void Init_ResetParameter()
       OPT__UM_IC_NVAR = NCOMP_TOTAL;      // load all fields
 #     endif
 
-      PRINT_RESER_PARA( OPT__UM_IC_NVAR, FORMAT_INT, "" );
+      PRINT_RESET_PARA( OPT__UM_IC_NVAR, FORMAT_INT, "" );
    }
 
 
@@ -796,7 +796,7 @@ void Init_ResetParameter()
    {
       OPT__CK_PARTICLE = true;
 
-      PRINT_RESER_PARA( OPT__CK_PARTICLE, FORMAT_INT, "since DEBUG_PARTICLE is enabled" );
+      PRINT_RESET_PARA( OPT__CK_PARTICLE, FORMAT_INT, "since DEBUG_PARTICLE is enabled" );
    }
 #  endif
 
@@ -808,7 +808,7 @@ void Init_ResetParameter()
       amr->Par->Init = PAR_INIT_BY_RESTART;
 
       const ParInit_t PAR_INIT = amr->Par->Init;
-      PRINT_RESER_PARA( PAR_INIT, FORMAT_INT, "for restart" );
+      PRINT_RESET_PARA( PAR_INIT, FORMAT_INT, "for restart" );
    }
 #  endif
 
@@ -820,7 +820,7 @@ void Init_ResetParameter()
    {
       JEANS_MIN_PRES = false;
 
-      PRINT_RESER_PARA( JEANS_MIN_PRES, FORMAT_INT, "since GRAVITY is disabled" );
+      PRINT_RESET_PARA( JEANS_MIN_PRES, FORMAT_INT, "since GRAVITY is disabled" );
    }
 #  endif
 
@@ -828,7 +828,7 @@ void Init_ResetParameter()
    {
       JEANS_MIN_PRES_LEVEL = MAX_LEVEL;
 
-      PRINT_RESER_PARA( JEANS_MIN_PRES_LEVEL, FORMAT_INT, "" );
+      PRINT_RESET_PARA( JEANS_MIN_PRES_LEVEL, FORMAT_INT, "" );
    }
 #  endif
 
@@ -839,14 +839,14 @@ void Init_ResetParameter()
    {
       MIN_EINT = MIN_PRES*1.5;
 
-      PRINT_RESER_PARA( MIN_EINT, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( MIN_EINT, FORMAT_FLT, "" );
    }
 
    else if ( MIN_EINT > 0.0  &&  MIN_PRES == 0.0 )
    {
       MIN_PRES = MIN_EINT/1.5;
 
-      PRINT_RESER_PARA( MIN_PRES, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( MIN_PRES, FORMAT_FLT, "" );
    }
 #  endif
 
@@ -859,14 +859,14 @@ void Init_ResetParameter()
       {
          OPT__CHECK_PRES_AFTER_FLU = 1;
 
-         PRINT_RESER_PARA( OPT__CHECK_PRES_AFTER_FLU, FORMAT_INT, "" );
+         PRINT_RESET_PARA( OPT__CHECK_PRES_AFTER_FLU, FORMAT_INT, "" );
       }
 
       else
       {
          OPT__CHECK_PRES_AFTER_FLU = 0;
 
-         PRINT_RESER_PARA( OPT__CHECK_PRES_AFTER_FLU, FORMAT_INT, "" );
+         PRINT_RESET_PARA( OPT__CHECK_PRES_AFTER_FLU, FORMAT_INT, "" );
       }
    }
 #  endif
@@ -877,14 +877,14 @@ void Init_ResetParameter()
    {
       MU_NORM = Const_mH;
 
-      PRINT_RESER_PARA( MU_NORM, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( MU_NORM, FORMAT_FLT, "" );
    }
 
    else if ( MU_NORM == 0.0 )
    {
       MU_NORM = Const_amu;
 
-      PRINT_RESER_PARA( MU_NORM, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( MU_NORM, FORMAT_FLT, "" );
    }
 #  endif
 
@@ -894,7 +894,7 @@ void Init_ResetParameter()
    {
       AUTO_REDUCE_DT = false;
 
-      PRINT_RESER_PARA( AUTO_REDUCE_DT, FORMAT_INT, "since OPT__DT_LEVEL != DT_LEVEL_FLEXIBLE" );
+      PRINT_RESET_PARA( AUTO_REDUCE_DT, FORMAT_INT, "since OPT__DT_LEVEL != DT_LEVEL_FLEXIBLE" );
    }
 
 
@@ -904,7 +904,7 @@ void Init_ResetParameter()
    {
       FLAG_BUFFER_SIZE = PS1;
 
-      PRINT_RESER_PARA( FLAG_BUFFER_SIZE, FORMAT_INT, "to match PATCH_SIZE" );
+      PRINT_RESET_PARA( FLAG_BUFFER_SIZE, FORMAT_INT, "to match PATCH_SIZE" );
    }
 
 // level MAX_LEVEL-1
@@ -912,7 +912,7 @@ void Init_ResetParameter()
    {
       FLAG_BUFFER_SIZE_MAXM1_LV = REGRID_COUNT;
 
-      PRINT_RESER_PARA( FLAG_BUFFER_SIZE_MAXM1_LV, FORMAT_INT, "to match REGRID_COUNT" );
+      PRINT_RESET_PARA( FLAG_BUFFER_SIZE_MAXM1_LV, FORMAT_INT, "to match REGRID_COUNT" );
    }
 
 // level MAX_LEVEL-2
@@ -921,7 +921,7 @@ void Init_ResetParameter()
    {
       FLAG_BUFFER_SIZE_MAXM2_LV = ( FLAG_BUFFER_SIZE_MAXM1_LV + FLAG_BUFFER_SIZE_MAXM1_LV%2 + PS1 ) / 2;
 
-      PRINT_RESER_PARA( FLAG_BUFFER_SIZE_MAXM2_LV, FORMAT_INT, "" );
+      PRINT_RESET_PARA( FLAG_BUFFER_SIZE_MAXM2_LV, FORMAT_INT, "" );
    }
 
 
@@ -931,17 +931,17 @@ void Init_ResetParameter()
    {
       SF_CREATE_STAR_MIN_LEVEL = MAX_LEVEL;
 
-      PRINT_RESER_PARA( SF_CREATE_STAR_MIN_LEVEL, FORMAT_INT, "" );
+      PRINT_RESET_PARA( SF_CREATE_STAR_MIN_LEVEL, FORMAT_INT, "" );
    }
 
    if ( SF_CREATE_STAR_DET_RANDOM < 0 )
    {
 #     ifdef BITWISE_REPRODUCIBILITY
          SF_CREATE_STAR_DET_RANDOM = 1;
-         PRINT_RESER_PARA( SF_CREATE_STAR_DET_RANDOM, FORMAT_INT, "since BITWISE_REPRODUCIBILITY is enabled" );
+         PRINT_RESET_PARA( SF_CREATE_STAR_DET_RANDOM, FORMAT_INT, "since BITWISE_REPRODUCIBILITY is enabled" );
 #     else
          SF_CREATE_STAR_DET_RANDOM = 0;
-         PRINT_RESER_PARA( SF_CREATE_STAR_DET_RANDOM, FORMAT_INT, "since BITWISE_REPRODUCIBILITY is disabled" );
+         PRINT_RESET_PARA( SF_CREATE_STAR_DET_RANDOM, FORMAT_INT, "since BITWISE_REPRODUCIBILITY is disabled" );
 #     endif
 
    }
@@ -954,7 +954,7 @@ void Init_ResetParameter()
    {
       FB_LEVEL = MAX_LEVEL;
 
-      PRINT_RESER_PARA( FB_LEVEL, FORMAT_INT, "" );
+      PRINT_RESET_PARA( FB_LEVEL, FORMAT_INT, "" );
    }
 #  endif // #ifdef FEEDBACK
 
@@ -964,13 +964,13 @@ void Init_ResetParameter()
 // SF_CREATE_STAR_MIN_GAS_DENS: HI count/cm^3 --> mass density in code units
    SF_CREATE_STAR_MIN_GAS_DENS *= Const_mH / UNIT_D;
 
-   PRINT_RESER_PARA( SF_CREATE_STAR_MIN_GAS_DENS, FORMAT_FLT, "to be consistent with the code units" );
+   PRINT_RESET_PARA( SF_CREATE_STAR_MIN_GAS_DENS, FORMAT_FLT, "to be consistent with the code units" );
 
 
 // SF_CREATE_STAR_MIN_STAR_MASS: Msun --> code units
    SF_CREATE_STAR_MIN_STAR_MASS *= Const_Msun / UNIT_M;
 
-   PRINT_RESER_PARA( SF_CREATE_STAR_MIN_STAR_MASS, FORMAT_FLT, "to be consistent with the code units" );
+   PRINT_RESET_PARA( SF_CREATE_STAR_MIN_STAR_MASS, FORMAT_FLT, "to be consistent with the code units" );
 #  endif // #ifdef STAR_FORMATION
 
 
@@ -980,7 +980,7 @@ void Init_ResetParameter()
    {
       OPT__MINIMIZE_MPI_BARRIER = false;
 
-      PRINT_RESER_PARA( OPT__MINIMIZE_MPI_BARRIER, FORMAT_INT, "since SERIAL is enabled" );
+      PRINT_RESET_PARA( OPT__MINIMIZE_MPI_BARRIER, FORMAT_INT, "since SERIAL is enabled" );
    }
 #  endif
 
@@ -991,7 +991,7 @@ void Init_ResetParameter()
    {
       OPT__INIT_GRID_WITH_OMP = false;
 
-      PRINT_RESER_PARA( OPT__INIT_GRID_WITH_OMP, FORMAT_INT, "since OPENMP is disabled" );
+      PRINT_RESET_PARA( OPT__INIT_GRID_WITH_OMP, FORMAT_INT, "since OPENMP is disabled" );
    }
 #  endif
 
@@ -1001,7 +1001,7 @@ void Init_ResetParameter()
    {
       OPT__RESET_FLUID_INIT = OPT__RESET_FLUID;
 
-      PRINT_RESER_PARA( OPT__RESET_FLUID_INIT, FORMAT_INT, "to match OPT__RESET_FLUID" );
+      PRINT_RESET_PARA( OPT__RESET_FLUID_INIT, FORMAT_INT, "to match OPT__RESET_FLUID" );
    }
 
 
@@ -1011,7 +1011,7 @@ void Init_ResetParameter()
    {
       OPT__SORT_PATCH_BY_LBIDX = false;
 
-      PRINT_RESER_PARA( OPT__SORT_PATCH_BY_LBIDX, FORMAT_INT, "for SERIAL" );
+      PRINT_RESET_PARA( OPT__SORT_PATCH_BY_LBIDX, FORMAT_INT, "for SERIAL" );
    }
 #  endif
 
@@ -1025,11 +1025,11 @@ void Init_ResetParameter()
    {
 #     ifdef BITWISE_REPRODUCIBILITY
       OPT__FFTW_STARTUP = FFTW_STARTUP_ESTIMATE;
-      PRINT_RESER_PARA( OPT__FFTW_STARTUP, FORMAT_INT, "when enabling BITWISE_REPRODUCIBILITY" );
+      PRINT_RESET_PARA( OPT__FFTW_STARTUP, FORMAT_INT, "when enabling BITWISE_REPRODUCIBILITY" );
 #     else
 //    OPT__FFTW_STARTUP = FFTW_STARTUP_MEASURE;
       OPT__FFTW_STARTUP = FFTW_STARTUP_ESTIMATE;
-      PRINT_RESER_PARA( OPT__FFTW_STARTUP, FORMAT_INT, "when disabling BITWISE_REPRODUCIBILITY" );
+      PRINT_RESET_PARA( OPT__FFTW_STARTUP, FORMAT_INT, "when disabling BITWISE_REPRODUCIBILITY" );
 #     endif
    }
 #  endif

--- a/src/Init/Init_ResetParameter.cpp
+++ b/src/Init/Init_ResetParameter.cpp
@@ -25,31 +25,20 @@ void Init_ResetParameter()
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ...\n", __FUNCTION__ );
 
 
-// helper macro for printing warning messages
-#  define FORMAT_INT    %- 21d
-#  define FORMAT_FLT    %- 21.14e
-#  define PRINT_WARNING( name, format, reason )                                                                \
-   {                                                                                                           \
-      if ( MPI_Rank == 0 )                                                                                     \
-         Aux_Message( stderr, "WARNING : parameter [%-28s] is reset to [" EXPAND_AND_QUOTE(format) "] %s\n",   \
-                      #name, name, reason );                                                                   \
-   }
-
-
 // number of OpenMP threads
 #  ifdef OPENMP
    if ( OMP_NTHREAD <= 0 )
    {
       OMP_NTHREAD = omp_get_max_threads();
 
-      PRINT_WARNING( OMP_NTHREAD, FORMAT_INT, "" );
+      PRINT_RESET_PARA( OMP_NTHREAD, FORMAT_INT, "" );
    }
 #  else
    if ( OMP_NTHREAD != 1 )
    {
       OMP_NTHREAD = 1;
 
-      PRINT_WARNING( OMP_NTHREAD, FORMAT_INT, "since OPENMP is disabled" );
+      PRINT_RESET_PARA( OMP_NTHREAD, FORMAT_INT, "since OPENMP is disabled" );
    }
 #  endif // #ifdef OPENMP ... else ...
 
@@ -85,14 +74,14 @@ void Init_ResetParameter()
 #     error : ERROR : unsupported MODEL !!
 #     endif // MODEL
 
-      PRINT_WARNING( DT__FLUID, FORMAT_FLT, "" );
+      PRINT_RESER_PARA( DT__FLUID, FORMAT_FLT, "" );
    } // if ( DT__FLUID < 0.0 )
 
    if ( DT__FLUID_INIT < 0.0 )
    {
       DT__FLUID_INIT = DT__FLUID;
 
-      PRINT_WARNING( DT__FLUID_INIT, FORMAT_FLT, "" );
+      PRINT_RESER_PARA( DT__FLUID_INIT, FORMAT_FLT, "" );
    }
 
 
@@ -108,7 +97,7 @@ void Init_ResetParameter()
 #     error : ERROR : unsupported MODEL !!
 #     endif // MODEL
 
-      PRINT_WARNING( DT__GRAVITY, FORMAT_FLT, "" );
+      PRINT_RESER_PARA( DT__GRAVITY, FORMAT_FLT, "" );
    } // if ( DT__GRAVITY < 0.0 )
 #  endif
 
@@ -119,7 +108,7 @@ void Init_ResetParameter()
    {
       DT__PARACC = 0.0;    // disable it
 
-      PRINT_WARNING( DT__PARACC, FORMAT_FLT, "since STORE_PAR_ACC is disabled" );
+      PRINT_RESER_PARA( DT__PARACC, FORMAT_FLT, "since STORE_PAR_ACC is disabled" );
    }
 #  endif
 
@@ -145,7 +134,7 @@ void Init_ResetParameter()
       EXT_POT_TABLE_FLOAT8 = 0;
 #     endif
 
-      PRINT_WARNING( EXT_POT_TABLE_FLOAT8, FORMAT_INT, "to be consistent with FLOAT8" );
+      PRINT_RESER_PARA( EXT_POT_TABLE_FLOAT8, FORMAT_INT, "to be consistent with FLOAT8" );
    }
 #  endif
 
@@ -154,7 +143,7 @@ void Init_ResetParameter()
 #  ifndef GPU
    GPU_NSTREAM = 1;
 
-   PRINT_WARNING( GPU_NSTREAM, FORMAT_INT, "since GPU is disabled" );
+   PRINT_RESER_PARA( GPU_NSTREAM, FORMAT_INT, "since GPU is disabled" );
 
    if ( FLU_GPU_NPGROUP <= 0 )
    {
@@ -164,7 +153,7 @@ void Init_ResetParameter()
       FLU_GPU_NPGROUP = 1;
 #     endif
 
-      PRINT_WARNING( FLU_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
+      PRINT_RESER_PARA( FLU_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
    }
 
 #  ifdef GRAVITY
@@ -176,7 +165,7 @@ void Init_ResetParameter()
       POT_GPU_NPGROUP = 1;
 #     endif
 
-      PRINT_WARNING( POT_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
+      PRINT_RESER_PARA( POT_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
    }
 #  endif
 
@@ -189,7 +178,7 @@ void Init_ResetParameter()
       CHE_GPU_NPGROUP = 1;
 #     endif
 
-      PRINT_WARNING( CHE_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
+      PRINT_RESER_PARA( CHE_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
    }
 #  endif
 
@@ -201,7 +190,7 @@ void Init_ResetParameter()
       SRC_GPU_NPGROUP = 1;
 #     endif
 
-      PRINT_WARNING( SRC_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
+      PRINT_RESER_PARA( SRC_GPU_NPGROUP, FORMAT_INT, "since GPU is disabled" );
    }
 #  endif // #ifndef GPU
 
@@ -250,7 +239,7 @@ void Init_ResetParameter()
 #  if ( MODEL == ELBDM )
    ELBDM_ETA = ELBDM_MASS / ELBDM_PLANCK_CONST;
 
-   PRINT_WARNING( ELBDM_ETA, FORMAT_FLT, "" );
+   PRINT_RESER_PARA( ELBDM_ETA, FORMAT_FLT, "" );
 
 #  ifdef COMOVING
    if ( MPI_Rank == 0 )
@@ -265,7 +254,7 @@ void Init_ResetParameter()
    {
       ELBDM_TAYLOR3_COEFF = NULL_REAL;
 
-      PRINT_WARNING( ELBDM_TAYLOR3_COEFF, FORMAT_FLT, "since ELBDM_TAYLOR3_AUTO is enabled" );
+      PRINT_RESER_PARA( ELBDM_TAYLOR3_COEFF, FORMAT_FLT, "since ELBDM_TAYLOR3_AUTO is enabled" );
    }
 #  endif // #if ( MODEL == ELBDM )
 
@@ -276,14 +265,14 @@ void Init_ResetParameter()
    {
       OPT__FLU_INT_SCHEME = INT_CQUAD;
 
-      PRINT_WARNING( OPT__FLU_INT_SCHEME, FORMAT_INT, "" );
+      PRINT_RESER_PARA( OPT__FLU_INT_SCHEME, FORMAT_INT, "" );
    }
 
    if ( OPT__REF_FLU_INT_SCHEME == INT_DEFAULT )
    {
       OPT__REF_FLU_INT_SCHEME = INT_CQUAD;
 
-      PRINT_WARNING( OPT__REF_FLU_INT_SCHEME, FORMAT_INT, "" );
+      PRINT_RESER_PARA( OPT__REF_FLU_INT_SCHEME, FORMAT_INT, "" );
    }
 
 #  elif ( MODEL == ELBDM )
@@ -291,14 +280,14 @@ void Init_ResetParameter()
    {
       OPT__FLU_INT_SCHEME = INT_CQUAR;
 
-      PRINT_WARNING( OPT__FLU_INT_SCHEME, FORMAT_INT, "" );
+      PRINT_RESER_PARA( OPT__FLU_INT_SCHEME, FORMAT_INT, "" );
    }
 
    if ( OPT__REF_FLU_INT_SCHEME == INT_DEFAULT )
    {
       OPT__REF_FLU_INT_SCHEME = INT_CQUAR;
 
-      PRINT_WARNING( OPT__REF_FLU_INT_SCHEME, FORMAT_INT, "" );
+      PRINT_RESER_PARA( OPT__REF_FLU_INT_SCHEME, FORMAT_INT, "" );
    }
 
 #  else
@@ -348,7 +337,7 @@ void Init_ResetParameter()
       }
 
       const double PAR_REMOVE_CELL = amr->Par->RemoveCell;
-      PRINT_WARNING( PAR_REMOVE_CELL, FORMAT_FLT, "for the adopted PAR_INTERP scheme" );
+      PRINT_RESER_PARA( PAR_REMOVE_CELL, FORMAT_FLT, "for the adopted PAR_INTERP scheme" );
    }
 
 // RemoveCell is useless for the periodic B.C.
@@ -357,7 +346,7 @@ void Init_ResetParameter()
       amr->Par->RemoveCell = -1.0;
 
       const double PAR_REMOVE_CELL = amr->Par->RemoveCell;
-      PRINT_WARNING( PAR_REMOVE_CELL, FORMAT_FLT, "since the periodic BC is adopted along all directions" );
+      PRINT_RESER_PARA( PAR_REMOVE_CELL, FORMAT_FLT, "since the periodic BC is adopted along all directions" );
    }
 
 // number of ghost zones for the particle interpolation scheme
@@ -371,7 +360,7 @@ void Init_ResetParameter()
          default: Aux_Error( ERROR_INFO, "unsupported particle interpolation scheme !!\n" );
       }
 
-      PRINT_WARNING( amr->Par->GhostSize, FORMAT_INT, "for the adopted PAR_INTERP scheme" );
+      PRINT_RESER_PARA( amr->Par->GhostSize, FORMAT_INT, "for the adopted PAR_INTERP scheme" );
    }
 
    if ( amr->Par->GhostSizeTracer < 0 )
@@ -384,7 +373,7 @@ void Init_ResetParameter()
          default: Aux_Error( ERROR_INFO, "unsupported particle interpolation scheme !!\n" );
       }
 
-      PRINT_WARNING( amr->Par->GhostSizeTracer, FORMAT_INT, "for the adopted PAR_TR_INTERP scheme" );
+      PRINT_RESER_PARA( amr->Par->GhostSizeTracer, FORMAT_INT, "for the adopted PAR_TR_INTERP scheme" );
    }
 
 #  endif // #ifdef PARTICLE
@@ -410,7 +399,7 @@ void Init_ResetParameter()
 
       GFUNC_COEFF0 = 3.8;  // empirically determined value for minimizing the center-of-mass drift
 
-      PRINT_WARNING( GFUNC_COEFF0, FORMAT_FLT, "" );
+      PRINT_RESER_PARA( GFUNC_COEFF0, FORMAT_FLT, "" );
    }
 #  endif
 
@@ -422,7 +411,7 @@ void Init_ResetParameter()
 #     ifdef MHD
       OPT__1ST_FLUX_CORR = FIRST_FLUX_CORR_3D;
 
-      PRINT_WARNING( OPT__1ST_FLUX_CORR, FORMAT_INT, "for MHD" );
+      PRINT_RESER_PARA( OPT__1ST_FLUX_CORR, FORMAT_INT, "for MHD" );
 
 #     else
 
@@ -432,7 +421,7 @@ void Init_ResetParameter()
       OPT__1ST_FLUX_CORR = FIRST_FLUX_CORR_3D1D;
 #     endif
 
-      PRINT_WARNING( OPT__1ST_FLUX_CORR, FORMAT_INT, "for HYDRO" );
+      PRINT_RESER_PARA( OPT__1ST_FLUX_CORR, FORMAT_INT, "for HYDRO" );
 #     endif // #ifdef MHD ... else ...
    }
 
@@ -440,7 +429,7 @@ void Init_ResetParameter()
    {
       OPT__1ST_FLUX_CORR_SCHEME = RSOLVER_1ST_NONE;
 
-      PRINT_WARNING( OPT__1ST_FLUX_CORR_SCHEME, FORMAT_INT, "since OPT__1ST_FLUX_CORR is disabled" );
+      PRINT_RESER_PARA( OPT__1ST_FLUX_CORR_SCHEME, FORMAT_INT, "since OPT__1ST_FLUX_CORR is disabled" );
    }
 
    else if ( OPT__1ST_FLUX_CORR != FIRST_FLUX_CORR_NONE  &&  OPT__1ST_FLUX_CORR_SCHEME == RSOLVER_1ST_DEFAULT )
@@ -451,7 +440,7 @@ void Init_ResetParameter()
       OPT__1ST_FLUX_CORR_SCHEME = RSOLVER_1ST_HLLE;
 #     endif
 
-      PRINT_WARNING( OPT__1ST_FLUX_CORR_SCHEME, FORMAT_INT, "" );
+      PRINT_RESER_PARA( OPT__1ST_FLUX_CORR_SCHEME, FORMAT_INT, "" );
    }
 #  endif // if ( MODEL == HYDRO )
 
@@ -470,7 +459,7 @@ void Init_ResetParameter()
       OPT__TIMING_BARRIER = 1;
 #     endif
 
-      PRINT_WARNING( OPT__TIMING_BARRIER, FORMAT_INT, "" );
+      PRINT_RESER_PARA( OPT__TIMING_BARRIER, FORMAT_INT, "" );
    }
 
 
@@ -507,7 +496,7 @@ void Init_ResetParameter()
    {
       OPT__CORR_AFTER_ALL_SYNC = CORR_AFTER_SYNC_BEFORE_DUMP;
 
-      PRINT_WARNING( OPT__CORR_AFTER_ALL_SYNC, FORMAT_INT, "" );
+      PRINT_RESER_PARA( OPT__CORR_AFTER_ALL_SYNC, FORMAT_INT, "" );
    }
 
 
@@ -518,7 +507,7 @@ void Init_ResetParameter()
    {
       OPT__OVERLAP_MPI = false;
 
-      PRINT_WARNING( OPT__OVERLAP_MPI, FORMAT_INT, "since OVERLAP_MPI is disabled in the makefile" );
+      PRINT_RESER_PARA( OPT__OVERLAP_MPI, FORMAT_INT, "since OVERLAP_MPI is disabled in the makefile" );
    }
 #  endif
 
@@ -527,7 +516,7 @@ void Init_ResetParameter()
    {
       OPT__OVERLAP_MPI = false;
 
-      PRINT_WARNING( OPT__OVERLAP_MPI, FORMAT_INT, "since SERIAL is enabled" );
+      PRINT_RESER_PARA( OPT__OVERLAP_MPI, FORMAT_INT, "since SERIAL is enabled" );
    }
 #  endif // ifdef SERIAL
 
@@ -536,7 +525,7 @@ void Init_ResetParameter()
    {
       OPT__OVERLAP_MPI = false;
 
-      PRINT_WARNING( OPT__OVERLAP_MPI, FORMAT_INT, "since LOAD_BALANCE is disabled" );
+      PRINT_RESER_PARA( OPT__OVERLAP_MPI, FORMAT_INT, "since LOAD_BALANCE is disabled" );
    }
 #  endif // #ifndef LOAD_BALANCE
 
@@ -545,7 +534,7 @@ void Init_ResetParameter()
    {
       OPT__OVERLAP_MPI = false;
 
-      PRINT_WARNING( OPT__OVERLAP_MPI, FORMAT_INT, "since OPENMP is disabled" );
+      PRINT_RESER_PARA( OPT__OVERLAP_MPI, FORMAT_INT, "since OPENMP is disabled" );
    }
 #  endif
 
@@ -557,7 +546,7 @@ void Init_ResetParameter()
    {
       OPT__OVERLAP_MPI = false;
 
-      PRINT_WARNING( OPT__OVERLAP_MPI, FORMAT_INT, "since the level of MPI thread support == MPI_THREAD_SINGLE" );
+      PRINT_RESER_PARA( OPT__OVERLAP_MPI, FORMAT_INT, "since the level of MPI thread support == MPI_THREAD_SINGLE" );
    }
 #  endif
 
@@ -567,7 +556,7 @@ void Init_ResetParameter()
    {
       OPT__CK_FLUX_ALLOCATE = false;
 
-      PRINT_WARNING( OPT__CK_FLUX_ALLOCATE, FORMAT_INT, "since no flux is required" );
+      PRINT_RESER_PARA( OPT__CK_FLUX_ALLOCATE, FORMAT_INT, "since no flux is required" );
    }
 
 
@@ -576,7 +565,7 @@ void Init_ResetParameter()
    {
       OPT__INT_TIME = false;
 
-      PRINT_WARNING( OPT__INT_TIME, FORMAT_INT, "since OPT__DT_LEVEL == DT_LEVEL_SHARED" );
+      PRINT_RESER_PARA( OPT__INT_TIME, FORMAT_INT, "since OPT__DT_LEVEL == DT_LEVEL_SHARED" );
    }
 
 
@@ -586,7 +575,7 @@ void Init_ResetParameter()
    {
       OPT__VERBOSE = true;
 
-      PRINT_WARNING( OPT__VERBOSE, FORMAT_INT, "since GAMER_DEBUG is enabled" );
+      PRINT_RESER_PARA( OPT__VERBOSE, FORMAT_INT, "since GAMER_DEBUG is enabled" );
    }
 #  endif
 
@@ -597,14 +586,14 @@ void Init_ResetParameter()
    {
       OPT__FIXUP_FLUX = false;
 
-      PRINT_WARNING( OPT__FIXUP_FLUX, FORMAT_INT, "since it's only supported in HYDRO/ELBDM" );
+      PRINT_RESER_PARA( OPT__FIXUP_FLUX, FORMAT_INT, "since it's only supported in HYDRO/ELBDM" );
    }
 
    if ( OPT__CK_FLUX_ALLOCATE )
    {
       OPT__CK_FLUX_ALLOCATE = false;
 
-      PRINT_WARNING( OPT__CK_FLUX_ALLOCATE, FORMAT_INT, "since it's only supported in HYDRO/ELBDM" );
+      PRINT_RESER_PARA( OPT__CK_FLUX_ALLOCATE, FORMAT_INT, "since it's only supported in HYDRO/ELBDM" );
    }
 #  endif
 
@@ -615,21 +604,21 @@ void Init_ResetParameter()
    {
       OPT__FLAG_RHO = false;
 
-      PRINT_WARNING( OPT__FLAG_RHO, FORMAT_INT, "since the symbolic constant DENS is not defined" );
+      PRINT_RESER_PARA( OPT__FLAG_RHO, FORMAT_INT, "since the symbolic constant DENS is not defined" );
    }
 
    if ( OPT__FLAG_RHO_GRADIENT )
    {
       OPT__FLAG_RHO_GRADIENT = false;
 
-      PRINT_WARNING( OPT__FLAG_RHO_GRADIENT, FORMAT_INT, "since the symbolic constant DENS is not defined" );
+      PRINT_RESER_PARA( OPT__FLAG_RHO_GRADIENT, FORMAT_INT, "since the symbolic constant DENS is not defined" );
    }
 
    if ( OPT__CK_REFINE )
    {
       OPT__CK_REFINE = false;
 
-      PRINT_WARNING( OPT__CK_REFINE, FORMAT_INT, "since the symbolic constant DENS is not defined" );
+      PRINT_RESER_PARA( OPT__CK_REFINE, FORMAT_INT, "since the symbolic constant DENS is not defined" );
    }
 #  endif // #ifndef DENS
 
@@ -640,7 +629,7 @@ void Init_ResetParameter()
    {
       OPT__CK_CONSERVATION = false;
 
-      PRINT_WARNING( OPT__CK_CONSERVATION, FORMAT_INT, "since it's only supported in HYDRO/ELBDM" );
+      PRINT_RESER_PARA( OPT__CK_CONSERVATION, FORMAT_INT, "since it's only supported in HYDRO/ELBDM" );
    }
 #  endif
 
@@ -656,14 +645,14 @@ void Init_ResetParameter()
 //    OPT__LR_LIMITER = LR_LIMITER_VL_GMINMOD;
       OPT__LR_LIMITER = LR_LIMITER_GMINMOD;
 
-      PRINT_WARNING( OPT__LR_LIMITER, FORMAT_INT, "for MHM_RP+PPM" );
+      PRINT_RESER_PARA( OPT__LR_LIMITER, FORMAT_INT, "for MHM_RP+PPM" );
    }
 #  else
    if ( OPT__LR_LIMITER == LR_LIMITER_DEFAULT )
    {
       OPT__LR_LIMITER = LR_LIMITER_VL_GMINMOD;
 
-      PRINT_WARNING( OPT__LR_LIMITER, FORMAT_INT, "" );
+      PRINT_RESER_PARA( OPT__LR_LIMITER, FORMAT_INT, "" );
    }
 #  endif // #if ( FLU_SCHEME == MHM_RP  &&  LR_SCHEME == PPM ) ... else ...
 
@@ -673,7 +662,7 @@ void Init_ResetParameter()
    {
       OPT__LR_LIMITER = LR_LIMITER_NONE;
 
-      PRINT_WARNING( OPT__LR_LIMITER, FORMAT_INT, "since it's only useful for the MHM/MHM_RP/CTU integrators" );
+      PRINT_RESER_PARA( OPT__LR_LIMITER, FORMAT_INT, "since it's only useful for the MHM/MHM_RP/CTU integrators" );
    }
 
 #  endif // #if ( FLU_SCHEME == MHM  ||  FLU_SCHEME == MHM_RP  ||  FLU_SCHEME == CTU ) ... else ...
@@ -686,7 +675,7 @@ void Init_ResetParameter()
    {
       OPT__FLAG_JEANS = false;
 
-      PRINT_WARNING( OPT__FLAG_JEANS, FORMAT_INT, "since GRAVITY is disabled" );
+      PRINT_RESER_PARA( OPT__FLAG_JEANS, FORMAT_INT, "since GRAVITY is disabled" );
    }
 #  endif
 
@@ -697,14 +686,14 @@ void Init_ResetParameter()
    {
       OPT__FIXUP_FLUX = false;
 
-      PRINT_WARNING( OPT__FIXUP_FLUX, FORMAT_INT, "since CONSERVE_MASS is disabled" );
+      PRINT_RESER_PARA( OPT__FIXUP_FLUX, FORMAT_INT, "since CONSERVE_MASS is disabled" );
    }
 
    if ( OPT__CK_FLUX_ALLOCATE )
    {
       OPT__CK_FLUX_ALLOCATE = false;
 
-      PRINT_WARNING( OPT__CK_FLUX_ALLOCATE, FORMAT_INT, "since CONSERVE_MASS is disabled" );
+      PRINT_RESER_PARA( OPT__CK_FLUX_ALLOCATE, FORMAT_INT, "since CONSERVE_MASS is disabled" );
    }
 #  endif
 
@@ -715,7 +704,7 @@ void Init_ResetParameter()
    {
       OPT__OUTPUT_BASEPS = false;
 
-      PRINT_WARNING( OPT__OUTPUT_BASEPS, FORMAT_INT, "since SUPPORT_FFTW is disabled" );
+      PRINT_RESER_PARA( OPT__OUTPUT_BASEPS, FORMAT_INT, "since SUPPORT_FFTW is disabled" );
    }
 #  endif
 
@@ -726,7 +715,7 @@ void Init_ResetParameter()
    if ( MPI_NRank_X[d] != 1 )
    {
       MPI_NRank_X[d] = 1;
-      PRINT_WARNING( MPI_NRank_X[d], FORMAT_INT, "for SERIAL" );
+      PRINT_RESER_PARA( MPI_NRank_X[d], FORMAT_INT, "for SERIAL" );
    }
 #  endif
 
@@ -736,7 +725,7 @@ void Init_ResetParameter()
    {
       MPI_NRank_X[d] = -1;
 
-      PRINT_WARNING( MPI_NRank_X[d], FORMAT_INT, "since it's useless" );
+      PRINT_RESER_PARA( MPI_NRank_X[d], FORMAT_INT, "since it's useless" );
    }
 #  endif
 
@@ -747,28 +736,28 @@ void Init_ResetParameter()
    {
       OPT__RECORD_PERFORMANCE = false;
 
-      PRINT_WARNING( OPT__RECORD_PERFORMANCE, FORMAT_INT, "since TIMING is disabled" );
+      PRINT_RESER_PARA( OPT__RECORD_PERFORMANCE, FORMAT_INT, "since TIMING is disabled" );
    }
 
    if ( OPT__TIMING_BARRIER != 0 )
    {
       OPT__TIMING_BARRIER = 0;
 
-      PRINT_WARNING( OPT__TIMING_BARRIER, FORMAT_INT, "since TIMING is disabled" );
+      PRINT_RESER_PARA( OPT__TIMING_BARRIER, FORMAT_INT, "since TIMING is disabled" );
    }
 
    if ( OPT__TIMING_BALANCE )
    {
       OPT__TIMING_BALANCE = false;
 
-      PRINT_WARNING( OPT__TIMING_BALANCE, FORMAT_INT, "since TIMING is disabled" );
+      PRINT_RESER_PARA( OPT__TIMING_BALANCE, FORMAT_INT, "since TIMING is disabled" );
    }
 
    if ( OPT__TIMING_MPI )
    {
       OPT__TIMING_MPI = false;
 
-      PRINT_WARNING( OPT__TIMING_MPI, FORMAT_INT, "since TIMING is disabled" );
+      PRINT_RESER_PARA( OPT__TIMING_MPI, FORMAT_INT, "since TIMING is disabled" );
    }
 #  endif // #ifndef TIMING
 
@@ -779,7 +768,7 @@ void Init_ResetParameter()
    {
       OPT__TIMING_MPI = false;
 
-      PRINT_WARNING( OPT__TIMING_MPI, FORMAT_INT, "since LOAD_BALANCE is disabled" );
+      PRINT_RESER_PARA( OPT__TIMING_MPI, FORMAT_INT, "since LOAD_BALANCE is disabled" );
    }
 #  endif
 
@@ -797,7 +786,7 @@ void Init_ResetParameter()
       OPT__UM_IC_NVAR = NCOMP_TOTAL;      // load all fields
 #     endif
 
-      PRINT_WARNING( OPT__UM_IC_NVAR, FORMAT_INT, "" );
+      PRINT_RESER_PARA( OPT__UM_IC_NVAR, FORMAT_INT, "" );
    }
 
 
@@ -807,7 +796,7 @@ void Init_ResetParameter()
    {
       OPT__CK_PARTICLE = true;
 
-      PRINT_WARNING( OPT__CK_PARTICLE, FORMAT_INT, "since DEBUG_PARTICLE is enabled" );
+      PRINT_RESER_PARA( OPT__CK_PARTICLE, FORMAT_INT, "since DEBUG_PARTICLE is enabled" );
    }
 #  endif
 
@@ -819,7 +808,7 @@ void Init_ResetParameter()
       amr->Par->Init = PAR_INIT_BY_RESTART;
 
       const ParInit_t PAR_INIT = amr->Par->Init;
-      PRINT_WARNING( PAR_INIT, FORMAT_INT, "for restart" );
+      PRINT_RESER_PARA( PAR_INIT, FORMAT_INT, "for restart" );
    }
 #  endif
 
@@ -831,7 +820,7 @@ void Init_ResetParameter()
    {
       JEANS_MIN_PRES = false;
 
-      PRINT_WARNING( JEANS_MIN_PRES, FORMAT_INT, "since GRAVITY is disabled" );
+      PRINT_RESER_PARA( JEANS_MIN_PRES, FORMAT_INT, "since GRAVITY is disabled" );
    }
 #  endif
 
@@ -839,7 +828,7 @@ void Init_ResetParameter()
    {
       JEANS_MIN_PRES_LEVEL = MAX_LEVEL;
 
-      PRINT_WARNING( JEANS_MIN_PRES_LEVEL, FORMAT_INT, "" );
+      PRINT_RESER_PARA( JEANS_MIN_PRES_LEVEL, FORMAT_INT, "" );
    }
 #  endif
 
@@ -850,14 +839,14 @@ void Init_ResetParameter()
    {
       MIN_EINT = MIN_PRES*1.5;
 
-      PRINT_WARNING( MIN_EINT, FORMAT_FLT, "" );
+      PRINT_RESER_PARA( MIN_EINT, FORMAT_FLT, "" );
    }
 
    else if ( MIN_EINT > 0.0  &&  MIN_PRES == 0.0 )
    {
       MIN_PRES = MIN_EINT/1.5;
 
-      PRINT_WARNING( MIN_PRES, FORMAT_FLT, "" );
+      PRINT_RESER_PARA( MIN_PRES, FORMAT_FLT, "" );
    }
 #  endif
 
@@ -870,14 +859,14 @@ void Init_ResetParameter()
       {
          OPT__CHECK_PRES_AFTER_FLU = 1;
 
-         PRINT_WARNING( OPT__CHECK_PRES_AFTER_FLU, FORMAT_INT, "" );
+         PRINT_RESER_PARA( OPT__CHECK_PRES_AFTER_FLU, FORMAT_INT, "" );
       }
 
       else
       {
          OPT__CHECK_PRES_AFTER_FLU = 0;
 
-         PRINT_WARNING( OPT__CHECK_PRES_AFTER_FLU, FORMAT_INT, "" );
+         PRINT_RESER_PARA( OPT__CHECK_PRES_AFTER_FLU, FORMAT_INT, "" );
       }
    }
 #  endif
@@ -888,14 +877,14 @@ void Init_ResetParameter()
    {
       MU_NORM = Const_mH;
 
-      PRINT_WARNING( MU_NORM, FORMAT_FLT, "" );
+      PRINT_RESER_PARA( MU_NORM, FORMAT_FLT, "" );
    }
 
    else if ( MU_NORM == 0.0 )
    {
       MU_NORM = Const_amu;
 
-      PRINT_WARNING( MU_NORM, FORMAT_FLT, "" );
+      PRINT_RESER_PARA( MU_NORM, FORMAT_FLT, "" );
    }
 #  endif
 
@@ -905,7 +894,7 @@ void Init_ResetParameter()
    {
       AUTO_REDUCE_DT = false;
 
-      PRINT_WARNING( AUTO_REDUCE_DT, FORMAT_INT, "since OPT__DT_LEVEL != DT_LEVEL_FLEXIBLE" );
+      PRINT_RESER_PARA( AUTO_REDUCE_DT, FORMAT_INT, "since OPT__DT_LEVEL != DT_LEVEL_FLEXIBLE" );
    }
 
 
@@ -915,7 +904,7 @@ void Init_ResetParameter()
    {
       FLAG_BUFFER_SIZE = PS1;
 
-      PRINT_WARNING( FLAG_BUFFER_SIZE, FORMAT_INT, "to match PATCH_SIZE" );
+      PRINT_RESER_PARA( FLAG_BUFFER_SIZE, FORMAT_INT, "to match PATCH_SIZE" );
    }
 
 // level MAX_LEVEL-1
@@ -923,7 +912,7 @@ void Init_ResetParameter()
    {
       FLAG_BUFFER_SIZE_MAXM1_LV = REGRID_COUNT;
 
-      PRINT_WARNING( FLAG_BUFFER_SIZE_MAXM1_LV, FORMAT_INT, "to match REGRID_COUNT" );
+      PRINT_RESER_PARA( FLAG_BUFFER_SIZE_MAXM1_LV, FORMAT_INT, "to match REGRID_COUNT" );
    }
 
 // level MAX_LEVEL-2
@@ -932,7 +921,7 @@ void Init_ResetParameter()
    {
       FLAG_BUFFER_SIZE_MAXM2_LV = ( FLAG_BUFFER_SIZE_MAXM1_LV + FLAG_BUFFER_SIZE_MAXM1_LV%2 + PS1 ) / 2;
 
-      PRINT_WARNING( FLAG_BUFFER_SIZE_MAXM2_LV, FORMAT_INT, "" );
+      PRINT_RESER_PARA( FLAG_BUFFER_SIZE_MAXM2_LV, FORMAT_INT, "" );
    }
 
 
@@ -942,17 +931,17 @@ void Init_ResetParameter()
    {
       SF_CREATE_STAR_MIN_LEVEL = MAX_LEVEL;
 
-      PRINT_WARNING( SF_CREATE_STAR_MIN_LEVEL, FORMAT_INT, "" );
+      PRINT_RESER_PARA( SF_CREATE_STAR_MIN_LEVEL, FORMAT_INT, "" );
    }
 
    if ( SF_CREATE_STAR_DET_RANDOM < 0 )
    {
 #     ifdef BITWISE_REPRODUCIBILITY
          SF_CREATE_STAR_DET_RANDOM = 1;
-         PRINT_WARNING( SF_CREATE_STAR_DET_RANDOM, FORMAT_INT, "since BITWISE_REPRODUCIBILITY is enabled" );
+         PRINT_RESER_PARA( SF_CREATE_STAR_DET_RANDOM, FORMAT_INT, "since BITWISE_REPRODUCIBILITY is enabled" );
 #     else
          SF_CREATE_STAR_DET_RANDOM = 0;
-         PRINT_WARNING( SF_CREATE_STAR_DET_RANDOM, FORMAT_INT, "since BITWISE_REPRODUCIBILITY is disabled" );
+         PRINT_RESER_PARA( SF_CREATE_STAR_DET_RANDOM, FORMAT_INT, "since BITWISE_REPRODUCIBILITY is disabled" );
 #     endif
 
    }
@@ -965,7 +954,7 @@ void Init_ResetParameter()
    {
       FB_LEVEL = MAX_LEVEL;
 
-      PRINT_WARNING( FB_LEVEL, FORMAT_INT, "" );
+      PRINT_RESER_PARA( FB_LEVEL, FORMAT_INT, "" );
    }
 #  endif // #ifdef FEEDBACK
 
@@ -975,13 +964,13 @@ void Init_ResetParameter()
 // SF_CREATE_STAR_MIN_GAS_DENS: HI count/cm^3 --> mass density in code units
    SF_CREATE_STAR_MIN_GAS_DENS *= Const_mH / UNIT_D;
 
-   PRINT_WARNING( SF_CREATE_STAR_MIN_GAS_DENS, FORMAT_FLT, "to be consistent with the code units" );
+   PRINT_RESER_PARA( SF_CREATE_STAR_MIN_GAS_DENS, FORMAT_FLT, "to be consistent with the code units" );
 
 
 // SF_CREATE_STAR_MIN_STAR_MASS: Msun --> code units
    SF_CREATE_STAR_MIN_STAR_MASS *= Const_Msun / UNIT_M;
 
-   PRINT_WARNING( SF_CREATE_STAR_MIN_STAR_MASS, FORMAT_FLT, "to be consistent with the code units" );
+   PRINT_RESER_PARA( SF_CREATE_STAR_MIN_STAR_MASS, FORMAT_FLT, "to be consistent with the code units" );
 #  endif // #ifdef STAR_FORMATION
 
 
@@ -991,7 +980,7 @@ void Init_ResetParameter()
    {
       OPT__MINIMIZE_MPI_BARRIER = false;
 
-      PRINT_WARNING( OPT__MINIMIZE_MPI_BARRIER, FORMAT_INT, "since SERIAL is enabled" );
+      PRINT_RESER_PARA( OPT__MINIMIZE_MPI_BARRIER, FORMAT_INT, "since SERIAL is enabled" );
    }
 #  endif
 
@@ -1002,7 +991,7 @@ void Init_ResetParameter()
    {
       OPT__INIT_GRID_WITH_OMP = false;
 
-      PRINT_WARNING( OPT__INIT_GRID_WITH_OMP, FORMAT_INT, "since OPENMP is disabled" );
+      PRINT_RESER_PARA( OPT__INIT_GRID_WITH_OMP, FORMAT_INT, "since OPENMP is disabled" );
    }
 #  endif
 
@@ -1012,7 +1001,7 @@ void Init_ResetParameter()
    {
       OPT__RESET_FLUID_INIT = OPT__RESET_FLUID;
 
-      PRINT_WARNING( OPT__RESET_FLUID_INIT, FORMAT_INT, "to match OPT__RESET_FLUID" );
+      PRINT_RESER_PARA( OPT__RESET_FLUID_INIT, FORMAT_INT, "to match OPT__RESET_FLUID" );
    }
 
 
@@ -1022,7 +1011,7 @@ void Init_ResetParameter()
    {
       OPT__SORT_PATCH_BY_LBIDX = false;
 
-      PRINT_WARNING( OPT__SORT_PATCH_BY_LBIDX, FORMAT_INT, "for SERIAL" );
+      PRINT_RESER_PARA( OPT__SORT_PATCH_BY_LBIDX, FORMAT_INT, "for SERIAL" );
    }
 #  endif
 
@@ -1036,11 +1025,11 @@ void Init_ResetParameter()
    {
 #     ifdef BITWISE_REPRODUCIBILITY
       OPT__FFTW_STARTUP = FFTW_STARTUP_ESTIMATE;
-      PRINT_WARNING( OPT__FFTW_STARTUP, FORMAT_INT, "when enabling BITWISE_REPRODUCIBILITY" );
+      PRINT_RESER_PARA( OPT__FFTW_STARTUP, FORMAT_INT, "when enabling BITWISE_REPRODUCIBILITY" );
 #     else
 //    OPT__FFTW_STARTUP = FFTW_STARTUP_MEASURE;
       OPT__FFTW_STARTUP = FFTW_STARTUP_ESTIMATE;
-      PRINT_WARNING( OPT__FFTW_STARTUP, FORMAT_INT, "when disabling BITWISE_REPRODUCIBILITY" );
+      PRINT_RESER_PARA( OPT__FFTW_STARTUP, FORMAT_INT, "when disabling BITWISE_REPRODUCIBILITY" );
 #     endif
    }
 #  endif

--- a/src/Init/Init_ResetParameter.cpp
+++ b/src/Init/Init_ResetParameter.cpp
@@ -116,9 +116,9 @@ void Init_ResetParameter()
 // Poisson solver parameters
 #  ifdef GRAVITY
 #  if   ( POT_SCHEME == SOR )
-   Init_Set_Default_SOR_Parameter( SOR_OMEGA, SOR_MAX_ITER, SOR_MIN_ITER );
+   Init_Set_Default_SOR_Parameter();
 #  elif ( POT_SCHEME == MG  )
-   Init_Set_Default_MG_Parameter( MG_MAX_ITER, MG_NPRE_SMOOTH, MG_NPOST_SMOOTH, MG_TOLERATED_ERROR );
+   Init_Set_Default_MG_Parameter();
 #  endif
 #  endif // GRAVITY
 

--- a/src/Init/Init_ResetParameter.cpp
+++ b/src/Init/Init_ResetParameter.cpp
@@ -1016,7 +1016,7 @@ void Init_ResetParameter()
 #  endif
 
 
-// must set OPT__FFTW_STARTUP = FFTW_STARTUP_ESTIMATE for BITWISE_REPRODUCIBILITY 
+// must set OPT__FFTW_STARTUP = FFTW_STARTUP_ESTIMATE for BITWISE_REPRODUCIBILITY
 // --> even when disabling BITWISE_REPRODUCIBILITY, we still use FFTW_STARTUP_ESTIMATE
 //     by default since otherwise the FFT results can vary in each run on the level
 //     of machine precision, which can be confusing
@@ -1033,12 +1033,6 @@ void Init_ResetParameter()
 #     endif
    }
 #  endif
-
-
-// remove symbolic constants and macros only used in this structure
-#  undef FORMAT_INT
-#  undef FORMAT_FLT
-#  undef QUOTE
 
 
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ... done\n", __FUNCTION__ );

--- a/src/SelfGravity/Init_Set_Default_MG_Parameter.cpp
+++ b/src/SelfGravity/Init_Set_Default_MG_Parameter.cpp
@@ -49,7 +49,7 @@ void Init_Set_Default_MG_Parameter()
    {
       MG_TOLERATED_ERROR = Default_Tolerated_Error;
 
-      PRINT_RESET_PARA( MG_TOLERATED_ERROR, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( MG_TOLERATED_ERROR, FORMAT_REAL, "" );
    }
 
 } // FUNCTION : Init_Set_Default_MG_Parameter

--- a/src/SelfGravity/Init_Set_Default_MG_Parameter.cpp
+++ b/src/SelfGravity/Init_Set_Default_MG_Parameter.cpp
@@ -11,26 +11,9 @@
 //
 // Note        :  1. Work only when the corresponding input parameters are negative
 //                2. Default values are determined empirically
-//
-// Parameter   :  Max_Iter        : Maximum number of iterations
-//                NPre_Smooth     : Number of pre-smoothing steps
-//                NPos_tSmooth    : Number of post-smoothing steps
-//                Tolerated_Error : Maximum tolerated error
 //-------------------------------------------------------------------------------------------------------
-void Init_Set_Default_MG_Parameter( int &Max_Iter, int &NPre_Smooth, int &NPost_Smooth, double &Tolerated_Error )
+void Init_Set_Default_MG_Parameter()
 {
-
-// helper macro for printing warning messages
-#  define FORMAT_INT    %- 21d
-#  define FORMAT_FLT    %- 21.14e
-#  define PRINT_WARNING( name, value, format, reason )                                                         \
-   {                                                                                                           \
-      if ( MPI_Rank == 0 )                                                                                     \
-         Aux_Message( stderr, "WARNING : parameter [%-28s] is reset to [" EXPAND_AND_QUOTE(format) "] %s\n",   \
-                      #name, value, reason );                                                                  \
-   }
-
-
 #  ifdef FLOAT8
    const int    Default_Max_Iter        = 20;
    const double Default_Tolerated_Error = 1.e-15;
@@ -41,39 +24,33 @@ void Init_Set_Default_MG_Parameter( int &Max_Iter, int &NPre_Smooth, int &NPost_
    const int    Default_NPre_Smooth     = 3;
    const int    Default_NPost_Smooth    = 3;
 
-   if ( Max_Iter < 0 )
+   if ( MG_MAX_ITER < 0 )
    {
-      Max_Iter = Default_Max_Iter;
+      MG_MAX_ITER = Default_Max_Iter;
 
-      PRINT_WARNING( MG_MAX_ITER, Max_Iter, FORMAT_INT, "" );
+      PRINT_RESET_PARA( MG_MAX_ITER, FORMAT_INT, "" );
    }
 
-   if ( NPre_Smooth < 0 )
+   if ( MG_NPRE_SMOOTH < 0 )
    {
-      NPre_Smooth = Default_NPre_Smooth;
+      MG_NPRE_SMOOTH = Default_NPre_Smooth;
 
-      PRINT_WARNING( MG_NPRE_SMOOTH, NPre_Smooth, FORMAT_INT, "" );
+      PRINT_RESET_PARA( MG_NPRE_SMOOTH, FORMAT_INT, "" );
    }
 
-   if ( NPost_Smooth < 0 )
+   if ( MG_NPOST_SMOOTH < 0 )
    {
-      NPost_Smooth = Default_NPost_Smooth;
+      MG_NPOST_SMOOTH = Default_NPost_Smooth;
 
-      PRINT_WARNING( MG_NPOST_SMOOTH, NPost_Smooth, FORMAT_INT, "" );
+      PRINT_RESET_PARA( MG_NPOST_SMOOTH, FORMAT_INT, "" );
    }
 
-   if ( Tolerated_Error < 0.0 )
+   if ( MG_TOLERATED_ERROR < 0.0 )
    {
-      Tolerated_Error = Default_Tolerated_Error;
+      MG_TOLERATED_ERROR = Default_Tolerated_Error;
 
-      PRINT_WARNING( MG_TOLERATED_ERROR, Tolerated_Error, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( MG_TOLERATED_ERROR, FORMAT_FLT, "" );
    }
-
-
-// remove symbolic constants and macros only used in this structure
-#  undef FORMAT_INT
-#  undef FORMAT_FLT
-#  undef QUOTE
 
 } // FUNCTION : Init_Set_Default_MG_Parameter
 

--- a/src/SelfGravity/Init_Set_Default_SOR_Parameter.cpp
+++ b/src/SelfGravity/Init_Set_Default_SOR_Parameter.cpp
@@ -37,14 +37,14 @@ void Init_Set_Default_SOR_Parameter()
    {
       SOR_MAX_ITER = Default_MaxIter;
 
-      PRINT_RESER_PARA( SOR_MAX_ITER, FORMAT_INT, "" );
+      PRINT_RESET_PARA( SOR_MAX_ITER, FORMAT_INT, "" );
    }
 
    if ( SOR_MIN_ITER < 0 )
    {
       SOR_MIN_ITER = Default_MinIter;
 
-      PRINT_RESER_PARA( SOR_MIN_ITER, FORMAT_INT, "" );
+      PRINT_RESET_PARA( SOR_MIN_ITER, FORMAT_INT, "" );
    }
 
 } // FUNCTION : Init_Set_Default_SOR_Parameter

--- a/src/SelfGravity/Init_Set_Default_SOR_Parameter.cpp
+++ b/src/SelfGravity/Init_Set_Default_SOR_Parameter.cpp
@@ -11,25 +11,9 @@
 //
 // Note        :  1. Work only when the corresponding input parameters are negative
 //                2. The default values are determined empirically from the cosmological simulations
-//
-// Parameter   :  SOR_Omega    : Over-relaxation parameter for SOR
-//                SOR_Max_Iter : Maximum number of iterations for SOR
-//                SOR_Min_Iter : Minimum number of iterations for SOR
 //-------------------------------------------------------------------------------------------------------
-void Init_Set_Default_SOR_Parameter( double &SOR_Omega, int &SOR_Max_Iter, int &SOR_Min_Iter )
+void Init_Set_Default_SOR_Parameter()
 {
-
-// helper macro for printing warning messages
-#  define FORMAT_INT    %- 21d
-#  define FORMAT_FLT    %- 21.14e
-#  define PRINT_WARNING( name, value, format, reason )                                                         \
-   {                                                                                                           \
-      if ( MPI_Rank == 0 )                                                                                     \
-         Aux_Message( stderr, "WARNING : parameter [%-28s] is reset to [" EXPAND_AND_QUOTE(format) "] %s\n",   \
-                      #name, value, reason );                                                                  \
-   }
-
-
 // reference to the optimum relaxation parameter: Yang & Gobbert, Appl. Math. Lett. 22, 325 (2009)
 // --> Eq. [1.3] and the last paragraph in Sec. 3
 // --> further confirmed with the test problem "Hydro/Gravity" using different PATCH_SIZE and POT_GHOST_SIZE
@@ -42,32 +26,26 @@ void Init_Set_Default_SOR_Parameter( double &SOR_Omega, int &SOR_Max_Iter, int &
 #  endif
    const int    Default_MinIter = Default_MaxIter / 5;   // 20% of the maximum iteration (determined empirically)
 
-   if ( SOR_Omega < 0.0 )
+   if ( SOR_OMEGA < 0.0 )
    {
-      SOR_Omega = Default_Omega;
+      SOR_OMEGA = Default_Omega;
 
-      PRINT_WARNING( SOR_OMEGA, SOR_Omega, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( SOR_OMEGA, FORMAT_FLT, "" );
    }
 
-   if ( SOR_Max_Iter < 0 )
+   if ( SOR_MAX_ITER < 0 )
    {
-      SOR_Max_Iter = Default_MaxIter;
+      SOR_MAX_ITER = Default_MaxIter;
 
-      PRINT_WARNING( SOR_MAX_ITER, SOR_Max_Iter, FORMAT_INT, "" );
+      PRINT_RESER_PARA( SOR_MAX_ITER, FORMAT_INT, "" );
    }
 
-   if ( SOR_Min_Iter < 0 )
+   if ( SOR_MIN_ITER < 0 )
    {
-      SOR_Min_Iter = Default_MinIter;
+      SOR_MIN_ITER = Default_MinIter;
 
-      PRINT_WARNING( SOR_MIN_ITER, SOR_Min_Iter, FORMAT_INT, "" );
+      PRINT_RESER_PARA( SOR_MIN_ITER, FORMAT_INT, "" );
    }
-
-
-// remove symbolic constants and macros only used in this structure
-#  undef FORMAT_INT
-#  undef FORMAT_FLT
-#  undef QUOTE
 
 } // FUNCTION : Init_Set_Default_SOR_Parameter
 

--- a/src/SelfGravity/Init_Set_Default_SOR_Parameter.cpp
+++ b/src/SelfGravity/Init_Set_Default_SOR_Parameter.cpp
@@ -30,7 +30,7 @@ void Init_Set_Default_SOR_Parameter()
    {
       SOR_OMEGA = Default_Omega;
 
-      PRINT_RESET_PARA( SOR_OMEGA, FORMAT_FLT, "" );
+      PRINT_RESET_PARA( SOR_OMEGA, FORMAT_REAL, "" );
    }
 
    if ( SOR_MAX_ITER < 0 )

--- a/src/TestProblem/ELBDM/ExtPot/Init_TestProb_ELBDM_ExtPot.cpp
+++ b/src/TestProblem/ELBDM/ExtPot/Init_TestProb_ELBDM_ExtPot.cpp
@@ -118,18 +118,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    = 1.0e-2;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/AGORA_IsolatedGalaxy/Init_TestProb_Hydro_AGORA_IsolatedGalaxy.cpp
+++ b/src/TestProblem/Hydro/AGORA_IsolatedGalaxy/Init_TestProb_Hydro_AGORA_IsolatedGalaxy.cpp
@@ -236,18 +236,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    =  500.0*Const_Myr/UNIT_T;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/AcousticWave/Init_TestProb_Hydro_AcousticWave.cpp
+++ b/src/TestProblem/Hydro/AcousticWave/Init_TestProb_Hydro_AcousticWave.cpp
@@ -136,18 +136,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const double End_T_Default    = Acoustic_WaveLength / Acoustic_Cs;
    const long   End_Step_Default = __INT_MAX__;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/BlastWave/Init_TestProb_Hydro_BlastWave.cpp
+++ b/src/TestProblem/Hydro/BlastWave/Init_TestProb_Hydro_BlastWave.cpp
@@ -137,18 +137,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const double End_T_Default    = 5.0e-3;
    const long   End_Step_Default = __INT_MAX__;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/Bondi/Init_TestProb_Hydro_Bondi.cpp
+++ b/src/TestProblem/Hydro/Bondi/Init_TestProb_Hydro_Bondi.cpp
@@ -332,18 +332,18 @@ void SetParameter()
 
 
 // (4) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    = 1.0e1*Bondi_TimeB;    // 10 Bondi time
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/CDM_LSS/Init_TestProb_Hydro_CDM_LSS.cpp
+++ b/src/TestProblem/Hydro/CDM_LSS/Init_TestProb_Hydro_CDM_LSS.cpp
@@ -103,18 +103,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    = 1.0;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/CMZ/Init_TestProb_Hydro_CMZ.cpp
+++ b/src/TestProblem/Hydro/CMZ/Init_TestProb_Hydro_CMZ.cpp
@@ -149,18 +149,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    = 1.0*Const_Gyr/UNIT_T;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/Caustic/Init_TestProb_Hydro_Caustic.cpp
+++ b/src/TestProblem/Hydro/Caustic/Init_TestProb_Hydro_Caustic.cpp
@@ -105,18 +105,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    = ( Caustic_Dir == 0 ) ? 3.0 : 2.0;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
    if (  Caustic_Dir == 1  &&  ( amr->BoxSize[0] != amr->BoxSize[1] || amr->BoxSize[0] != amr->BoxSize[2] )  )

--- a/src/TestProblem/Hydro/ClusterMerger/Init_TestProb_ClusterMerger.cpp
+++ b/src/TestProblem/Hydro/ClusterMerger/Init_TestProb_ClusterMerger.cpp
@@ -384,7 +384,7 @@ void SetParameter()
 
       // overwrite the total number of particles
       amr->Par->NPar_Active_AllRank = NPar_AllCluster;
-      PRINT_RESET_PARA( amr->Par->NPar_Active_AllRank, FORMAT_LONG, "This is PAR_NPAR in Input__Parameter." );
+      PRINT_RESET_PARA( amr->Par->NPar_Active_AllRank, FORMAT_LONG, "(PAR_NPAR in Input__Parameter)" );
 
    } // if ( OPT__INIT != INIT_BY_RESTART )
 

--- a/src/TestProblem/Hydro/ClusterMerger/Init_TestProb_ClusterMerger.cpp
+++ b/src/TestProblem/Hydro/ClusterMerger/Init_TestProb_ClusterMerger.cpp
@@ -384,24 +384,24 @@ void SetParameter()
 
       // overwrite the total number of particles
       amr->Par->NPar_Active_AllRank = NPar_AllCluster;
-      PRINT_WARNING( "PAR_NPAR", amr->Par->NPar_Active_AllRank, FORMAT_LONG );
+      PRINT_RESET_PARA( amr->Par->NPar_Active_AllRank, FORMAT_LONG, "This is PAR_NPAR in Input__Parameter." );
 
    } // if ( OPT__INIT != INIT_BY_RESTART )
 
 
 // (4) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    = 10.0*Const_Gyr/UNIT_T;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/EnergyPowerSpectrum/Init_TestProb_Hydro_EnergyPowerSpectrum.cpp
+++ b/src/TestProblem/Hydro/EnergyPowerSpectrum/Init_TestProb_Hydro_EnergyPowerSpectrum.cpp
@@ -114,18 +114,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const double End_T_Default    = 0.0;
    const long   End_Step_Default = 0;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/Gravity/Init_TestProb_Hydro_Gravity.cpp
+++ b/src/TestProblem/Hydro/Gravity/Init_TestProb_Hydro_Gravity.cpp
@@ -139,28 +139,28 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = 0;
    const double End_T_Default    = 0.0;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
    if ( Gra_NIterPerf > 0  &&  !OPT__RECORD_USER ) {
       OPT__RECORD_USER = true;
-      PRINT_WARNING( "OPT__RECORD_USER", OPT__RECORD_USER, FORMAT_BOOL );
+      PRINT_RESET_PARA( OPT__RECORD_USER, FORMAT_BOOL, "" );
    }
 
    else if ( Gra_NIterPerf == 0  &&  OPT__RECORD_USER ) {
       OPT__RECORD_USER = false;
-      PRINT_WARNING( "OPT__RECORD_USER", OPT__RECORD_USER, FORMAT_BOOL );
+      PRINT_RESET_PARA( OPT__RECORD_USER, FORMAT_BOOL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/JeansInstability/Init_TestProb_Hydro_JeansInstability.cpp
+++ b/src/TestProblem/Hydro/JeansInstability/Init_TestProb_Hydro_JeansInstability.cpp
@@ -160,18 +160,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const double End_T_Default    = ( Jeans_Stable ) ? 2.0*M_PI/Jeans_WaveW : log(50.0)/Jeans_WaveW;
    const long   End_Step_Default = __INT_MAX__;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/Jet/Init_TestProb_Hydro_Jet.cpp
+++ b/src/TestProblem/Hydro/Jet/Init_TestProb_Hydro_Jet.cpp
@@ -292,18 +292,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    = 50.0*Const_Myr/UNIT_T;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/KelvinHelmholtzInstability/Init_TestProb_Hydro_KelvinHelmholtzInstability.cpp
+++ b/src/TestProblem/Hydro/KelvinHelmholtzInstability/Init_TestProb_Hydro_KelvinHelmholtzInstability.cpp
@@ -144,18 +144,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const double End_T_Default    = 1.0;
    const long   End_Step_Default = __INT_MAX__;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/MHD_ABC/Init_TestProb_Hydro_MHD_ABC.cpp
+++ b/src/TestProblem/Hydro/MHD_ABC/Init_TestProb_Hydro_MHD_ABC.cpp
@@ -119,18 +119,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    = 0.5;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/MHD_LinearWave/Init_TestProb_Hydro_MHD_LinearWave.cpp
+++ b/src/TestProblem/Hydro/MHD_LinearWave/Init_TestProb_Hydro_MHD_LinearWave.cpp
@@ -146,18 +146,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const double End_T_Default    = MHDLinear_WaveLength / MHDLinear_WaveSpeed;
    const long   End_Step_Default = __INT_MAX__;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/MHD_OrszagTangVortex/Init_TestProb_Hydro_MHD_OrszagTangVortex.cpp
+++ b/src/TestProblem/Hydro/MHD_OrszagTangVortex/Init_TestProb_Hydro_MHD_OrszagTangVortex.cpp
@@ -113,18 +113,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    = 1.0;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/ParticleEquilibriumIC/Init_TestProb_Hydro_ParEqmIC.cpp
+++ b/src/TestProblem/Hydro/ParticleEquilibriumIC/Init_TestProb_Hydro_ParEqmIC.cpp
@@ -101,18 +101,18 @@ void Validate()
 //-------------------------------------------------------------------------------------------------------
 void SetParameter()
 {
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    =  10;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 // load run-time parameters

--- a/src/TestProblem/Hydro/ParticleTest/Init_TestProb_Hydro_ParticleTest.cpp
+++ b/src/TestProblem/Hydro/ParticleTest/Init_TestProb_Hydro_ParticleTest.cpp
@@ -149,7 +149,7 @@ void SetParameter()
    amr->Par->NPar_Active_AllRank = 0;
    if ( ParTest_Use_Massive )    amr->Par->NPar_Active_AllRank += 2;
    if ( ParTest_Use_Tracers )    amr->Par->NPar_Active_AllRank += ParTest_NPar[0]*ParTest_NPar[1]*ParTest_NPar[2];
-   PRINT_RESET_PARA( amr->Par->NPar_Active_AllRank, FORMAT_LONG, "This is PAR_NPAR in Input__Parameter" );
+   PRINT_RESET_PARA( amr->Par->NPar_Active_AllRank, FORMAT_LONG, "(PAR_NPAR in Input__Parameter)" );
 #  endif
 
 

--- a/src/TestProblem/Hydro/ParticleTest/Init_TestProb_Hydro_ParticleTest.cpp
+++ b/src/TestProblem/Hydro/ParticleTest/Init_TestProb_Hydro_ParticleTest.cpp
@@ -130,18 +130,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const double End_T_Default    = 2*M_PI/ParTest_Ang_Freq;
    const long   End_Step_Default = __INT_MAX__;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 // overwrite the total number of particles
@@ -149,7 +149,7 @@ void SetParameter()
    amr->Par->NPar_Active_AllRank = 0;
    if ( ParTest_Use_Massive )    amr->Par->NPar_Active_AllRank += 2;
    if ( ParTest_Use_Tracers )    amr->Par->NPar_Active_AllRank += ParTest_NPar[0]*ParTest_NPar[1]*ParTest_NPar[2];
-   PRINT_WARNING( "PAR_NPAR", amr->Par->NPar_Active_AllRank, FORMAT_LONG );
+   PRINT_RESET_PARA( amr->Par->NPar_Active_AllRank, FORMAT_LONG, "This is PAR_NPAR in Input__Parameter" );
 #  endif
 
 

--- a/src/TestProblem/Hydro/Plummer/Init_TestProb_Hydro_Plummer.cpp
+++ b/src/TestProblem/Hydro/Plummer/Init_TestProb_Hydro_Plummer.cpp
@@ -190,17 +190,13 @@ void SetParameter()
    if ( !OPT__EXT_ACC  &&  Plummer_ExtAccMFrac != 0.0 )
    {
       Plummer_ExtAccMFrac = 0.0;
-
-      if ( MPI_Rank == 0 )
-         Aux_Message( stderr, "WARNING : \"Plummer_ExtAccMFrac\" is reset to 0.0 since OPT__EXT_ACC is disabled !!\n" );
+      PRINT_RESET_PARA( Plummer_ExtAccMFrac, FORMAT_REAL, "since OPT__EXT_ACC is disabled" );
    }
 
    if ( !OPT__EXT_POT  &&  Plummer_ExtPotMFrac != 0.0 )
    {
       Plummer_ExtPotMFrac = 0.0;
-
-      if ( MPI_Rank == 0 )
-         Aux_Message( stderr, "WARNING : \"Plummer_ExtPotMFrac\" is reset to 0.0 since OPT__EXT_POT is disabled !!\n" );
+      PRINT_RESET_PARA( Plummer_ExtPotMFrac, FORMAT_REAL, "since OPT__EXT_POT is disabled" );
    }
 #  endif
 
@@ -226,9 +222,7 @@ void SetParameter()
       if (  ! Mis_CompareRealValue( NonParMFrac, 1.0, NULL, false )  )
       {
          Plummer_GasMFrac = 1.0 - Plummer_ExtAccMFrac - Plummer_ExtPotMFrac;
-
-         if ( MPI_Rank == 0 )
-            Aux_Message( stderr, "WARNING : \"Plummer_GasMFrac\" is reset to %13.7e !!\n", Plummer_GasMFrac );
+         PRINT_RESET_PARA( Plummer_GasMFrac, FORMAT_REAL, "" );
       }
 #     endif
    } // if ( OPT__SELF_GRAVITY )
@@ -248,9 +242,7 @@ void SetParameter()
       if (  ! Mis_CompareRealValue( Plummer_GasMFrac, 1.0, NULL, false )  )
       {
          Plummer_GasMFrac = 1.0;
-
-         if ( MPI_Rank == 0 )
-            Aux_Message( stderr, "WARNING : \"Plummer_GasMFrac\" is reset to %13.7e !!\n", Plummer_GasMFrac );
+         PRINT_RESET_PARA( Plummer_GasMFrac, FORMAT_REAL, "" );
       }
 #     endif
 
@@ -262,9 +254,7 @@ void SetParameter()
             if (  ! Mis_CompareRealValue( Plummer_ExtAccMFrac+Plummer_ExtPotMFrac, 1.0, NULL, false )  )
             {
                Plummer_ExtPotMFrac = 1.0 - Plummer_ExtAccMFrac;
-
-               if ( MPI_Rank == 0 )
-                  Aux_Message( stderr, "WARNING : \"Plummer_ExtPotMFrac\" is reset to %13.7e !!\n", Plummer_ExtPotMFrac );
+               PRINT_RESET_PARA( Plummer_ExtPotMFrac, FORMAT_REAL, "" );
             }
          }
 
@@ -273,9 +263,7 @@ void SetParameter()
             if (  ! Mis_CompareRealValue( Plummer_ExtPotMFrac, 1.0, NULL, false )  )
             {
                Plummer_ExtPotMFrac = 1.0;
-
-               if ( MPI_Rank == 0 )
-                  Aux_Message( stderr, "WARNING : \"Plummer_ExtPotMFrac\" is reset to %13.7e !!\n", Plummer_ExtPotMFrac );
+               PRINT_RESET_PARA( Plummer_ExtPotMFrac, FORMAT_REAL, "" );
             }
          }
       } // if ( OPT__EXT_POT )
@@ -287,9 +275,7 @@ void SetParameter()
             if (  ! Mis_CompareRealValue( Plummer_ExtAccMFrac, 1.0, NULL, false )  )
             {
                Plummer_ExtAccMFrac = 1.0;
-
-               if ( MPI_Rank == 0 )
-                  Aux_Message( stderr, "WARNING : \"Plummer_ExtAccMFrac\" is reset to %13.7e !!\n", Plummer_ExtAccMFrac );
+               PRINT_RESET_PARA( Plummer_ExtAccMFrac, FORMAT_REAL, "" );
             }
          }
 

--- a/src/TestProblem/Hydro/Plummer/Init_TestProb_Hydro_Plummer.cpp
+++ b/src/TestProblem/Hydro/Plummer/Init_TestProb_Hydro_Plummer.cpp
@@ -331,18 +331,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    = (Plummer_Collision) ? 50.0 : 20.0*Plummer_FreeT;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/Riemann/Init_TestProb_Hydro_Riemann.cpp
+++ b/src/TestProblem/Hydro/Riemann/Init_TestProb_Hydro_Riemann.cpp
@@ -249,18 +249,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    = Riemann_EndT;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
    if (  ( Riemann_XYZ == 0 && OPT__OUTPUT_PART != OUTPUT_X )  ||
@@ -268,7 +268,7 @@ void SetParameter()
          ( Riemann_XYZ == 2 && OPT__OUTPUT_PART != OUTPUT_Z )    )
    {
       OPT__OUTPUT_PART = ( Riemann_XYZ == 0 ) ? OUTPUT_X : ( Riemann_XYZ == 1 ) ? OUTPUT_Y : OUTPUT_Z;
-      PRINT_WARNING( "OPT__OUTPUT_PART", OPT__OUTPUT_PART, FORMAT_INT );
+      PRINT_RESET_PARA( OPT__OUTPUT_PART, FORMAT_INT, "" );
    }
 
 

--- a/src/TestProblem/Hydro/SphericalCollapse/Init_TestProb_Hydro_SphericalCollapse.cpp
+++ b/src/TestProblem/Hydro/SphericalCollapse/Init_TestProb_Hydro_SphericalCollapse.cpp
@@ -137,18 +137,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    = 5.0e-2;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 

--- a/src/TestProblem/Hydro/Zeldovich/Init_TestProb_Zeldovich.cpp
+++ b/src/TestProblem/Hydro/Zeldovich/Init_TestProb_Zeldovich.cpp
@@ -205,18 +205,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    = 1.0;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 #  ifdef PARTICLE
@@ -226,7 +226,7 @@ void SetParameter()
    else if ( Gas_Par_Setup == 2 )   // overwrite the total number of particles in particle-only setup
       amr->Par->NPar_Active_AllRank = (long)NPar_X*SQR((long)NPar_YZ);
 
-   PRINT_WARNING( "PAR_NPAR", amr->Par->NPar_Active_AllRank, FORMAT_LONG );
+   PRINT_RESET_PARA( amr->Par->NPar_Active_AllRank, FORMAT_LONG, "This is PAR_NPAR in Input__Parameter" );
 #  endif
 
 

--- a/src/TestProblem/Hydro/Zeldovich/Init_TestProb_Zeldovich.cpp
+++ b/src/TestProblem/Hydro/Zeldovich/Init_TestProb_Zeldovich.cpp
@@ -226,7 +226,7 @@ void SetParameter()
    else if ( Gas_Par_Setup == 2 )   // overwrite the total number of particles in particle-only setup
       amr->Par->NPar_Active_AllRank = (long)NPar_X*SQR((long)NPar_YZ);
 
-   PRINT_RESET_PARA( amr->Par->NPar_Active_AllRank, FORMAT_LONG, "This is PAR_NPAR in Input__Parameter" );
+   PRINT_RESET_PARA( amr->Par->NPar_Active_AllRank, FORMAT_LONG, "(PAR_NPAR in Input__Parameter)" );
 #  endif
 
 

--- a/src/TestProblem/Template/Init_TestProb_Template.cpp
+++ b/src/TestProblem/Template/Init_TestProb_Template.cpp
@@ -122,18 +122,18 @@ void SetParameter()
 
 
 // (3) reset other general-purpose parameters
-//     --> a helper macro PRINT_WARNING is defined in TestProb.h
+//     --> a helper macro PRINT_RESET_PARA is defined in Macro.h
    const long   End_Step_Default = __INT_MAX__;
    const double End_T_Default    = __FLT_MAX__;
 
    if ( END_STEP < 0 ) {
       END_STEP = End_Step_Default;
-      PRINT_WARNING( "END_STEP", END_STEP, FORMAT_LONG );
+      PRINT_RESET_PARA( END_STEP, FORMAT_LONG, "" );
    }
 
    if ( END_T < 0.0 ) {
       END_T = End_T_Default;
-      PRINT_WARNING( "END_T", END_T, FORMAT_REAL );
+      PRINT_RESET_PARA( END_T, FORMAT_REAL, "" );
    }
 
 


### PR DESCRIPTION
For solving #170, all the `PRINT_WARNING` is now rewritten as `PRINT_RESET_PARA` defined under `include/Macro.h`.