### PR TITLE
`MPI_Alltoallv_GAMER` Wrapper

### DIFF
--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -278,6 +278,7 @@ void MPI_ExchangeBufferPosition( int NSend[26], int NRecv[26], int *Send_PosList
 void MPI_ExchangeData( const int TargetRank[2], const int SendSize[2], const int RecvSize[2],
                        real *SendBuffer[2], real *RecvBuffer[2] );
 void MPI_Exit();
+template <typename T> void MPI_Alltoallv_GAMER( T * SendBuf, int *Send_NCount, long *Send_NDisp, MPI_Datatype Send_Datatype, T *RecvBuf, int *Recv_NCount, long *Recv_NDisp, MPI_Datatype Recv_DataType, MPI_Comm comm );
 #endif // #ifndef SERIAL
 
 
@@ -691,9 +692,9 @@ void Par_LB_ExchangeParticleBetweenPatch( const int lv,
                                           const int Recv_NPatchTotal, const int *Recv_PIDList, int *Recv_NPatchEachRank,
                                           Timer_t *Timer, const char *Timer_Comment );
 void Par_LB_SendParticleData( const int NParAtt, int *SendBuf_NPatchEachRank, int *SendBuf_NParEachPatch,
-                              long *SendBuf_LBIdxEachPatch, real *SendBuf_ParDataEachPatch, const int NSendParTotal,
+                              long *SendBuf_LBIdxEachPatch, real *SendBuf_ParDataEachPatch, const long NSendParTotal,
                               int *&RecvBuf_NPatchEachRank, int *&RecvBuf_NParEachPatch, long *&RecvBuf_LBIdxEachPatch,
-                              real *&RecvBuf_ParDataEachPatch, int &NRecvPatchTotal, int &NRecvParTotal,
+                              real *&RecvBuf_ParDataEachPatch, int &NRecvPatchTotal, long &NRecvParTotal,
                               const bool Exchange_NPatchEachRank, const bool Exchange_LBIdxEachRank,
                               const bool Exchange_ParDataEachRank, Timer_t *Timer, const char *Timer_Comment );
 void Par_LB_RecordExchangeParticlePatchID( const int MainLv );

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -218,11 +218,11 @@ void Init_ByRestart_HDF5( const char *FileName );
 void End_FFTW();
 void Init_FFTW();
 void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf_SIdx, long *RecvBuf_SIdx,
-                 int **List_PID, int **List_k, int *List_NSend_Var, int *List_NRecv_Var,
+                 int **List_PID, int **List_k, long *List_NSend_Var, long *List_NRecv_Var,
                  const int *List_z_start, const int local_nz, const int FFT_Size[], const int NRecvSlice,
                  const double PrepTime, const long TVar, const bool InPlacePad, const bool ForPoisson, const bool AddExtraMass );
 void Slab2Patch( const real *VarS, real *SendBuf, real *RecvBuf, const int SaveSg, const long *List_SIdx,
-                 int **List_PID, int **List_k, int *List_NSend, int *List_NRecv, const int local_nz, const int FFT_Size[],
+                 int **List_PID, int **List_k, long *List_NSend, long *List_NRecv, const int local_nz, const int FFT_Size[],
                  const int NSendSlice, const long TVar, const bool InPlacePad );
 #endif // #ifdef SUPPORT_FFTW
 
@@ -239,13 +239,13 @@ void Int_Table( const IntScheme_t IntScheme, int &NSide, int &NGhost );
 
 // Miscellaneous
 template <typename T> void  Mis_Idx1D2Idx3D( const int Size[], const T Idx1D, int Idx3D[] );
-template <typename T> int   Mis_BinarySearch( const T Array[], int Min, int Max, const T Key );
+template <typename U, typename T> U Mis_BinarySearch( const T Array[], U Min, U Max, const T Key );
 template <typename T> int   Mis_BinarySearch_Real( const T Array[], int Min, int Max, const T Key );
 template <typename T> T     Mis_InterpolateFromTable( const int N, const T Table_x[], const T Table_y[], const T x );
 template <typename T> ulong Mis_Idx3D2Idx1D( const int Size[], const int Idx3D[] );
-template <typename T> void  Mis_Heapsort( const int N, T Array[], int IdxTable[] );
+template <typename U, typename T> void  Mis_Heapsort( const U N, T Array[], U IdxTable[] );
 template <typename T> int   Mis_Matching_char( const int N, const T Array[], const int M, const T Key[], char Match[] );
-template <typename T> int   Mis_Matching_int( const int N, const T Array[], const int M, const T Key[], int Match[] );
+template <typename U, typename T> int Mis_Matching_int( const U N, const T Array[], const U M, const T Key[], U Match[] );
 template <typename T> bool  Mis_CompareRealValue( const T Input1, const T Input2, const char *comment, const bool Verbose );
 ulong  Mis_Idx3D2Idx1D( const int Size[], const int Idx3D[] );
 double Mis_GetTimeStep( const int lv, const double dTime_SyncFaLv, const double AutoReduceDtCoeff );
@@ -278,7 +278,7 @@ void MPI_ExchangeBufferPosition( int NSend[26], int NRecv[26], int *Send_PosList
 void MPI_ExchangeData( const int TargetRank[2], const int SendSize[2], const int RecvSize[2],
                        real *SendBuffer[2], real *RecvBuffer[2] );
 void MPI_Exit();
-template <typename T> void MPI_Alltoallv_GAMER( T * SendBuf, int *Send_NCount, long *Send_NDisp, MPI_Datatype Send_Datatype, T *RecvBuf, int *Recv_NCount, long *Recv_NDisp, MPI_Datatype Recv_DataType, MPI_Comm comm );
+template <typename T> void MPI_Alltoallv_GAMER( T * SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Datatype Send_Datatype, T *RecvBuf, long *Recv_NCount, long *Recv_NDisp, MPI_Datatype Recv_DataType, MPI_Comm comm );
 #endif // #ifndef SERIAL
 
 
@@ -644,7 +644,7 @@ void Par_MassAssignment( const long *ParList, const long NPar, const ParInterp_t
                          const int RhoSize, const double *EdgeL, const double dh, const bool PredictPos,
                          const double TargetTime, const bool InitZero, const bool Periodic[], const int PeriodicSize[3],
                          const bool UnitDens, const bool CheckFarAway, const bool UseInputMassPos, real **InputMassPos );
-void Par_SortByPos( const long NPar, const real *PosX, const real *PosY, const real *PosZ, int *IdxTable );
+void Par_SortByPos( const long NPar, const real *PosX, const real *PosY, const real *PosZ, long *IdxTable );
 void Par_UpdateParticle( const int lv, const double TimeNew, const double TimeOld, const ParUpStep_t UpdateStep,
                          const bool StoreAcc, const bool UseStoredAcc );
 void Par_UpdateTracerParticle( const int lv, const double TimeNew, const double TimeOld,

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -240,12 +240,12 @@ void Int_Table( const IntScheme_t IntScheme, int &NSide, int &NGhost );
 // Miscellaneous
 template <typename T> void  Mis_Idx1D2Idx3D( const int Size[], const T Idx1D, int Idx3D[] );
 template <typename U, typename T> U Mis_BinarySearch( const T Array[], U Min, U Max, const T Key );
-template <typename T> int   Mis_BinarySearch_Real( const T Array[], int Min, int Max, const T Key );
+template <typename U, typename T> U Mis_BinarySearch_Real( const T Array[], U Min, U Max, const T Key );
 template <typename T> T     Mis_InterpolateFromTable( const int N, const T Table_x[], const T Table_y[], const T x );
 template <typename T> ulong Mis_Idx3D2Idx1D( const int Size[], const int Idx3D[] );
 template <typename U, typename T> void  Mis_Heapsort( const U N, T Array[], U IdxTable[] );
 template <typename T> int   Mis_Matching_char( const int N, const T Array[], const int M, const T Key[], char Match[] );
-template <typename U, typename T> int Mis_Matching_int( const U N, const T Array[], const U M, const T Key[], U Match[] );
+template <typename U, typename T> U Mis_Matching_int( const U N, const T Array[], const U M, const T Key[], U Match[] );
 template <typename T> bool  Mis_CompareRealValue( const T Input1, const T Input2, const char *comment, const bool Verbose );
 ulong  Mis_Idx3D2Idx1D( const int Size[], const int Idx3D[] );
 double Mis_GetTimeStep( const int lv, const double dTime_SyncFaLv, const double AutoReduceDtCoeff );

--- a/include/Serial.h
+++ b/include/Serial.h
@@ -30,6 +30,8 @@
         {   for (int ssss=0; ssss<(SCount); ssss++)   (RBuf)[ssss] = (SBuf)[ssss];  }
 #define MPI_Scatterv( SBuf, SCount, SDisp, SType, RBuf, RCount, RType, Root, MPI_COMM ) \
         {   for (int ssss=0; ssss<((SCount)[0]); ssss++)    (RBuf)[ssss] = (SBuf)[ssss];  }
+#define MPI_Alltoallv_GAMER( SBuf, SCount, SDisp, SType, RBuf, RCount, RDisp, RType, MPI_COMM ) \
+        {   for (long ssss=0; ssss<((SCount)[0]); ssss++)    (RBuf)[ssss] = (SBuf)[ssss];  }
 
 
 #define Buf_AllocateBufferPatch( Tpatch, lv ) {}

--- a/src/Auxiliary/Aux_Check_PatchAllocate.cpp
+++ b/src/Auxiliary/Aux_Check_PatchAllocate.cpp
@@ -155,7 +155,7 @@ void Aux_Check_PatchAllocate( const int lv, const char *comment )
 
 //       check 3
          memcpy( Cr1D_Sort, Cr1D, NTot*sizeof(ulong) );
-         Mis_Heapsort( NTot, Cr1D_Sort, NULL );
+         Mis_Heapsort<int,ulong>( NTot, Cr1D_Sort, NULL );
          for (int t=0; t<NTot-1; t++)
          {
             if ( Cr1D_Sort[t] == Cr1D_Sort[t+1] )
@@ -246,8 +246,8 @@ void Aux_Check_PatchAllocate( const int lv, const char *comment )
 
 
 //    sort all real and buffer patches
-      Mis_Heapsort( NReal_Tot, Cr1D_Real, NULL );
-      Mis_Heapsort( NBuff_Tot, Cr1D_Buff, NULL );
+      Mis_Heapsort<int,ulong>( NReal_Tot, Cr1D_Real, NULL );
+      Mis_Heapsort<int,ulong>( NBuff_Tot, Cr1D_Buff, NULL );
 
 
 //    check 4

--- a/src/Feedback/FB_AdvanceDt.cpp
+++ b/src/Feedback/FB_AdvanceDt.cpp
@@ -197,7 +197,7 @@ void FB_AdvanceDt( const int lv, const double TimeNew, const double TimeOld, con
 //    5.2. sort PID by position
 //         --> necessary for fixing the order of particles in different patches
       long *NearbyPIDList_IdxTable = new long [NNearbyPatch];
-      int  *NearbyPIDList_Old      = new int [NNearbyPatch];
+      int  *NearbyPIDList_Old      = new int  [NNearbyPatch];
       real **PCr = NULL;
       Aux_AllocateArray2D( PCr, 3, NNearbyPatch );
 
@@ -250,7 +250,7 @@ void FB_AdvanceDt( const int lv, const double TimeNew, const double TimeOld, con
          for (int v=0; v<PAR_NATT_TOTAL; v++)
             if ( ParAttBitIdx_In & BIDX(v) )    ParAtt_Local[v] = new real [NParMax];
 
-         ParSortID = new long [NParMax];   // it will fail if "long" is actually required for NParMax
+         ParSortID = new long [NParMax];
       }
 
 

--- a/src/Feedback/FB_AdvanceDt.cpp
+++ b/src/Feedback/FB_AdvanceDt.cpp
@@ -250,7 +250,7 @@ void FB_AdvanceDt( const int lv, const double TimeNew, const double TimeOld, con
          for (int v=0; v<PAR_NATT_TOTAL; v++)
             if ( ParAttBitIdx_In & BIDX(v) )    ParAtt_Local[v] = new real [NParMax];
 
-         ParSortID = new long [NParMax];
+         ParSortID = new long [NParMax];  // it will fail if "long" is actually required for NParMax
       }
 
 

--- a/src/Feedback/FB_AdvanceDt.cpp
+++ b/src/Feedback/FB_AdvanceDt.cpp
@@ -6,14 +6,14 @@
 
 // prototypes of built-in feedbacks
 int FB_SNe( const int lv, const double TimeNew, const double TimeOld, const double dt,
-            const int NPar, const int *ParSortID, real *ParAtt[PAR_NATT_TOTAL],
+            const int NPar, const long *ParSortID, real *ParAtt[PAR_NATT_TOTAL],
             real (*Fluid)[FB_NXT][FB_NXT][FB_NXT], const double EdgeL[], const double dh, bool CoarseFine[],
             const int TID, RandomNumber_t *RNG );
 
 
 // user-specified feedback to be set by a test problem initializer
 int (*FB_User_Ptr)( const int lv, const double TimeNew, const double TimeOld, const double dt,
-                    const int NPar, const int *ParSortID, real *ParAtt[PAR_NATT_TOTAL],
+                    const int NPar, const long *ParSortID, real *ParAtt[PAR_NATT_TOTAL],
                     real (*Fluid)[FB_NXT][FB_NXT][FB_NXT], const double EdgeL[], const double dh, bool CoarseFine[],
                     const int TID, RandomNumber_t *RNG ) = NULL;
 
@@ -196,8 +196,8 @@ void FB_AdvanceDt( const int lv, const double TimeNew, const double TimeOld, con
 
 //    5.2. sort PID by position
 //         --> necessary for fixing the order of particles in different patches
-      int *NearbyPIDList_IdxTable = new int [NNearbyPatch];
-      int *NearbyPIDList_Old      = new int [NNearbyPatch];
+      long *NearbyPIDList_IdxTable = new long [NNearbyPatch];
+      int  *NearbyPIDList_Old      = new int [NNearbyPatch];
       real **PCr = NULL;
       Aux_AllocateArray2D( PCr, 3, NNearbyPatch );
 
@@ -231,7 +231,7 @@ void FB_AdvanceDt( const int lv, const double TimeNew, const double TimeOld, con
 //       --> allocate the **maximum** required size among all nearby patches of a given patch group **just once**
 //           for better performance
       real *ParAtt_Local[PAR_NATT_TOTAL];
-      int  *ParSortID = NULL;
+      long *ParSortID = NULL;
       int   NParMax   = -1;
 
       for (int v=0; v<PAR_NATT_TOTAL; v++)   ParAtt_Local[v] = NULL;
@@ -250,7 +250,7 @@ void FB_AdvanceDt( const int lv, const double TimeNew, const double TimeOld, con
          for (int v=0; v<PAR_NATT_TOTAL; v++)
             if ( ParAttBitIdx_In & BIDX(v) )    ParAtt_Local[v] = new real [NParMax];
 
-         ParSortID = new int [NParMax];   // it will fail if "long" is actually required for NParMax
+         ParSortID = new long [NParMax];   // it will fail if "long" is actually required for NParMax
       }
 
 

--- a/src/Feedback/SNe/FB_SNe.cpp
+++ b/src/Feedback/SNe/FB_SNe.cpp
@@ -66,7 +66,7 @@
 // Return      :  Fluid, ParAtt
 //-------------------------------------------------------------------------------------------------------
 int FB_SNe( const int lv, const double TimeNew, const double TimeOld, const double dt,
-            const int NPar, const int *ParSortID, real *ParAtt[PAR_NATT_TOTAL],
+            const int NPar, const long *ParSortID, real *ParAtt[PAR_NATT_TOTAL],
             real (*Fluid)[FB_NXT][FB_NXT][FB_NXT], const double EdgeL[], const double dh, bool CoarseFine[],
             const int TID, RandomNumber_t *RNG )
 {

--- a/src/Feedback/User_Template/FB_User_Template.cpp
+++ b/src/Feedback/User_Template/FB_User_Template.cpp
@@ -6,7 +6,7 @@
 
 // function pointers to be set by FB_Init_User_Template()
 extern int (*FB_User_Ptr)( const int lv, const double TimeNew, const double TimeOld, const double dt,
-                           const int NPar, const int *ParSortID, real *ParAtt[PAR_NATT_TOTAL],
+                           const int NPar, const long *ParSortID, real *ParAtt[PAR_NATT_TOTAL],
                            real (*Fluid)[FB_NXT][FB_NXT][FB_NXT], const double EdgeL[], const double dh, bool CoarseFine[],
                            const int TID, RandomNumber_t *RNG );
 extern void (*FB_End_User_Ptr)();

--- a/src/Init/Init_FFTW.cpp
+++ b/src/Init/Init_FFTW.cpp
@@ -431,8 +431,8 @@ void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf
 #  ifdef GAMER_DEBUG
    const long NSend_Total  = Send_Disp_Var[MPI_NRank-1] + (long)List_NSend_Var[MPI_NRank-1];
    const long NRecv_Total  = Recv_Disp_Var[MPI_NRank-1] + (long)List_NRecv_Var[MPI_NRank-1];
-   const int NSend_Expect  = (long)amr->NPatchComma[0][1]*(long)CUBE(PS1);
-   const int NRecv_Expect  = (long)NX0_TOT[0]*(long)NX0_TOT[1]*(long)NRecvSlice;
+   const long NSend_Expect = (long)amr->NPatchComma[0][1]*(long)CUBE(PS1);
+   const long NRecv_Expect = (long)NX0_TOT[0]*(long)NX0_TOT[1]*(long)NRecvSlice;
 
    if ( NSend_Total != NSend_Expect )  Aux_Error( ERROR_INFO, "NSend_Total = %ld != expected value = %ld !!\n",
                                                   NSend_Total, NSend_Expect );

--- a/src/Init/Init_FFTW.cpp
+++ b/src/Init/Init_FFTW.cpp
@@ -459,8 +459,8 @@ void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf
 
 
 // 4. exchange data by MPI
-   MPI_Alltoallv( SendBuf_SIdx, List_NSend_SIdx, Send_Disp_SIdx, MPI_LONG,
-                  RecvBuf_SIdx, List_NRecv_SIdx, Recv_Disp_SIdx, MPI_LONG,   MPI_COMM_WORLD );
+   MPI_Alltoallv      ( SendBuf_SIdx, List_NSend_SIdx, Send_Disp_SIdx, MPI_LONG,
+                        RecvBuf_SIdx, List_NRecv_SIdx, Recv_Disp_SIdx, MPI_LONG,       MPI_COMM_WORLD );
 
    MPI_Alltoallv_GAMER( SendBuf_Var,  List_NSend_Var,  Send_Disp_Var,  MPI_GAMER_REAL,
                         RecvBuf_Var,  List_NRecv_Var,  Recv_Disp_Var,  MPI_GAMER_REAL, MPI_COMM_WORLD );

--- a/src/LoadBalance/LB_AllocateBufferPatch_Father.cpp
+++ b/src/LoadBalance/LB_AllocateBufferPatch_Father.cpp
@@ -209,7 +209,7 @@ void LB_AllocateBufferPatch_Father( const int SonLv, const bool SearchAllSon, co
 
 
 // 2. sort the candidate list and remove duplicates (with the same FaCr1D)
-   Mis_Heapsort( NFaBuf_Dup, FaCr1D_List, NULL );
+   Mis_Heapsort<int,ulong>( NFaBuf_Dup, FaCr1D_List, NULL );
 
    NFaBuf = ( NFaBuf_Dup > 0 ) ? 1 : 0;
 

--- a/src/LoadBalance/LB_AllocateBufferPatch_Sibling.cpp
+++ b/src/LoadBalance/LB_AllocateBufferPatch_Sibling.cpp
@@ -172,7 +172,7 @@ void LB_AllocateBufferPatch_Sibling( const int lv )
 // 1.3 sort the query list and remove duplicates (with the same LB_Idx)
    for (int r=0; r<MPI_NRank; r++)
    {
-      Mis_Heapsort( NQuery_Temp[r], Query_Temp[r], NULL );
+      Mis_Heapsort<int,long>( NQuery_Temp[r], Query_Temp[r], NULL );
 
       if ( NQuery_Temp[r] > 0 )  NQuery[r] = 1;
 
@@ -184,7 +184,7 @@ void LB_AllocateBufferPatch_Sibling( const int lv )
 // 1.4 sort the internal buffer patch list and remove duplicates (with the same LB_Idx)
    for (int r=0; r<MPI_NRank; r++)
    {
-      Mis_Heapsort( Int_NQuery_Temp[r], Int_LBIdx[r], NULL );
+      Mis_Heapsort<int,long>( Int_NQuery_Temp[r], Int_LBIdx[r], NULL );
 
       if ( Int_NQuery_Temp[r] > 0 )  Int_NQuery[r] = 1;
 

--- a/src/LoadBalance/LB_AllocateBufferPatch_Sibling_Base.cpp
+++ b/src/LoadBalance/LB_AllocateBufferPatch_Sibling_Base.cpp
@@ -123,7 +123,7 @@ void LB_AllocateBufferPatch_Sibling_Base()
 // ==========================================================================================
    int NAlloc = ( NAlloc_Temp > 0 ) ? 1 : 0;
 
-   Mis_Heapsort( NAlloc_Temp, FaPaddedCr1D, NULL );
+   Mis_Heapsort<int,ulong>( NAlloc_Temp, FaPaddedCr1D, NULL );
 
    for (int t=1; t<NAlloc_Temp; t++)
       if ( FaPaddedCr1D[t] != FaPaddedCr1D[t-1] )  FaPaddedCr1D[ NAlloc ++ ] = FaPaddedCr1D[t];

--- a/src/LoadBalance/LB_ExchangeFlaggedBuffer.cpp
+++ b/src/LoadBalance/LB_ExchangeFlaggedBuffer.cpp
@@ -97,7 +97,7 @@ void LB_ExchangeFlaggedBuffer( const int lv )
    int *Match = new int [NRecv_Total];
 
 // 3.1 sort the received list
-   Mis_Heapsort( NRecv_Total, RecvBuf, NULL );
+   Mis_Heapsort<int,long>( NRecv_Total, RecvBuf, NULL );
 
 // 3.2 match the corresponding PID
    Mis_Matching_int( amr->NPatchComma[lv][1], amr->LB->IdxList_Real[lv], NRecv_Total, RecvBuf, Match );

--- a/src/LoadBalance/LB_GetBufferData.cpp
+++ b/src/LoadBalance/LB_GetBufferData.cpp
@@ -187,10 +187,10 @@ void LB_GetBufferData( const int lv, const int FluSg, const int MagSg, const int
    int  *RecvY_NList=NULL, **RecvY_IDList=NULL, **RecvY_SibList=NULL;
 #  endif
 
-   int  *Send_NCount = new int  [MPI_NRank];
-   int  *Recv_NCount = new int  [MPI_NRank];
-   long *Send_NDisp  = new long [MPI_NRank];
-   long *Recv_NDisp  = new long [MPI_NRank];
+   long *Send_NCount  = new long [MPI_NRank];
+   long *Recv_NCount  = new long [MPI_NRank];
+   long *Send_NDisp   = new long [MPI_NRank];
+   long *Recv_NDisp   = new long [MPI_NRank];
 
 
 // 1. set up the number of elements to be sent and received in each cell and the send/recv lists
@@ -362,21 +362,21 @@ void LB_GetBufferData( const int lv, const int FluSg, const int MagSg, const int
 
          for (int r=0; r<MPI_NRank; r++)
          {
-            Send_NCount[r] = 0;
-            Recv_NCount[r] = 0;
+            Send_NCount[r] = 0L;
+            Recv_NCount[r] = 0L;
 
             for (int t=0; t<Send_NList[r]; t++)
             {
                if ( Send_SibList[r][t] != 0 )
                for (int s=0; s<27; s++)
-                  if ( Send_SibList[r][t] & (1<<s) )  Send_NCount[r] += DataUnit_Buf[s];
+                  if ( Send_SibList[r][t] & (1<<s) )  Send_NCount[r] += (long)DataUnit_Buf[s];
             }
 
             for (int t=0; t<Recv_NList[r]; t++)
             {
                if ( Recv_SibList[r][t] != 0 )
                for (int s=0; s<27; s++)
-                  if ( Recv_SibList[r][t] & (1<<s) )  Recv_NCount[r] += DataUnit_Buf[s];
+                  if ( Recv_SibList[r][t] & (1<<s) )  Recv_NCount[r] += (long)DataUnit_Buf[s];
             }
          }
          break; // cases DATA_GENERAL, DATA_AFTER_REFINE, POT_FOR_POISSON, POT_AFTER_REFINE
@@ -451,26 +451,26 @@ void LB_GetBufferData( const int lv, const int FluSg, const int MagSg, const int
 
          for (int r=0; r<MPI_NRank; r++)
          {
-            Send_NCount[r] = 0;
-            Recv_NCount[r] = 0;
+            Send_NCount[r] = 0L;
+            Recv_NCount[r] = 0L;
 
 //          for restriction fix-up
             for (int t=0; t<Send_NResList[r]; t++)
             for (int s=0; s<27; s++)
-               if ( Send_SibList[r][t] & (1<<s) )  Send_NCount[r] += DataUnit_Buf[s];
+               if ( Send_SibList[r][t] & (1<<s) )  Send_NCount[r] += (long)DataUnit_Buf[s];
 
             for (int t=0; t<Recv_NResList[r]; t++)
             for (int s=0; s<27; s++)
-               if ( Recv_SibList[r][t] & (1<<s) )  Recv_NCount[r] += DataUnit_Buf[s];
+               if ( Recv_SibList[r][t] & (1<<s) )  Recv_NCount[r] += (long)DataUnit_Buf[s];
 
 //          for flux fix-up
             for (int t=Send_NResList[r]; t<Send_NList[r]; t++)
             for (int s=0; s<6; s++)
-               if ( Send_SibList[r][t] & (1<<s) )  Send_NCount[r] += DataUnit_Flux;
+               if ( Send_SibList[r][t] & (1<<s) )  Send_NCount[r] += (long)DataUnit_Flux;
 
             for (int t=Recv_NResList[r]; t<Recv_NList[r]; t++)
             for (int s=0; s<6; s++)
-               if ( Recv_SibList[r][t] & (1<<s) )  Recv_NCount[r] += DataUnit_Flux;
+               if ( Recv_SibList[r][t] & (1<<s) )  Recv_NCount[r] += (long)DataUnit_Flux;
          }
 
 //       for electric field fix-up
@@ -519,11 +519,11 @@ void LB_GetBufferData( const int lv, const int FluSg, const int MagSg, const int
          {
             for (int t=0; t<SendY_NList[r]; t++)
             for (int s=0; s<27; s++)
-               if ( SendY_SibList[r][t] & (1<<s) )    Send_NCount[r] += DataUnit_Buf[s];
+               if ( SendY_SibList[r][t] & (1<<s) )    Send_NCount[r] += (long)DataUnit_Buf[s];
 
             for (int t=0; t<RecvY_NList[r]; t++)
             for (int s=0; s<27; s++)
-               if ( RecvY_SibList[r][t] & (1<<s) )    Recv_NCount[r] += DataUnit_Buf[s];
+               if ( RecvY_SibList[r][t] & (1<<s) )    Recv_NCount[r] += (long)DataUnit_Buf[s];
          }
 #        endif // #ifdef MHD
          break; // case DATA_AFTER_FIXUP
@@ -533,11 +533,11 @@ void LB_GetBufferData( const int lv, const int FluSg, const int MagSg, const int
 //    ----------------------------------------------
          for (int r=0; r<MPI_NRank; r++)
          {
-            Send_NCount[r]  = Send_NList[r]*CUBE( PS1 )*NVarCC_Tot;
-            Recv_NCount[r]  = Recv_NList[r]*CUBE( PS1 )*NVarCC_Tot;
+            Send_NCount[r]  = (long)Send_NList[r]*(long)CUBE( PS1 )*(long)NVarCC_Tot;
+            Recv_NCount[r]  = (long)Recv_NList[r]*(long)CUBE( PS1 )*(long)NVarCC_Tot;
 #           ifdef MHD
-            Send_NCount[r] += Send_NList[r]*SQR( PS1 )*PS1P1*NVarFC_Mag;
-            Recv_NCount[r] += Recv_NList[r]*SQR( PS1 )*PS1P1*NVarFC_Mag;
+            Send_NCount[r] += (long)Send_NList[r]*(long)SQR( PS1 )*(long)PS1P1*(long)NVarFC_Mag;
+            Recv_NCount[r] += (long)Recv_NList[r]*(long)SQR( PS1 )*(long)PS1P1*(long)NVarFC_Mag;
 #           endif
          }
          break; // case DATA_RESTRICT
@@ -547,8 +547,8 @@ void LB_GetBufferData( const int lv, const int FluSg, const int MagSg, const int
 //    ----------------------------------------------
          for (int r=0; r<MPI_NRank; r++)
          {
-            Send_NCount[r] = Send_NList[r]*DataUnit_Flux;
-            Recv_NCount[r] = Recv_NList[r]*DataUnit_Flux;
+            Send_NCount[r] = (long)Send_NList[r]*(long)DataUnit_Flux;
+            Recv_NCount[r] = (long)Recv_NList[r]*(long)DataUnit_Flux;
          }
          break; // case COARSE_FINE_FLUX
 
@@ -558,11 +558,11 @@ void LB_GetBufferData( const int lv, const int FluSg, const int MagSg, const int
 //    ----------------------------------------------
          for (int r=0; r<MPI_NRank; r++)
          {
-            Send_NCount[r] = 0;
-            Recv_NCount[r] = 0;
+            Send_NCount[r] = 0L;
+            Recv_NCount[r] = 0L;
 
-            for(int t=0; t<Send_NList[r]; t++)  Send_NCount[r] += ( Send_SibList[r][t] < 6 ) ? NCOMP_ELE*PS1M1*PS1 : PS1;
-            for(int t=0; t<Recv_NList[r]; t++)  Recv_NCount[r] += ( Recv_SibList[r][t] < 6 ) ? NCOMP_ELE*PS1M1*PS1 : PS1;
+            for(int t=0; t<Send_NList[r]; t++)  Send_NCount[r] += ( Send_SibList[r][t] < 6 ) ? (long)NCOMP_ELE*(long)PS1M1*(long)PS1 : (long)PS1;
+            for(int t=0; t<Recv_NList[r]; t++)  Recv_NCount[r] += ( Recv_SibList[r][t] < 6 ) ? (long)NCOMP_ELE*(long)PS1M1*(long)PS1 : (long)PS1;
          }
          break; // case COARSE_FINE_ELECTRIC
 #     endif
@@ -575,12 +575,12 @@ void LB_GetBufferData( const int lv, const int FluSg, const int MagSg, const int
 
    for (int r=1; r<MPI_NRank; r++)
    {
-      Send_NDisp[r] = Send_NDisp[r-1] + (long)Send_NCount[r-1];
-      Recv_NDisp[r] = Recv_NDisp[r-1] + (long)Recv_NCount[r-1];
+      Send_NDisp[r] = Send_NDisp[r-1] + Send_NCount[r-1];
+      Recv_NDisp[r] = Recv_NDisp[r-1] + Recv_NCount[r-1];
    }
 
-   NSend_Total = Send_NDisp[ MPI_NRank-1 ] + (long)Send_NCount[ MPI_NRank-1 ];
-   NRecv_Total = Recv_NDisp[ MPI_NRank-1 ] + (long)Recv_NCount[ MPI_NRank-1 ];
+   NSend_Total = Send_NDisp[ MPI_NRank-1 ] + Send_NCount[ MPI_NRank-1 ];
+   NRecv_Total = Recv_NDisp[ MPI_NRank-1 ] + Recv_NCount[ MPI_NRank-1 ];
 
 
 // allocate send/recv buffers (only when the current buffer size is not large enough --> improve performance)

--- a/src/LoadBalance/LB_GetBufferData.cpp
+++ b/src/LoadBalance/LB_GetBufferData.cpp
@@ -187,10 +187,10 @@ void LB_GetBufferData( const int lv, const int FluSg, const int MagSg, const int
    int  *RecvY_NList=NULL, **RecvY_IDList=NULL, **RecvY_SibList=NULL;
 #  endif
 
-   long *Send_NCount  = new long [MPI_NRank];
-   long *Recv_NCount  = new long [MPI_NRank];
-   long *Send_NDisp   = new long [MPI_NRank];
-   long *Recv_NDisp   = new long [MPI_NRank];
+   long *Send_NCount = new long [MPI_NRank];
+   long *Recv_NCount = new long [MPI_NRank];
+   long *Send_NDisp  = new long [MPI_NRank];
+   long *Recv_NDisp  = new long [MPI_NRank];
 
 
 // 1. set up the number of elements to be sent and received in each cell and the send/recv lists

--- a/src/LoadBalance/LB_Init_LoadBalance.cpp
+++ b/src/LoadBalance/LB_Init_LoadBalance.cpp
@@ -411,7 +411,7 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
 #  endif
 
 // 1.2 receive count
-   MPI_Alltoall( Send_NCount_Patch,   1, MPI_INT , Recv_NCount_Patch,   1, MPI_INT , MPI_COMM_WORLD );
+   MPI_Alltoall( Send_NCount_Patch,   1, MPI_INT,  Recv_NCount_Patch,   1, MPI_INT,  MPI_COMM_WORLD );
 #  ifdef PARTICLE
    MPI_Alltoall( Send_NCount_ParData, 1, MPI_LONG, Recv_NCount_ParData, 1, MPI_LONG, MPI_COMM_WORLD );
 #  endif

--- a/src/LoadBalance/LB_Init_LoadBalance.cpp
+++ b/src/LoadBalance/LB_Init_LoadBalance.cpp
@@ -340,28 +340,28 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
    int  NSend_Total_Patch, NRecv_Total_Patch, TRank;
    long LB_Idx;
 
-   int *Send_NCount_Patch  = new int  [MPI_NRank];
-   int *Recv_NCount_Patch  = new int  [MPI_NRank];
-   int *Send_NDisp_Patch   = new int  [MPI_NRank];
-   int *Recv_NDisp_Patch   = new int  [MPI_NRank];
-   int *Send_NCount_Flu1v  = new int  [MPI_NRank];
-   int *Recv_NCount_Flu1v  = new int  [MPI_NRank];
-   int *NDone_Patch        = new int  [MPI_NRank];
-   long *Send_NDisp_Flu1v  = new long [MPI_NRank];
-   long *Recv_NDisp_Flu1v  = new long [MPI_NRank];
+   int *Send_NCount_Patch    = new int  [MPI_NRank];
+   int *Recv_NCount_Patch    = new int  [MPI_NRank];
+   int *Send_NDisp_Patch     = new int  [MPI_NRank];
+   int *Recv_NDisp_Patch     = new int  [MPI_NRank];
+   int *NDone_Patch          = new int  [MPI_NRank];
+   long *Send_NCount_Flu1v   = new long [MPI_NRank];
+   long *Recv_NCount_Flu1v   = new long [MPI_NRank];
+   long *Send_NDisp_Flu1v    = new long [MPI_NRank];
+   long *Recv_NDisp_Flu1v    = new long [MPI_NRank];
 
 #  ifdef STORE_POT_GHOST
-   int *Send_NCount_PotExt = new int  [MPI_NRank];
-   int *Recv_NCount_PotExt = new int  [MPI_NRank];
-   long *Send_NDisp_PotExt = new long [MPI_NRank];
-   long *Recv_NDisp_PotExt = new long [MPI_NRank];
+   long *Send_NCount_PotExt  = new long [MPI_NRank];
+   long *Recv_NCount_PotExt  = new long [MPI_NRank];
+   long *Send_NDisp_PotExt   = new long [MPI_NRank];
+   long *Recv_NDisp_PotExt   = new long [MPI_NRank];
 #  endif
 
 #  ifdef MHD
-   int *Send_NCount_Mag1v  = new int  [MPI_NRank];
-   int *Recv_NCount_Mag1v  = new int  [MPI_NRank];
-   long *Send_NDisp_Mag1v  = new long [MPI_NRank];
-   long *Recv_NDisp_Mag1v  = new long [MPI_NRank];
+   long *Send_NCount_Mag1v   = new long [MPI_NRank];
+   long *Recv_NCount_Mag1v   = new long [MPI_NRank];
+   long *Send_NDisp_Mag1v    = new long [MPI_NRank];
+   long *Recv_NDisp_Mag1v    = new long [MPI_NRank];
 #  endif
 
 #  ifdef PARTICLE
@@ -370,11 +370,11 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
    long NSend_Total_ParData, NRecv_Total_ParData;
    long ParID;
 
-   int *Send_NCount_ParData = new int  [MPI_NRank];
-   int *Recv_NCount_ParData = new int  [MPI_NRank];
-   int *NDone_ParData       = new int  [MPI_NRank];
-   long *Send_NDisp_ParData = new long [MPI_NRank];
-   long *Recv_NDisp_ParData = new long [MPI_NRank];
+   long *NDone_ParData       = new long [MPI_NRank];
+   long *Send_NCount_ParData = new long [MPI_NRank];
+   long *Recv_NCount_ParData = new long [MPI_NRank];
+   long *Send_NDisp_ParData  = new long [MPI_NRank];
+   long *Recv_NDisp_ParData  = new long [MPI_NRank];
 
 #  ifdef DEBUG_PARTICLE
    if ( ParAtt_Old  == NULL )    Aux_Error( ERROR_INFO, "ParAtt_Old == NULL !!\n" );
@@ -385,7 +385,7 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
    {
       Send_NCount_Patch  [r] = 0;
 #     ifdef PARTICLE
-      Send_NCount_ParData[r] = 0;
+      Send_NCount_ParData[r] = 0L;
 #     endif
    }
    Send_NDisp_Patch  [0] = 0;
@@ -403,17 +403,17 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
 
       Send_NCount_Patch  [TRank] ++;
 #     ifdef PARTICLE
-      Send_NCount_ParData[TRank] += amr->patch[0][lv][PID]->NPar;
+      Send_NCount_ParData[TRank] += (long)amr->patch[0][lv][PID]->NPar;
 #     endif
    }
 #  ifdef PARTICLE
-   for (int r=0; r<MPI_NRank; r++)  Send_NCount_ParData[r] *= PAR_NATT_TOTAL;
+   for (int r=0; r<MPI_NRank; r++)  Send_NCount_ParData[r] *= (long)PAR_NATT_TOTAL;
 #  endif
 
 // 1.2 receive count
-   MPI_Alltoall( Send_NCount_Patch,   1, MPI_INT, Recv_NCount_Patch,   1, MPI_INT, MPI_COMM_WORLD );
+   MPI_Alltoall( Send_NCount_Patch,   1, MPI_INT , Recv_NCount_Patch,   1, MPI_INT , MPI_COMM_WORLD );
 #  ifdef PARTICLE
-   MPI_Alltoall( Send_NCount_ParData, 1, MPI_INT, Recv_NCount_ParData, 1, MPI_INT, MPI_COMM_WORLD );
+   MPI_Alltoall( Send_NCount_ParData, 1, MPI_LONG, Recv_NCount_ParData, 1, MPI_LONG, MPI_COMM_WORLD );
 #  endif
 
 // 1.3 send/recv displacement
@@ -422,27 +422,27 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
       Send_NDisp_Patch  [r] = Send_NDisp_Patch  [r-1] + Send_NCount_Patch  [r-1];
       Recv_NDisp_Patch  [r] = Recv_NDisp_Patch  [r-1] + Recv_NCount_Patch  [r-1];
 #     ifdef PARTICLE
-      Send_NDisp_ParData[r] = Send_NDisp_ParData[r-1] + (long)Send_NCount_ParData[r-1];
-      Recv_NDisp_ParData[r] = Recv_NDisp_ParData[r-1] + (long)Recv_NCount_ParData[r-1];
+      Send_NDisp_ParData[r] = Send_NDisp_ParData[r-1] + Send_NCount_ParData[r-1];
+      Recv_NDisp_ParData[r] = Recv_NDisp_ParData[r-1] + Recv_NCount_ParData[r-1];
 #     endif
    }
 
 // 1.4 send/recv data displacement
    for (int r=0; r<MPI_NRank; r++)
    {
-      Send_NCount_Flu1v [r] = FluSize1v  * Send_NCount_Patch[r];
-      Recv_NCount_Flu1v [r] = FluSize1v  * Recv_NCount_Patch[r];
+      Send_NCount_Flu1v [r] = (long)FluSize1v  * (long)Send_NCount_Patch[r];
+      Recv_NCount_Flu1v [r] = (long)FluSize1v  * (long)Recv_NCount_Patch[r];
       Send_NDisp_Flu1v  [r] = (long)FluSize1v  * (long)Send_NDisp_Patch [r];
       Recv_NDisp_Flu1v  [r] = (long)FluSize1v  * (long)Recv_NDisp_Patch [r];
 #     ifdef STORE_POT_GHOST
-      Send_NCount_PotExt[r] = GraNxtSize * Send_NCount_Patch[r];
-      Recv_NCount_PotExt[r] = GraNxtSize * Recv_NCount_Patch[r];
+      Send_NCount_PotExt[r] = (long)GraNxtSize * (long)Send_NCount_Patch[r];
+      Recv_NCount_PotExt[r] = (long)GraNxtSize * (long)Recv_NCount_Patch[r];
       Send_NDisp_PotExt [r] = (long)GraNxtSize * (long)Send_NDisp_Patch [r];
       Recv_NDisp_PotExt [r] = (long)GraNxtSize * (long)Recv_NDisp_Patch [r];
 #     endif
 #     ifdef MHD
-      Send_NCount_Mag1v [r] = MagSize1v  * Send_NCount_Patch[r];
-      Recv_NCount_Mag1v [r] = MagSize1v  * Recv_NCount_Patch[r];
+      Send_NCount_Mag1v [r] = (long)MagSize1v  * (long)Send_NCount_Patch[r];
+      Recv_NCount_Mag1v [r] = (long)MagSize1v  * (long)Recv_NCount_Patch[r];
       Send_NDisp_Mag1v  [r] = (long)MagSize1v  * (long)Send_NDisp_Patch [r];
       Recv_NDisp_Mag1v  [r] = (long)MagSize1v  * (long)Recv_NDisp_Patch [r];
 #     endif
@@ -452,8 +452,8 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
    NSend_Total_Patch   = Send_NDisp_Patch  [ MPI_NRank-1 ] + Send_NCount_Patch  [ MPI_NRank-1 ];
    NRecv_Total_Patch   = Recv_NDisp_Patch  [ MPI_NRank-1 ] + Recv_NCount_Patch  [ MPI_NRank-1 ];
 #  ifdef PARTICLE
-   NSend_Total_ParData = Send_NDisp_ParData[ MPI_NRank-1 ] + (long)Send_NCount_ParData[ MPI_NRank-1 ];
-   NRecv_Total_ParData = Recv_NDisp_ParData[ MPI_NRank-1 ] + (long)Recv_NCount_ParData[ MPI_NRank-1 ];
+   NSend_Total_ParData = Send_NDisp_ParData[ MPI_NRank-1 ] + Send_NCount_ParData[ MPI_NRank-1 ];
+   NRecv_Total_ParData = Recv_NDisp_ParData[ MPI_NRank-1 ] + Recv_NCount_ParData[ MPI_NRank-1 ];
 #  endif
 
 // 1.6 check
@@ -463,9 +463,9 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
                  NSend_Total_Patch, amr->NPatchComma[lv][1] );
 #  endif
 #  ifdef DEBUG_PARTICLE
-   if ( NSend_Total_ParData != amr->Par->NPar_Lv[lv]*PAR_NATT_TOTAL )
+   if ( NSend_Total_ParData != (long)amr->Par->NPar_Lv[lv]*(long)PAR_NATT_TOTAL )
       Aux_Error( ERROR_INFO, "NSend_Total_ParData (%ld) != expected (%ld) !!\n",
-                 NSend_Total_ParData, amr->Par->NPar_Lv[lv]*PAR_NATT_TOTAL );
+                 NSend_Total_ParData, (long)amr->Par->NPar_Lv[lv]*(long)PAR_NATT_TOTAL );
 #  endif
 
 
@@ -508,7 +508,7 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
    {
       NDone_Patch  [r] = 0;
 #     ifdef PARTICLE
-      NDone_ParData[r] = 0;
+      NDone_ParData[r] = 0L;
 #     endif
    }
 
@@ -576,7 +576,7 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
 
       NDone_Patch  [TRank] ++;
 #     ifdef PARTICLE
-      NDone_ParData[TRank] += amr->patch[0][lv][PID]->NPar*PAR_NATT_TOTAL;
+      NDone_ParData[TRank] += (long)amr->patch[0][lv][PID]->NPar*(long)PAR_NATT_TOTAL;
 
 //    detach particles from patches to avoid warning messages when deleting
 //    patches with particles

--- a/src/LoadBalance/LB_Init_LoadBalance.cpp
+++ b/src/LoadBalance/LB_Init_LoadBalance.cpp
@@ -553,7 +553,7 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
 
 //    2.6 particle
 #     ifdef PARTICLE
-      SendBuf_NPar[ Send_NDisp_Patch[TRank] + NDone_Patch[TRank] ] = amr->patch[0][lv][PID]->NPar;
+      SendBuf_NPar[ Send_NDisp_Patch[TRank] + (long)NDone_Patch[TRank] ] = amr->patch[0][lv][PID]->NPar;
 
       SendPtr = SendBuf_ParData + Send_NDisp_ParData[TRank] + NDone_ParData[TRank];
 
@@ -715,7 +715,7 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
 // check: for RemoveParFromRepo == false, the size of particle repository should be exactly equal to the received particles
 // --> see LB_RedistributeParticle_Init()
 #  ifdef DEBUG_PARTICLE
-   const long NParExpect = amr->Par->NPar_AcPlusInac + NRecv_Total_ParData/PAR_NATT_TOTAL;
+   const long NParExpect = amr->Par->NPar_AcPlusInac + NRecv_Total_ParData/(long)PAR_NATT_TOTAL;
    if ( !RemoveParFromRepo  &&  NParExpect > amr->Par->ParListSize )
       Aux_Error( ERROR_INFO, "NParExpect (%ld) > ParListSize (%ld) !!\n", NParExpect, amr->Par->ParListSize );
 #  endif

--- a/src/LoadBalance/LB_Init_LoadBalance.cpp
+++ b/src/LoadBalance/LB_Init_LoadBalance.cpp
@@ -340,41 +340,41 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
    int  NSend_Total_Patch, NRecv_Total_Patch, TRank;
    long LB_Idx;
 
-   int *Send_NCount_Patch  = new int [MPI_NRank];
-   int *Recv_NCount_Patch  = new int [MPI_NRank];
-   int *Send_NDisp_Patch   = new int [MPI_NRank];
-   int *Recv_NDisp_Patch   = new int [MPI_NRank];
-   int *Send_NCount_Flu1v  = new int [MPI_NRank];
-   int *Recv_NCount_Flu1v  = new int [MPI_NRank];
-   int *Send_NDisp_Flu1v   = new int [MPI_NRank];
-   int *Recv_NDisp_Flu1v   = new int [MPI_NRank];
-   int *NDone_Patch        = new int [MPI_NRank];
+   int *Send_NCount_Patch  = new int  [MPI_NRank];
+   int *Recv_NCount_Patch  = new int  [MPI_NRank];
+   int *Send_NDisp_Patch   = new int  [MPI_NRank];
+   int *Recv_NDisp_Patch   = new int  [MPI_NRank];
+   int *Send_NCount_Flu1v  = new int  [MPI_NRank];
+   int *Recv_NCount_Flu1v  = new int  [MPI_NRank];
+   int *NDone_Patch        = new int  [MPI_NRank];
+   long *Send_NDisp_Flu1v  = new long [MPI_NRank];
+   long *Recv_NDisp_Flu1v  = new long [MPI_NRank];
 
 #  ifdef STORE_POT_GHOST
-   int *Send_NCount_PotExt = new int [MPI_NRank];
-   int *Recv_NCount_PotExt = new int [MPI_NRank];
-   int *Send_NDisp_PotExt  = new int [MPI_NRank];
-   int *Recv_NDisp_PotExt  = new int [MPI_NRank];
+   int *Send_NCount_PotExt = new int  [MPI_NRank];
+   int *Recv_NCount_PotExt = new int  [MPI_NRank];
+   long *Send_NDisp_PotExt = new long [MPI_NRank];
+   long *Recv_NDisp_PotExt = new long [MPI_NRank];
 #  endif
 
 #  ifdef MHD
-   int *Send_NCount_Mag1v  = new int [MPI_NRank];
-   int *Recv_NCount_Mag1v  = new int [MPI_NRank];
-   int *Send_NDisp_Mag1v   = new int [MPI_NRank];
-   int *Recv_NDisp_Mag1v   = new int [MPI_NRank];
+   int *Send_NCount_Mag1v  = new int  [MPI_NRank];
+   int *Recv_NCount_Mag1v  = new int  [MPI_NRank];
+   long *Send_NDisp_Mag1v  = new long [MPI_NRank];
+   long *Recv_NDisp_Mag1v  = new long [MPI_NRank];
 #  endif
 
 #  ifdef PARTICLE
    const bool RemoveAllParticle = true;
 
-   int  NSend_Total_ParData, NRecv_Total_ParData;
+   long NSend_Total_ParData, NRecv_Total_ParData;
    long ParID;
 
-   int *Send_NCount_ParData = new int [MPI_NRank];
-   int *Recv_NCount_ParData = new int [MPI_NRank];
-   int *Send_NDisp_ParData  = new int [MPI_NRank];
-   int *Recv_NDisp_ParData  = new int [MPI_NRank];
-   int *NDone_ParData       = new int [MPI_NRank];
+   int *Send_NCount_ParData = new int  [MPI_NRank];
+   int *Recv_NCount_ParData = new int  [MPI_NRank];
+   int *NDone_ParData       = new int  [MPI_NRank];
+   long *Send_NDisp_ParData = new long [MPI_NRank];
+   long *Recv_NDisp_ParData = new long [MPI_NRank];
 
 #  ifdef DEBUG_PARTICLE
    if ( ParAtt_Old  == NULL )    Aux_Error( ERROR_INFO, "ParAtt_Old == NULL !!\n" );
@@ -391,8 +391,8 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
    Send_NDisp_Patch  [0] = 0;
    Recv_NDisp_Patch  [0] = 0;
 #  ifdef PARTICLE
-   Send_NDisp_ParData[0] = 0;
-   Recv_NDisp_ParData[0] = 0;
+   Send_NDisp_ParData[0] = 0L;
+   Recv_NDisp_ParData[0] = 0L;
 #  endif
 
 // 1.1 send count
@@ -422,8 +422,8 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
       Send_NDisp_Patch  [r] = Send_NDisp_Patch  [r-1] + Send_NCount_Patch  [r-1];
       Recv_NDisp_Patch  [r] = Recv_NDisp_Patch  [r-1] + Recv_NCount_Patch  [r-1];
 #     ifdef PARTICLE
-      Send_NDisp_ParData[r] = Send_NDisp_ParData[r-1] + Send_NCount_ParData[r-1];
-      Recv_NDisp_ParData[r] = Recv_NDisp_ParData[r-1] + Recv_NCount_ParData[r-1];
+      Send_NDisp_ParData[r] = Send_NDisp_ParData[r-1] + (long)Send_NCount_ParData[r-1];
+      Recv_NDisp_ParData[r] = Recv_NDisp_ParData[r-1] + (long)Recv_NCount_ParData[r-1];
 #     endif
    }
 
@@ -432,19 +432,19 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
    {
       Send_NCount_Flu1v [r] = FluSize1v  * Send_NCount_Patch[r];
       Recv_NCount_Flu1v [r] = FluSize1v  * Recv_NCount_Patch[r];
-      Send_NDisp_Flu1v  [r] = FluSize1v  * Send_NDisp_Patch [r];
-      Recv_NDisp_Flu1v  [r] = FluSize1v  * Recv_NDisp_Patch [r];
+      Send_NDisp_Flu1v  [r] = (long)FluSize1v  * (long)Send_NDisp_Patch [r];
+      Recv_NDisp_Flu1v  [r] = (long)FluSize1v  * (long)Recv_NDisp_Patch [r];
 #     ifdef STORE_POT_GHOST
       Send_NCount_PotExt[r] = GraNxtSize * Send_NCount_Patch[r];
       Recv_NCount_PotExt[r] = GraNxtSize * Recv_NCount_Patch[r];
-      Send_NDisp_PotExt [r] = GraNxtSize * Send_NDisp_Patch [r];
-      Recv_NDisp_PotExt [r] = GraNxtSize * Recv_NDisp_Patch [r];
+      Send_NDisp_PotExt [r] = (long)GraNxtSize * (long)Send_NDisp_Patch [r];
+      Recv_NDisp_PotExt [r] = (long)GraNxtSize * (long)Recv_NDisp_Patch [r];
 #     endif
 #     ifdef MHD
       Send_NCount_Mag1v [r] = MagSize1v  * Send_NCount_Patch[r];
       Recv_NCount_Mag1v [r] = MagSize1v  * Recv_NCount_Patch[r];
-      Send_NDisp_Mag1v  [r] = MagSize1v  * Send_NDisp_Patch [r];
-      Recv_NDisp_Mag1v  [r] = MagSize1v  * Recv_NDisp_Patch [r];
+      Send_NDisp_Mag1v  [r] = (long)MagSize1v  * (long)Send_NDisp_Patch [r];
+      Recv_NDisp_Mag1v  [r] = (long)MagSize1v  * (long)Recv_NDisp_Patch [r];
 #     endif
    }
 
@@ -452,8 +452,8 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
    NSend_Total_Patch   = Send_NDisp_Patch  [ MPI_NRank-1 ] + Send_NCount_Patch  [ MPI_NRank-1 ];
    NRecv_Total_Patch   = Recv_NDisp_Patch  [ MPI_NRank-1 ] + Recv_NCount_Patch  [ MPI_NRank-1 ];
 #  ifdef PARTICLE
-   NSend_Total_ParData = Send_NDisp_ParData[ MPI_NRank-1 ] + Send_NCount_ParData[ MPI_NRank-1 ];
-   NRecv_Total_ParData = Recv_NDisp_ParData[ MPI_NRank-1 ] + Recv_NCount_ParData[ MPI_NRank-1 ];
+   NSend_Total_ParData = Send_NDisp_ParData[ MPI_NRank-1 ] + (long)Send_NCount_ParData[ MPI_NRank-1 ];
+   NRecv_Total_ParData = Recv_NDisp_ParData[ MPI_NRank-1 ] + (long)Recv_NCount_ParData[ MPI_NRank-1 ];
 #  endif
 
 // 1.6 check
@@ -464,7 +464,7 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
 #  endif
 #  ifdef DEBUG_PARTICLE
    if ( NSend_Total_ParData != amr->Par->NPar_Lv[lv]*PAR_NATT_TOTAL )
-      Aux_Error( ERROR_INFO, "NSend_Total_ParData (%d) != expected (%ld) !!\n",
+      Aux_Error( ERROR_INFO, "NSend_Total_ParData (%ld) != expected (%ld) !!\n",
                  NSend_Total_ParData, amr->Par->NPar_Lv[lv]*PAR_NATT_TOTAL );
 #  endif
 
@@ -525,18 +525,18 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
 //       2.2 fluid
          for (int v=0; v<NCOMP_TOTAL; v++)
          {
-            SendPtr = SendBuf_Flu + v*SendDataSizeFlu1v + (long)Send_NDisp_Flu1v[TRank] + (long)NDone_Patch[TRank]*FluSize1v;
+            SendPtr = SendBuf_Flu + v*SendDataSizeFlu1v + Send_NDisp_Flu1v[TRank] + (long)NDone_Patch[TRank]*FluSize1v;
             memcpy( SendPtr, &amr->patch[FluSg][lv][PID]->fluid[v][0][0][0], FluSize1v*sizeof(real) );
          }
 
 #        ifdef GRAVITY
 //       2.3 potential
-         SendPtr = SendBuf_Pot + (long)Send_NDisp_Flu1v[TRank] + (long)NDone_Patch[TRank]*FluSize1v;
+         SendPtr = SendBuf_Pot + Send_NDisp_Flu1v[TRank] + (long)NDone_Patch[TRank]*FluSize1v;
          memcpy( SendPtr, &amr->patch[PotSg][lv][PID]->pot[0][0][0], FluSize1v*sizeof(real) );
 
 //       2.4 potential with ghost zones
 #        ifdef STORE_POT_GHOST
-         SendPtr = SendBuf_PotExt + (long)Send_NDisp_PotExt[TRank] + (long)NDone_Patch[TRank]*GraNxtSize;
+         SendPtr = SendBuf_PotExt + Send_NDisp_PotExt[TRank] + (long)NDone_Patch[TRank]*GraNxtSize;
          memcpy( SendPtr, &amr->patch[PotSg][lv][PID]->pot_ext[0][0][0], GraNxtSize*sizeof(real) );
 #        endif
 #        endif
@@ -545,7 +545,7 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
 #        ifdef MHD
          for (int v=0; v<NCOMP_MAG; v++)
          {
-            SendPtr = SendBuf_Mag + v*SendDataSizeMag1v + (long)Send_NDisp_Mag1v[TRank] + (long)NDone_Patch[TRank]*MagSize1v;
+            SendPtr = SendBuf_Mag + v*SendDataSizeMag1v + Send_NDisp_Mag1v[TRank] + (long)NDone_Patch[TRank]*MagSize1v;
             memcpy( SendPtr, &amr->patch[MagSg][lv][PID]->magnetic[v][0], MagSize1v*sizeof(real) );
          }
 #        endif
@@ -628,13 +628,8 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
 //    4.2 fluid (transfer one component at a time to avoid exceeding the maximum allowed transfer size in MPI)
       for (int v=0; v<NCOMP_TOTAL; v++)
       {
-#        ifdef FLOAT8
-         MPI_Alltoallv( SendBuf_Flu + v*SendDataSizeFlu1v, Send_NCount_Flu1v, Send_NDisp_Flu1v, MPI_DOUBLE,
-                        RecvBuf_Flu + v*RecvDataSizeFlu1v, Recv_NCount_Flu1v, Recv_NDisp_Flu1v, MPI_DOUBLE, MPI_COMM_WORLD );
-#        else
-         MPI_Alltoallv( SendBuf_Flu + v*SendDataSizeFlu1v, Send_NCount_Flu1v, Send_NDisp_Flu1v, MPI_FLOAT,
-                        RecvBuf_Flu + v*RecvDataSizeFlu1v, Recv_NCount_Flu1v, Recv_NDisp_Flu1v, MPI_FLOAT,  MPI_COMM_WORLD );
-#        endif
+         MPI_Alltoallv_GAMER( SendBuf_Flu + v*SendDataSizeFlu1v, Send_NCount_Flu1v, Send_NDisp_Flu1v, MPI_GAMER_REAL,
+                              RecvBuf_Flu + v*RecvDataSizeFlu1v, Recv_NCount_Flu1v, Recv_NDisp_Flu1v, MPI_GAMER_REAL, MPI_COMM_WORLD );
       }
 
 #     ifdef GRAVITY
@@ -642,23 +637,13 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
 //    --> debugger may report that the potential data are NOT initialized when calling LB_Init_LoadBalance()
 //        during initialization
 //    --> it's fine since we will calculate potential AFTER invoking LB_Init_LoadBalance() in Init_GAMER()
-#     ifdef FLOAT8
-      MPI_Alltoallv( SendBuf_Pot, Send_NCount_Flu1v, Send_NDisp_Flu1v, MPI_DOUBLE,
-                     RecvBuf_Pot, Recv_NCount_Flu1v, Recv_NDisp_Flu1v, MPI_DOUBLE, MPI_COMM_WORLD );
-#     else
-      MPI_Alltoallv( SendBuf_Pot, Send_NCount_Flu1v, Send_NDisp_Flu1v, MPI_FLOAT,
-                     RecvBuf_Pot, Recv_NCount_Flu1v, Recv_NDisp_Flu1v, MPI_FLOAT,  MPI_COMM_WORLD );
-#     endif
+      MPI_Alltoallv_GAMER( SendBuf_Pot, Send_NCount_Flu1v, Send_NDisp_Flu1v, MPI_GAMER_REAL,
+                           RecvBuf_Pot, Recv_NCount_Flu1v, Recv_NDisp_Flu1v, MPI_GAMER_REAL, MPI_COMM_WORLD );
 
 //    4.4 potential with ghost zones
 #     ifdef STORE_POT_GHOST
-#     ifdef FLOAT8
-      MPI_Alltoallv( SendBuf_PotExt, Send_NCount_PotExt, Send_NDisp_PotExt, MPI_DOUBLE,
-                     RecvBuf_PotExt, Recv_NCount_PotExt, Recv_NDisp_PotExt, MPI_DOUBLE, MPI_COMM_WORLD );
-#     else
-      MPI_Alltoallv( SendBuf_PotExt, Send_NCount_PotExt, Send_NDisp_PotExt, MPI_FLOAT,
-                     RecvBuf_PotExt, Recv_NCount_PotExt, Recv_NDisp_PotExt, MPI_FLOAT,  MPI_COMM_WORLD );
-#     endif
+      MPI_Alltoallv_GAMER( SendBuf_PotExt, Send_NCount_PotExt, Send_NDisp_PotExt, MPI_GAMER_REAL,
+                           RecvBuf_PotExt, Recv_NCount_PotExt, Recv_NDisp_PotExt, MPI_GAMER_REAL, MPI_COMM_WORLD );
 #     endif // STORE_POT_GHOST
 #     endif // GRAVITY
 
@@ -666,13 +651,8 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
 #     ifdef MHD
       for (int v=0; v<NCOMP_MAG; v++)
       {
-#        ifdef FLOAT8
-         MPI_Alltoallv( SendBuf_Mag + v*SendDataSizeMag1v, Send_NCount_Mag1v, Send_NDisp_Mag1v, MPI_DOUBLE,
-                        RecvBuf_Mag + v*RecvDataSizeMag1v, Recv_NCount_Mag1v, Recv_NDisp_Mag1v, MPI_DOUBLE, MPI_COMM_WORLD );
-#        else
-         MPI_Alltoallv( SendBuf_Mag + v*SendDataSizeMag1v, Send_NCount_Mag1v, Send_NDisp_Mag1v, MPI_FLOAT,
-                        RecvBuf_Mag + v*RecvDataSizeMag1v, Recv_NCount_Mag1v, Recv_NDisp_Mag1v, MPI_FLOAT,  MPI_COMM_WORLD );
-#        endif
+         MPI_Alltoallv_GAMER( SendBuf_Mag + v*SendDataSizeMag1v, Send_NCount_Mag1v, Send_NDisp_Mag1v, MPI_GAMER_REAL,
+                              RecvBuf_Mag + v*RecvDataSizeMag1v, Recv_NCount_Mag1v, Recv_NDisp_Mag1v, MPI_GAMER_REAL, MPI_COMM_WORLD );
       }
 #     endif
    } // if ( SendGridData )
@@ -683,13 +663,8 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
                   RecvBuf_NPar, Recv_NCount_Patch, Recv_NDisp_Patch, MPI_INT, MPI_COMM_WORLD );
 
 // 4.7 particle data
-#  ifdef FLOAT8
-   MPI_Alltoallv( SendBuf_ParData, Send_NCount_ParData, Send_NDisp_ParData, MPI_DOUBLE,
-                  RecvBuf_ParData, Recv_NCount_ParData, Recv_NDisp_ParData, MPI_DOUBLE, MPI_COMM_WORLD );
-#  else
-   MPI_Alltoallv( SendBuf_ParData, Send_NCount_ParData, Send_NDisp_ParData, MPI_FLOAT,
-                  RecvBuf_ParData, Recv_NCount_ParData, Recv_NDisp_ParData, MPI_FLOAT,  MPI_COMM_WORLD );
-#  endif
+   MPI_Alltoallv_GAMER( SendBuf_ParData, Send_NCount_ParData, Send_NDisp_ParData, MPI_GAMER_REAL,
+                        RecvBuf_ParData, Recv_NCount_ParData, Recv_NDisp_ParData, MPI_GAMER_REAL, MPI_COMM_WORLD );
 #  endif // #ifdef PARTICLE
 
 

--- a/src/LoadBalance/LB_Init_LoadBalance.cpp
+++ b/src/LoadBalance/LB_Init_LoadBalance.cpp
@@ -553,7 +553,7 @@ void LB_RedistributeRealPatch( const int lv, real **ParAtt_Old, const bool Remov
 
 //    2.6 particle
 #     ifdef PARTICLE
-      SendBuf_NPar[ Send_NDisp_Patch[TRank] + (long)NDone_Patch[TRank] ] = amr->patch[0][lv][PID]->NPar;
+      SendBuf_NPar[ Send_NDisp_Patch[TRank] + NDone_Patch[TRank] ] = amr->patch[0][lv][PID]->NPar;
 
       SendPtr = SendBuf_ParData + Send_NDisp_ParData[TRank] + NDone_ParData[TRank];
 

--- a/src/LoadBalance/LB_Output_LBIdx.cpp
+++ b/src/LoadBalance/LB_Output_LBIdx.cpp
@@ -49,7 +49,7 @@ void LB_Output_LBIdx( const int lv )
          }
 
 //       sorting
-         Mis_Heapsort( NP, List, NULL );
+         Mis_Heapsort<int,long>( NP, List, NULL );
 
 //       get corner
          for (int t=0; t<NP; t++)

--- a/src/LoadBalance/LB_RecordExchangeDataPatchID.cpp
+++ b/src/LoadBalance/LB_RecordExchangeDataPatchID.cpp
@@ -553,7 +553,7 @@ void LB_RecordExchangeDataPatchID( const int Lv, const bool AfterRefine )
       int *TempIDList = new int [ LB_RecvH_NList[r] ];
       memcpy( TempIDList, LB_RecvH_IDList[r], LB_RecvH_NList[r]*sizeof(int) );
 
-      Mis_Heapsort( LB_RecvH_NList[r], TempIDList, NULL );
+      Mis_Heapsort<int,int>( LB_RecvH_NList[r], TempIDList, NULL );
 
       for (int t=1; t<LB_RecvH_NList[r]; t++)
          if ( TempIDList[t] == TempIDList[t-1] )
@@ -658,7 +658,7 @@ void LB_RecordExchangeDataPatchID( const int Lv, const bool AfterRefine )
       int *TempIDList = new int [ LB_RecvG_NList[r] ];
       memcpy( TempIDList, LB_RecvG_IDList[r], LB_RecvG_NList[r]*sizeof(int) );
 
-      Mis_Heapsort( LB_RecvG_NList[r], TempIDList, NULL );
+      Mis_Heapsort<int,int>( LB_RecvG_NList[r], TempIDList, NULL );
 
       for (int t=1; t<LB_RecvG_NList[r]; t++)
          if ( TempIDList[t] == TempIDList[t-1] )

--- a/src/LoadBalance/LB_RecordExchangeRestrictDataPatchID.cpp
+++ b/src/LoadBalance/LB_RecordExchangeRestrictDataPatchID.cpp
@@ -123,7 +123,7 @@ void LB_RecordExchangeRestrictDataPatchID( const int FaLv )
       int *TempIDList = new int [ LB_SendR_NList[r] ];
       memcpy( TempIDList, LB_SendR_IDList[r], LB_SendR_NList[r]*sizeof(int) );
 
-      Mis_Heapsort( LB_SendR_NList[r], TempIDList, NULL );
+      Mis_Heapsort<int,int>( LB_SendR_NList[r], TempIDList, NULL );
 
       for (int t=1; t<LB_SendR_NList[r]; t++)
          if ( TempIDList[t] == TempIDList[t-1] )

--- a/src/LoadBalance/LB_Refine.cpp
+++ b/src/LoadBalance/LB_Refine.cpp
@@ -14,7 +14,7 @@ void LB_Refine_AllocateNewPatch( const int FaLv, int NNew_Home, int *NewPID_Home
                                  int NDel_Home, int *DelPID_Home, int NDel_Away, ulong *DelCr1D_Away,
                                  int &RefineS2F_Send_NPatchTotal, int *&RefineS2F_Send_PIDList,
                                  const int (*CFB_SibRank_Home)[6], const int (*CFB_SibRank_Away)[6],
-                                 const real *CFB_BField, const int *CFB_NSibEachRank );
+                                 const real *CFB_BField, const long *CFB_NSibEachRank );
 #ifdef PARTICLE
 void Par_LB_Refine_SendParticle2Father( const int FaLv, const int RefineS2F_Send_NPatchTotal, int *RefineS2F_Send_PIDList );
 #endif
@@ -23,7 +23,7 @@ void MHD_LB_Refine_GetCoarseFineInterfaceBField(
    const int FaLv, const int NNew_Home, const int NNew_Away,
    const long (*CFB_SibLBIdx_Home)[6], const long (*CFB_SibLBIdx_Away)[6],
    int (*&CFB_SibRank_Home)[6], int (*&CFB_SibRank_Away)[6],
-   real *&CFB_BField, int *CFB_NSibEachRank );
+   real *&CFB_BField, long *CFB_NSibEachRank );
 #endif
 
 
@@ -88,7 +88,7 @@ void LB_Refine( const int FaLv )
 // CFB = Coarse-Fine interface B field (for MHD only)
    int  (*CFB_SibRank_Home)[6]=NULL, (*CFB_SibRank_Away)[6]=NULL;
    long (*CFB_SibLBIdx_Home)[6]=NULL, (*CFB_SibLBIdx_Away)[6]=NULL;
-   int    CFB_NSibEachRank[MPI_NRank];
+   long   CFB_NSibEachRank[MPI_NRank];
    real  *CFB_BField=NULL;
 
    LB_Refine_GetNewRealPatchList( FaLv, NNew_Home, NewPID_Home, NNew_Away, NewCr1D_Away, NewCr1D_Away_IdxTable, NewCData_Away,

--- a/src/LoadBalance/LB_Refine_AllocateNewPatch.cpp
+++ b/src/LoadBalance/LB_Refine_AllocateNewPatch.cpp
@@ -65,7 +65,7 @@ void LB_Refine_AllocateNewPatch( const int FaLv, int NNew_Home, int *NewPID_Home
                                  int NDel_Home, int *DelPID_Home, int NDel_Away, ulong *DelCr1D_Away,
                                  int &RefineS2F_Send_NPatchTotal, int *&RefineS2F_Send_PIDList,
                                  const int (*CFB_SibRank_Home)[6], const int (*CFB_SibRank_Away)[6],
-                                 const real *CFB_BField, const int *CFB_NSibEachRank )
+                                 const real *CFB_BField, const long *CFB_NSibEachRank )
 {
 
    const int SonLv    = FaLv + 1;
@@ -167,7 +167,7 @@ void LB_Refine_AllocateNewPatch( const int FaLv, int NNew_Home, int *NewPID_Home
       }
 
 //    2-1-3. sort the PID list and remove duplicates
-      Mis_Heapsort( NBufBk_Dup, PID_BufBk, NULL );
+      Mis_Heapsort<int,int>( NBufBk_Dup, PID_BufBk, NULL );
 
       NBufBk = ( NBufBk_Dup > 0 ) ? 1 : 0;
 

--- a/src/LoadBalance/LB_Refine_GetNewRealPatchList.cpp
+++ b/src/LoadBalance/LB_Refine_GetNewRealPatchList.cpp
@@ -317,8 +317,8 @@ void LB_Refine_GetNewRealPatchList( const int FaLv, int &NNew_Home, int *&NewPID
 
    int    New_Send_Disp[MPI_NRank], New_Recv_Disp[MPI_NRank], NNew_Recv[MPI_NRank], NNew_Send_Total, NNew_Recv_Total;
    int    Del_Send_Disp[MPI_NRank], Del_Recv_Disp[MPI_NRank], NDel_Recv[MPI_NRank], NDel_Send_Total, NDel_Recv_Total;
-   int    NNew_Send_CData[MPI_NRank], NNew_Recv_CData[MPI_NRank];
    int    Counter;
+   long   NNew_Send_CData[MPI_NRank], NNew_Recv_CData[MPI_NRank];
    long   New_Send_Disp_CData[MPI_NRank], New_Recv_Disp_CData[MPI_NRank];
    ulong *New_SendBuf_Cr1D=NULL, *New_RecvBuf_Cr1D=NULL, *Del_SendBuf_Cr1D=NULL, *Del_RecvBuf_Cr1D=NULL;
    real  *New_SendBuf_CData=NULL, *New_RecvBuf_CData=NULL;
@@ -354,8 +354,8 @@ void LB_Refine_GetNewRealPatchList( const int FaLv, int &NNew_Home, int *&NewPID
 
    for (int r=0; r<MPI_NRank; r++)
    {
-      NNew_Send_CData        [r] = PSize*NNew_Send    [r];
-      NNew_Recv_CData        [r] = PSize*NNew_Recv    [r];
+      NNew_Send_CData        [r] = (long)PSize*(long)NNew_Send    [r];
+      NNew_Recv_CData        [r] = (long)PSize*(long)NNew_Recv    [r];
       New_Send_Disp_CData    [r] = (long)PSize*(long)New_Send_Disp[r];
       New_Recv_Disp_CData    [r] = (long)PSize*(long)New_Recv_Disp[r];
 #     ifdef MHD
@@ -456,7 +456,7 @@ void LB_Refine_GetNewRealPatchList( const int FaLv, int &NNew_Home, int *&NewPID
 // 3. sort *Cr1D_Away[] and CFB_SibLBIdx_Away[]
 // ============================================================================================================
    Mis_Heapsort( NNew_Away, NewCr1D_Away, NewCr1D_Away_IdxTable );
-   Mis_Heapsort( NDel_Away, DelCr1D_Away, NULL                  );
+   Mis_Heapsort<int,ulong>( NDel_Away, DelCr1D_Away, NULL       );
 
 // must ensure that CFB_SibLBIdx_Away[] and Cr1D_Away[] are sorted consistently
 // --> so that the coarse-fine interface B field data received in MHD_LB_Refine_GetCoarseFineInterfaceBField()

--- a/src/LoadBalance/LB_Refine_GetNewRealPatchList.cpp
+++ b/src/LoadBalance/LB_Refine_GetNewRealPatchList.cpp
@@ -455,8 +455,8 @@ void LB_Refine_GetNewRealPatchList( const int FaLv, int &NNew_Home, int *&NewPID
 
 // 3. sort *Cr1D_Away[] and CFB_SibLBIdx_Away[]
 // ============================================================================================================
-   Mis_Heapsort( NNew_Away, NewCr1D_Away, NewCr1D_Away_IdxTable );
-   Mis_Heapsort<int,ulong>( NDel_Away, DelCr1D_Away, NULL       );
+   Mis_Heapsort           ( NNew_Away, NewCr1D_Away, NewCr1D_Away_IdxTable );
+   Mis_Heapsort<int,ulong>( NDel_Away, DelCr1D_Away, NULL                  );
 
 // must ensure that CFB_SibLBIdx_Away[] and Cr1D_Away[] are sorted consistently
 // --> so that the coarse-fine interface B field data received in MHD_LB_Refine_GetCoarseFineInterfaceBField()

--- a/src/LoadBalance/LB_Refine_GetNewRealPatchList.cpp
+++ b/src/LoadBalance/LB_Refine_GetNewRealPatchList.cpp
@@ -317,9 +317,9 @@ void LB_Refine_GetNewRealPatchList( const int FaLv, int &NNew_Home, int *&NewPID
 
    int    New_Send_Disp[MPI_NRank], New_Recv_Disp[MPI_NRank], NNew_Recv[MPI_NRank], NNew_Send_Total, NNew_Recv_Total;
    int    Del_Send_Disp[MPI_NRank], Del_Recv_Disp[MPI_NRank], NDel_Recv[MPI_NRank], NDel_Send_Total, NDel_Recv_Total;
-   int    New_Send_Disp_CData[MPI_NRank], New_Recv_Disp_CData[MPI_NRank];
    int    NNew_Send_CData[MPI_NRank], NNew_Recv_CData[MPI_NRank];
    int    Counter;
+   long   New_Send_Disp_CData[MPI_NRank], New_Recv_Disp_CData[MPI_NRank];
    ulong *New_SendBuf_Cr1D=NULL, *New_RecvBuf_Cr1D=NULL, *Del_SendBuf_Cr1D=NULL, *Del_RecvBuf_Cr1D=NULL;
    real  *New_SendBuf_CData=NULL, *New_RecvBuf_CData=NULL;
 
@@ -356,8 +356,8 @@ void LB_Refine_GetNewRealPatchList( const int FaLv, int &NNew_Home, int *&NewPID
    {
       NNew_Send_CData        [r] = PSize*NNew_Send    [r];
       NNew_Recv_CData        [r] = PSize*NNew_Recv    [r];
-      New_Send_Disp_CData    [r] = PSize*New_Send_Disp[r];
-      New_Recv_Disp_CData    [r] = PSize*New_Recv_Disp[r];
+      New_Send_Disp_CData    [r] = (long)PSize*(long)New_Send_Disp[r];
+      New_Recv_Disp_CData    [r] = (long)PSize*(long)New_Recv_Disp[r];
 #     ifdef MHD
       CFB_Send_NList_SibLBIdx[r] =     6*NNew_Send    [r];
       CFB_Recv_NList_SibLBIdx[r] =     6*NNew_Recv    [r];
@@ -444,13 +444,8 @@ void LB_Refine_GetNewRealPatchList( const int FaLv, int &NNew_Home, int *&NewPID
 #  endif
 
 // 2.4.3 new CData
-#  ifdef FLOAT8
-   MPI_Alltoallv( New_SendBuf_CData, NNew_Send_CData, New_Send_Disp_CData, MPI_DOUBLE,
-                  New_RecvBuf_CData, NNew_Recv_CData, New_Recv_Disp_CData, MPI_DOUBLE, MPI_COMM_WORLD );
-#  else
-   MPI_Alltoallv( New_SendBuf_CData, NNew_Send_CData, New_Send_Disp_CData, MPI_FLOAT,
-                  New_RecvBuf_CData, NNew_Recv_CData, New_Recv_Disp_CData, MPI_FLOAT,  MPI_COMM_WORLD );
-#  endif
+   MPI_Alltoallv_GAMER( New_SendBuf_CData, NNew_Send_CData, New_Send_Disp_CData, MPI_GAMER_REAL,
+                        New_RecvBuf_CData, NNew_Recv_CData, New_Recv_Disp_CData, MPI_GAMER_REAL, MPI_COMM_WORLD );
 
 // 2.4.4 delete Cr1D
    MPI_Alltoallv( Del_SendBuf_Cr1D, NDel_Send, Del_Send_Disp, MPI_UNSIGNED_LONG,

--- a/src/MPI/MPI_Alltoallv_GAMER.cpp
+++ b/src/MPI/MPI_Alltoallv_GAMER.cpp
@@ -35,13 +35,13 @@ void MPI_Alltoallv_GAMER(T *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Da
    MPI_Allreduce(MPI_IN_PLACE, &use_mpi_gamer_flag , 1, MPI_C_BOOL, MPI_LOR, MPI_COMM_WORLD);
 
    // ********************************purely for testing purpose!! Remember to comment this out for distribution!! ********************************
-   use_mpi_gamer_flag = true;
+//   use_mpi_gamer_flag = true;
    //
 
    if ( use_mpi_gamer_flag )
    {
       // ********************************purely for testing purpose!! Remember to comment this out for distribution!! ********************************
-      Aux_Message( stdout, "  Use MPI_Alltoallv_GAMER wrapper..." );
+//      Aux_Message( stdout, "  Use MPI_Alltoallv_GAMER wrapper..." );
       //
       MPI_Request *req_send_and_recv = new MPI_Request[2*MPI_NRank];
 

--- a/src/MPI/MPI_Alltoallv_GAMER.cpp
+++ b/src/MPI/MPI_Alltoallv_GAMER.cpp
@@ -84,6 +84,8 @@ void MPI_Alltoallv_GAMER(T *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Da
 // explicit template instantiation
 template void MPI_Alltoallv_GAMER <float>    ( float  *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Datatype Send_Datatype, float  *RecvBuf, long *Recv_NCount, long *Recv_NDisp, MPI_Datatype Recv_Datatype, MPI_Comm comm );
 template void MPI_Alltoallv_GAMER <double>   ( double *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Datatype Send_Datatype, double *RecvBuf, long *Recv_NCount, long *Recv_NDisp, MPI_Datatype Recv_Datatype, MPI_Comm comm );
+template void MPI_Alltoallv_GAMER <int>      ( int    *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Datatype Send_Datatype, int    *RecvBuf, long *Recv_NCount, long *Recv_NDisp, MPI_Datatype Recv_Datatype, MPI_Comm comm );
+template void MPI_Alltoallv_GAMER <long>     ( long   *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Datatype Send_Datatype, long   *RecvBuf, long *Recv_NCount, long *Recv_NDisp, MPI_Datatype Recv_Datatype, MPI_Comm comm );
 
 #endif // #ifndef SERIAL
 

--- a/src/MPI/MPI_Alltoallv_GAMER.cpp
+++ b/src/MPI/MPI_Alltoallv_GAMER.cpp
@@ -39,7 +39,7 @@ void MPI_Alltoallv_GAMER(T *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Da
       MPI_Request *req_send_and_recv = new MPI_Request[2*MPI_NRank];
 
 // for numbering the MPI_Isend/Irecv tags: since there are total MPI_NRank*MPI_NRank data-transferring tasks, we tag the data-transferring task between rank r_1(send) <--> rank r_2(recv) by number: r_1*MPI_NRank+r_2 
-      for(int r=0; r<MPI_NRank; r++)
+      for (int r=0; r<MPI_NRank; r++)
       {
           MPI_Isend(SendBuf+Send_NDisp[r], (int)Send_NCount[r], Send_Datatype, r, MPI_Rank*MPI_NRank + r       , comm, &req_send_and_recv[2*r  ]);
           MPI_Irecv(RecvBuf+Recv_NDisp[r], (int)Recv_NCount[r], Recv_Datatype, r,        r*MPI_NRank + MPI_Rank, comm, &req_send_and_recv[2*r+1]);
@@ -82,5 +82,3 @@ template void MPI_Alltoallv_GAMER <int>      ( int    *SendBuf, long *Send_NCoun
 template void MPI_Alltoallv_GAMER <long>     ( long   *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Datatype Send_Datatype, long   *RecvBuf, long *Recv_NCount, long *Recv_NDisp, MPI_Datatype Recv_Datatype, MPI_Comm comm );
 
 #endif // #ifndef SERIAL
-
-

--- a/src/MPI/MPI_Alltoallv_GAMER.cpp
+++ b/src/MPI/MPI_Alltoallv_GAMER.cpp
@@ -35,12 +35,14 @@ void MPI_Alltoallv_GAMER(T *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Da
    MPI_Allreduce(MPI_IN_PLACE, &use_mpi_gamer_flag , 1, MPI_C_BOOL, MPI_LOR, MPI_COMM_WORLD);
 
    // ********************************purely for testing purpose!! Remember to comment this out for distribution!! ********************************
-//   Aux_Message( stdout, "  Use MPI_Alltoallv_GAMER wrapper..." );
-//   use_mpi_gamer_flag = true;
+   use_mpi_gamer_flag = true;
    //
 
    if ( use_mpi_gamer_flag )
    {
+      // ********************************purely for testing purpose!! Remember to comment this out for distribution!! ********************************
+      Aux_Message( stdout, "  Use MPI_Alltoallv_GAMER wrapper..." );
+      //
       MPI_Request *req_send_and_recv = new MPI_Request[2*MPI_NRank];
 
       for(int r=0; r<MPI_NRank; r++)

--- a/src/MPI/MPI_Alltoallv_GAMER.cpp
+++ b/src/MPI/MPI_Alltoallv_GAMER.cpp
@@ -1,0 +1,75 @@
+#include "GAMER.h"
+
+#ifndef SERIAL
+
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  MPI_Alltoallv_GAMER
+// Description :  wrapper for replacing official MPI_Alltoallv() when the number of elements in Send_NDisp/Recv_NDisp exceed __INT_MAX__
+//
+// Parameter   :  SendBuf:      data to be send by this rank to other ranks via MPI_Alltoallv
+//                Send_NCount:  number of elements to be sent by each rank to other ranks in SendBuff; length euqals MPI_NRank
+//                Send_NDisp:   displacement indicating the stride where the sent data (to other ranks) starts in SendBuf for each rank;
+//                              length equals to MPI_NRank
+//                Send_Datatype: sent data type for MPI
+//                RecvBuf:      data to be received by this rank from other ranks via MPI_Alltoallv
+//                Recv_NCount:  number of elements to be received by each rank from other ranks in RecvBuff; length euqals MPI_NRank
+//                Recv_NDisp:   displacement indicating the stride where the received data (from other ranks) starts in RecvdBuf for each rank;
+//                              length equals to MPI_NRank
+//                Recv_Datatype: received data type for MPI (MPI_GAMER_REAL/MPI_GAMER_REAL_PAR)
+//                comm:          MPI communicator
+//-------------------------------------------------------------------------------------------------------
+template<typename T> 
+void MPI_Alltoallv_GAMER(T *SendBuf, int *Send_NCount, long *Send_NDisp, MPI_Datatype Send_Datatype, T *RecvBuf, int *Recv_NCount, long *Recv_NDisp, MPI_Datatype Recv_Datatype, MPI_Comm comm)
+{
+   bool use_mpi_gamer_flag = false;
+   if ( (Send_NDisp[MPI_NRank-1] > __INT_MAX__) || ( Recv_NDisp[MPI_NRank-1] > __INT_MAX__ ) )  use_mpi_gamer_flag = true;
+   MPI_Allreduce(MPI_IN_PLACE, &use_mpi_gamer_flag , 1, MPI_C_BOOL, MPI_LOR, MPI_COMM_WORLD);
+
+   // ********************************purely for testing purpose!! Remember to comment this out for distribution!! ********************************
+   Aux_Message( stdout, "  Use MPI_Alltoallv_GAMER wrapper..." );
+   use_mpi_gamer_flag = true;
+   //
+
+   if ( use_mpi_gamer_flag )
+   {
+      MPI_Request *req_send_and_recv = new MPI_Request[2*MPI_NRank];
+
+      for(int r=0; r<MPI_NRank; r++)
+      {
+          MPI_Isend(SendBuf+Send_NDisp[r], (int)Send_NCount[r], Send_Datatype, r, MPI_Rank*MPI_NRank + r       , comm, &req_send_and_recv[2*r  ]);
+          MPI_Irecv(RecvBuf+Recv_NDisp[r], (int)Recv_NCount[r], Recv_Datatype, r,        r*MPI_NRank + MPI_Rank, comm, &req_send_and_recv[2*r+1]);
+      }
+      MPI_Waitall(2*MPI_NRank, req_send_and_recv, MPI_STATUSES_IGNORE);
+
+      delete [] req_send_and_recv;
+   }
+   else
+   {
+      int *Send_NDisp_int  = new int [MPI_NRank];
+      int *Recv_NDisp_int  = new int [MPI_NRank];
+
+      for (int r=0; r<MPI_NRank; r++)
+      {
+         Send_NDisp_int[r]  = (int)Send_NDisp[r];
+         Recv_NDisp_int[r]  = (int)Recv_NDisp[r];
+      }
+
+      MPI_Alltoallv( SendBuf, Send_NCount, Send_NDisp_int, Send_Datatype,
+                     RecvBuf, Recv_NCount, Recv_NDisp_int, Recv_Datatype, comm );   
+
+      delete [] Send_NDisp_int;
+      delete [] Recv_NDisp_int;
+   }
+       
+} // FUNCTION :MPI_Alltoallv_GAMER()
+
+
+// explicit template instantiation
+template void MPI_Alltoallv_GAMER <float>    ( float  *SendBuf, int *Send_NCount, long *Send_NDisp, MPI_Datatype Send_Datatype, float  *RecvBuf, int *Recv_NCount, long *Recv_NDisp, MPI_Datatype Recv_Datatype, MPI_Comm comm );
+template void MPI_Alltoallv_GAMER <double>   ( double *SendBuf, int *Send_NCount, long *Send_NDisp, MPI_Datatype Send_Datatype, double *RecvBuf, int *Recv_NCount, long *Recv_NDisp, MPI_Datatype Recv_Datatype, MPI_Comm comm );
+
+#endif // #ifndef SERIAL
+
+

--- a/src/MPI/MPI_Alltoallv_GAMER.cpp
+++ b/src/MPI/MPI_Alltoallv_GAMER.cpp
@@ -38,7 +38,7 @@ void MPI_Alltoallv_GAMER(T *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Da
    {
       MPI_Request *req_send_and_recv = new MPI_Request[2*MPI_NRank];
 
-// for numbering the MPI_Isend/Irecv tags: since there are total MPI_Rank*MPI_Rank data-transferring tasks, we tag the data-transferring task between rank r_1(send) <--> rank r_2(recv) as number: r_1*MPI_Rank+r_2 
+// for numbering the MPI_Isend/Irecv tags: since there are total MPI_NRank*MPI_NRank data-transferring tasks, we tag the data-transferring task between rank r_1(send) <--> rank r_2(recv) as number: r_1*MPI_Rank+r_2 
       for(int r=0; r<MPI_NRank; r++)
       {
           MPI_Isend(SendBuf+Send_NDisp[r], (int)Send_NCount[r], Send_Datatype, r, MPI_Rank*MPI_NRank + r       , comm, &req_send_and_recv[2*r  ]);

--- a/src/MPI/MPI_Alltoallv_GAMER.cpp
+++ b/src/MPI/MPI_Alltoallv_GAMER.cpp
@@ -34,15 +34,9 @@ void MPI_Alltoallv_GAMER(T *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Da
    if ( (Send_NDisp[MPI_NRank-1] > __INT_MAX__) || ( Recv_NDisp[MPI_NRank-1] > __INT_MAX__ ) )  use_mpi_gamer_flag = true;
    MPI_Allreduce(MPI_IN_PLACE, &use_mpi_gamer_flag , 1, MPI_C_BOOL, MPI_LOR, MPI_COMM_WORLD);
 
-   // ********************************purely for testing purpose!! Remember to comment this out for distribution!! ********************************
-//   use_mpi_gamer_flag = true;
-   //
 
    if ( use_mpi_gamer_flag )
    {
-      // ********************************purely for testing purpose!! Remember to comment this out for distribution!! ********************************
-//      Aux_Message( stdout, "  Use MPI_Alltoallv_GAMER wrapper..." );
-      //
       MPI_Request *req_send_and_recv = new MPI_Request[2*MPI_NRank];
 
       for(int r=0; r<MPI_NRank; r++)

--- a/src/MPI/MPI_Alltoallv_GAMER.cpp
+++ b/src/MPI/MPI_Alltoallv_GAMER.cpp
@@ -38,7 +38,7 @@ void MPI_Alltoallv_GAMER(T *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Da
    {
       MPI_Request *req_send_and_recv = new MPI_Request[2*MPI_NRank];
 
-// for numbering the MPI_Isend/Irecv tags: since there are total MPI_NRank*MPI_NRank data-transferring tasks, we tag the data-transferring task between rank r_1(send) <--> rank r_2(recv) as number: r_1*MPI_Rank+r_2 
+// for numbering the MPI_Isend/Irecv tags: since there are total MPI_NRank*MPI_NRank data-transferring tasks, we tag the data-transferring task between rank r_1(send) <--> rank r_2(recv) by number: r_1*MPI_NRank+r_2 
       for(int r=0; r<MPI_NRank; r++)
       {
           MPI_Isend(SendBuf+Send_NDisp[r], (int)Send_NCount[r], Send_Datatype, r, MPI_Rank*MPI_NRank + r       , comm, &req_send_and_recv[2*r  ]);

--- a/src/MPI/MPI_Alltoallv_GAMER.cpp
+++ b/src/MPI/MPI_Alltoallv_GAMER.cpp
@@ -6,39 +6,39 @@
 
 //-------------------------------------------------------------------------------------------------------
 // Function    :  MPI_Alltoallv_GAMER
-// Description :  wrapper for replacing official MPI_Alltoallv() when the number of elements in Send_NDisp/Recv_NDisp exceed __INT_MAX__
+// Description :  Wrapper for replacing official MPI_Alltoallv() when the numbers of elements in Send_NDisp/Recv_NDisp exceed __INT_MAX__
 //
-// Parameter   :  SendBuf:      data to be send by this rank to other ranks via MPI_Alltoallv
-//                Send_NCount:  number of elements to be sent by each rank to other ranks in SendBuff; length euqals MPI_NRank
-//                Send_NDisp:   displacement indicating the stride where the sent data (to other ranks) starts in SendBuf for each rank;
-//                              length equals to MPI_NRank
-//                Send_Datatype: sent data type for MPI
-//                RecvBuf:      data to be received by this rank from other ranks via MPI_Alltoallv
-//                Recv_NCount:  number of elements to be received by each rank from other ranks in RecvBuff; length euqals MPI_NRank
-//                Recv_NDisp:   displacement indicating the stride where the received data (from other ranks) starts in RecvdBuf for each rank;
-//                              length equals to MPI_NRank
-//                Recv_Datatype: received data type for MPI (MPI_GAMER_REAL/MPI_GAMER_REAL_PAR)
+// Parameter   :  SendBuf:       Data to be sent by this rank to other ranks via MPI_Alltoallv
+//                Send_NCount:   Number of elements to be sent by each rank to other ranks in SendBuf; length equals MPI_NRank
+//                Send_NDisp:    Displacement indicating the stride where the sent data (to other ranks) starts in SendBuf for each rank;
+//                               length equals MPI_NRank
+//                Send_Datatype: Sent data type for MPI
+//                RecvBuf:       Data to be received by this rank from other ranks via MPI_Alltoallv
+//                Recv_NCount:   Number of elements to be received by each rank from other ranks in RecvBuf; length equals MPI_NRank
+//                Recv_NDisp:    Displacement indicating the stride where the received data (from other ranks) starts in RecvdBuf for each rank;
+//                               length equals MPI_NRank
+//                Recv_Datatype: Received data type for MPI (MPI_GAMER_REAL/MPI_GAMER_REAL_PAR)
 //                comm:          MPI communicator
 //-------------------------------------------------------------------------------------------------------
 template<typename T> 
 void MPI_Alltoallv_GAMER(T *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Datatype Send_Datatype, T *RecvBuf, long *Recv_NCount, long *Recv_NDisp, MPI_Datatype Recv_Datatype, MPI_Comm comm)
 {
-   // sanity check for Send_NCount and Recv_NCount
-   for ( int r=0; r<MPI_NRank; r++ )
+// sanity check for Send_NCount and Recv_NCount
+   for (int r=0; r<MPI_NRank; r++)
    {
       if ( Send_NCount[r] > __INT_MAX__ ) Aux_Error(ERROR_INFO, "Send_NCount[%d] (%ld) > __INT_MAX__ (%ld)!!\n", r, Send_NCount[r], (long)__INT_MAX__ );
       if ( Recv_NCount[r] > __INT_MAX__ ) Aux_Error(ERROR_INFO, "Recv_NCount[%d] (%ld) > __INT_MAX__ (%ld)!!\n", r, Recv_NCount[r], (long)__INT_MAX__ );
    }
 
    bool use_mpi_gamer_flag = false;
-   if ( (Send_NDisp[MPI_NRank-1] > __INT_MAX__) || ( Recv_NDisp[MPI_NRank-1] > __INT_MAX__ ) )  use_mpi_gamer_flag = true;
+   if ( ( Send_NDisp[MPI_NRank-1] > __INT_MAX__ ) || ( Recv_NDisp[MPI_NRank-1] > __INT_MAX__ ) )  use_mpi_gamer_flag = true;
    MPI_Allreduce(MPI_IN_PLACE, &use_mpi_gamer_flag , 1, MPI_C_BOOL, MPI_LOR, MPI_COMM_WORLD);
-
 
    if ( use_mpi_gamer_flag )
    {
       MPI_Request *req_send_and_recv = new MPI_Request[2*MPI_NRank];
 
+// for numbering the MPI_Isend/Irecv tags: since there are total MPI_Rank*MPI_Rank data-transferring tasks, we tag the data-transferring task between rank r_1(send) <--> rank r_2(recv) as number: r_1*MPI_Rank+r_2 
       for(int r=0; r<MPI_NRank; r++)
       {
           MPI_Isend(SendBuf+Send_NDisp[r], (int)Send_NCount[r], Send_Datatype, r, MPI_Rank*MPI_NRank + r       , comm, &req_send_and_recv[2*r  ]);
@@ -59,8 +59,8 @@ void MPI_Alltoallv_GAMER(T *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Da
       {
          Send_NCount_int[r] = (int)Send_NCount[r];
          Recv_NCount_int[r] = (int)Recv_NCount[r];
-         Send_NDisp_int[r]  = (int)Send_NDisp[r];
-         Recv_NDisp_int[r]  = (int)Recv_NDisp[r];
+         Send_NDisp_int [r] = (int)Send_NDisp [r];
+         Recv_NDisp_int [r] = (int)Recv_NDisp [r];
       }
 
       MPI_Alltoallv( SendBuf, Send_NCount_int, Send_NDisp_int, Send_Datatype,
@@ -72,7 +72,7 @@ void MPI_Alltoallv_GAMER(T *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_Da
       delete [] Recv_NDisp_int;
    }
        
-} // FUNCTION :MPI_Alltoallv_GAMER()
+} // FUNCTION :MPI_Alltoallv_GAMER
 
 
 // explicit template instantiation

--- a/src/Main/Prepare_PatchData.cpp
+++ b/src/Main/Prepare_PatchData.cpp
@@ -647,7 +647,7 @@ void Prepare_PatchData( const int lv, const double PrepTime, real *OutputCC, rea
 
 
 //    sort PID list and remove duplicate patches
-      Mis_Heapsort( ParMass_NPatch_Dup, ParMass_PID_List, NULL );
+      Mis_Heapsort<int,int>( ParMass_NPatch_Dup, ParMass_PID_List, NULL );
 
       ParMass_NPatch = ( ParMass_NPatch_Dup > 0 ) ? 1 : 0;
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -601,7 +601,7 @@ CPU_FILE    += Buf_AllocateBufferPatch.cpp  Buf_AllocateBufferPatch_Base.cpp  Bu
                Buf_ResetBufferFlux.cpp
 
 CPU_FILE    += MPI_ExchangeBoundaryFlag.cpp  MPI_ExchangeBufferPosition.cpp  MPI_ExchangeData.cpp \
-               Init_MPI.cpp  MPI_Exit.cpp
+               Init_MPI.cpp  MPI_Exit.cpp  MPI_Alltoallv_GAMER.cpp
 
 CPU_FILE    += Output_BoundaryFlagList.cpp  Output_ExchangeDataPatchList.cpp  Output_ExchangeFluxPatchList.cpp \
                Output_ExchangePatchMap.cpp

--- a/src/Makefile_base
+++ b/src/Makefile_base
@@ -253,7 +253,7 @@ CPU_FILE    += Buf_AllocateBufferPatch.cpp  Buf_AllocateBufferPatch_Base.cpp  Bu
                Buf_ResetBufferFlux.cpp
 
 CPU_FILE    += MPI_ExchangeBoundaryFlag.cpp  MPI_ExchangeBufferPosition.cpp  MPI_ExchangeData.cpp \
-               Init_MPI.cpp  MPI_Exit.cpp
+               Init_MPI.cpp  MPI_Exit.cpp MPI_Alltoallv_GAMER.cpp
 
 CPU_FILE    += Output_BoundaryFlagList.cpp  Output_ExchangeDataPatchList.cpp  Output_ExchangeFluxPatchList.cpp \
                Output_ExchangePatchMap.cpp

--- a/src/Makefile_base
+++ b/src/Makefile_base
@@ -253,7 +253,7 @@ CPU_FILE    += Buf_AllocateBufferPatch.cpp  Buf_AllocateBufferPatch_Base.cpp  Bu
                Buf_ResetBufferFlux.cpp
 
 CPU_FILE    += MPI_ExchangeBoundaryFlag.cpp  MPI_ExchangeBufferPosition.cpp  MPI_ExchangeData.cpp \
-               Init_MPI.cpp  MPI_Exit.cpp MPI_Alltoallv_GAMER.cpp
+               Init_MPI.cpp  MPI_Exit.cpp  MPI_Alltoallv_GAMER.cpp
 
 CPU_FILE    += Output_BoundaryFlagList.cpp  Output_ExchangeDataPatchList.cpp  Output_ExchangeFluxPatchList.cpp \
                Output_ExchangePatchMap.cpp

--- a/src/Miscellaneous/Mis_BinarySearch.cpp
+++ b/src/Miscellaneous/Mis_BinarySearch.cpp
@@ -21,11 +21,11 @@
 //                Max   : Maximum array index for searching
 //                Key   : Integer number to search for
 //-------------------------------------------------------------------------------------------------------
-template <typename T>
-int Mis_BinarySearch( const T Array[], int Min, int Max, const T Key )
+template <typename U, typename T>
+U Mis_BinarySearch( const T Array[], U Min, U Max, const T Key )
 {
 
-   int Mid = -1;
+   U Mid = -1;
 
    while ( Min <= Max )
    {
@@ -43,6 +43,10 @@ int Mis_BinarySearch( const T Array[], int Min, int Max, const T Key )
 
 
 // explicit template instantiation
-template int Mis_BinarySearch <int>   ( const int   Array[], int Min, int Max, const int   Key );
-template int Mis_BinarySearch <long>  ( const long  Array[], int Min, int Max, const long  Key );
-template int Mis_BinarySearch <ulong> ( const ulong Array[], int Min, int Max, const ulong Key );
+template int Mis_BinarySearch <int,int>    ( const int   Array[], int Min, int Max, const int   Key );
+template int Mis_BinarySearch <int,long>   ( const long  Array[], int Min, int Max, const long  Key );
+template int Mis_BinarySearch <int,ulong>  ( const ulong Array[], int Min, int Max, const ulong Key );
+
+template long Mis_BinarySearch <long,int>   ( const int   Array[], long Min, long Max, const int   Key );
+template long Mis_BinarySearch <long,long>  ( const long  Array[], long Min, long Max, const long  Key );
+template long Mis_BinarySearch <long,ulong> ( const ulong Array[], long Min, long Max, const ulong Key );

--- a/src/Miscellaneous/Mis_BinarySearch.cpp
+++ b/src/Miscellaneous/Mis_BinarySearch.cpp
@@ -43,9 +43,9 @@ U Mis_BinarySearch( const T Array[], U Min, U Max, const T Key )
 
 
 // explicit template instantiation
-template int Mis_BinarySearch <int,int>    ( const int   Array[], int Min, int Max, const int   Key );
-template int Mis_BinarySearch <int,long>   ( const long  Array[], int Min, int Max, const long  Key );
-template int Mis_BinarySearch <int,ulong>  ( const ulong Array[], int Min, int Max, const ulong Key );
+template int  Mis_BinarySearch <int,int>    ( const int   Array[], int  Min, int  Max, const int   Key );
+template int  Mis_BinarySearch <int,long>   ( const long  Array[], int  Min, int  Max, const long  Key );
+template int  Mis_BinarySearch <int,ulong>  ( const ulong Array[], int  Min, int  Max, const ulong Key );
 
 template long Mis_BinarySearch <long,int>   ( const int   Array[], long Min, long Max, const int   Key );
 template long Mis_BinarySearch <long,long>  ( const long  Array[], long Min, long Max, const long  Key );

--- a/src/Miscellaneous/Mis_BinarySearch_Real.cpp
+++ b/src/Miscellaneous/Mis_BinarySearch_Real.cpp
@@ -27,14 +27,14 @@
 //                Min-1 : if Key <  Array[Min]
 //                Max   : if Key >= Array[Max]
 //-------------------------------------------------------------------------------------------------------
-template <typename T>
-int Mis_BinarySearch_Real( const T Array[], int Min, int Max, const T Key )
+template <typename U, typename T>
+U Mis_BinarySearch_Real( const T Array[], U Min, U Max, const T Key )
 {
 
 // initial check
 #  ifdef GAMER_DEBUG
-   if ( Min < 0 )    Aux_Error( ERROR_INFO, "incorrect input parameter \"Min (%d) < 0\" !!\n", Min );
-   if ( Max <= Min ) Aux_Error( ERROR_INFO, "incorrect input parameters \"Max (%d) <= Min (%d)\" !!\n", Max, Min );
+   if ( Min < 0 )    Aux_Error( ERROR_INFO, "incorrect input parameter \"Min (%ld) < 0\" !!\n", (long)Min );
+   if ( Max <= Min ) Aux_Error( ERROR_INFO, "incorrect input parameters \"Max (%ld) <= Min (%ld)\" !!\n", (long)Max, (long)Min );
 #  endif
 
 
@@ -44,7 +44,7 @@ int Mis_BinarySearch_Real( const T Array[], int Min, int Max, const T Key )
 
 
 // binary search
-   int Idx = -2;
+   U Idx = -2;
 
    while (  ( Idx=(Min+Max)/2 ) != Min  )
    {
@@ -56,11 +56,11 @@ int Mis_BinarySearch_Real( const T Array[], int Min, int Max, const T Key )
 // check whether the found array index is correct
 #  ifdef GAMER_DEBUG
    if ( Idx < Min  ||  Idx >= Max )
-      Aux_Error( ERROR_INFO, "incorrect output index (Idx %d, Min %d, Max%d) !!\n", Idx, Min, Max );
+      Aux_Error( ERROR_INFO, "incorrect output index (Idx %ld, Min %ld, Max%ld) !!\n", (long)Idx, (long)Min, (long)Max );
 
    if (  Array[Idx] > Key  ||  Array[Idx+1] <= Key )
-      Aux_Error( ERROR_INFO, "incorrect output index (Idx %d, ValueL %14.7e, ValueR %14.7e, Key %14.7e) !!\n",
-                 Idx, Array[Idx], Array[Idx+1], Key );
+      Aux_Error( ERROR_INFO, "incorrect output index (Idx %ld, ValueL %14.7e, ValueR %14.7e, Key %14.7e) !!\n",
+                 (long)Idx, Array[Idx], Array[Idx+1], Key );
 #  endif
 
 
@@ -71,5 +71,8 @@ int Mis_BinarySearch_Real( const T Array[], int Min, int Max, const T Key )
 
 
 // explicit template instantiation
-template int Mis_BinarySearch_Real <float>  ( const float  Array[], int Min, int Max, const float  Key );
-template int Mis_BinarySearch_Real <double> ( const double Array[], int Min, int Max, const double Key );
+template int  Mis_BinarySearch_Real <int,float>   ( const float  Array[], int Min,  int Max,  const float  Key );
+template int  Mis_BinarySearch_Real <int,double>  ( const double Array[], int Min,  int Max,  const double Key );
+
+template long Mis_BinarySearch_Real <long,float>  ( const float  Array[], long Min, long Max, const float  Key );
+template long Mis_BinarySearch_Real <long,double> ( const double Array[], long Min, long Max, const double Key );

--- a/src/Miscellaneous/Mis_BinarySearch_Real.cpp
+++ b/src/Miscellaneous/Mis_BinarySearch_Real.cpp
@@ -71,8 +71,8 @@ U Mis_BinarySearch_Real( const T Array[], U Min, U Max, const T Key )
 
 
 // explicit template instantiation
-template int  Mis_BinarySearch_Real <int,float>   ( const float  Array[], int Min,  int Max,  const float  Key );
-template int  Mis_BinarySearch_Real <int,double>  ( const double Array[], int Min,  int Max,  const double Key );
+template int  Mis_BinarySearch_Real <int,float>   ( const float  Array[], int  Min, int  Max, const float  Key );
+template int  Mis_BinarySearch_Real <int,double>  ( const double Array[], int  Min, int  Max, const double Key );
 
 template long Mis_BinarySearch_Real <long,float>  ( const float  Array[], long Min, long Max, const float  Key );
 template long Mis_BinarySearch_Real <long,double> ( const double Array[], long Min, long Max, const double Key );

--- a/src/Miscellaneous/Mis_BinarySearch_Real.cpp
+++ b/src/Miscellaneous/Mis_BinarySearch_Real.cpp
@@ -31,7 +31,7 @@ template <typename U, typename T>
 U Mis_BinarySearch_Real( const T Array[], U Min, U Max, const T Key )
 {
 
-// initial check
+// initial check; force print format as long since typename U can be "int" or "long" 
 #  ifdef GAMER_DEBUG
    if ( Min < 0 )    Aux_Error( ERROR_INFO, "incorrect input parameter \"Min (%ld) < 0\" !!\n", (long)Min );
    if ( Max <= Min ) Aux_Error( ERROR_INFO, "incorrect input parameters \"Max (%ld) <= Min (%ld)\" !!\n", (long)Max, (long)Min );
@@ -53,7 +53,7 @@ U Mis_BinarySearch_Real( const T Array[], U Min, U Max, const T Key )
    }
 
 
-// check whether the found array index is correct
+// check whether the found array index is correct; force print format as long since typename U can be "int" or "long"
 #  ifdef GAMER_DEBUG
    if ( Idx < Min  ||  Idx >= Max )
       Aux_Error( ERROR_INFO, "incorrect output index (Idx %ld, Min %ld, Max%ld) !!\n", (long)Idx, (long)Min, (long)Max );

--- a/src/Miscellaneous/Mis_Heapsort.cpp
+++ b/src/Miscellaneous/Mis_Heapsort.cpp
@@ -1,7 +1,7 @@
 #include "GAMER.h"
 
-template <typename T>
-static void Heapsort_SiftDown( const int L, const int R, T Array[], int IdxTable[] );
+template <typename U, typename T>
+static void Heapsort_SiftDown( const U L, const U R, T Array[], U IdxTable[] );
 
 
 
@@ -20,20 +20,20 @@ static void Heapsort_SiftDown( const int L, const int R, T Array[], int IdxTable
 //                Array    :  Array to be sorted into ascending numerical order
 //                IdxTable :  Index table
 //-------------------------------------------------------------------------------------------------------
-template <typename T>
-void Mis_Heapsort( const int N, T Array[], int IdxTable[] )
+template <typename U, typename T>
+void Mis_Heapsort( const U N, T Array[], U IdxTable[] )
 {
 
 // initialize the IdxTable
    if ( IdxTable != NULL )
-      for (int t=0; t<N; t++)    IdxTable[t] = t;
+      for (U t=0; t<N; t++)    IdxTable[t] = t;
 
 // heap creation
-   for (int L=N/2-1; L>=0; L--)  Heapsort_SiftDown( L, N-1, Array, IdxTable );
+   for (U L=N/2-1; L>=0; L--)  Heapsort_SiftDown<U,T>( L, N-1, Array, IdxTable );
 
 // retirement-and-promotion
    T Buf;
-   for (int R=N-1; R>0; R--)
+   for (U R=N-1; R>0; R--)
    {
       Buf      = Array[R];
       Array[R] = Array[0];
@@ -46,7 +46,7 @@ void Mis_Heapsort( const int N, T Array[], int IdxTable[] )
          IdxTable[0] = Buf;
       }
 
-      Heapsort_SiftDown( 0, R-1, Array, IdxTable );
+      Heapsort_SiftDown<U,T>( 0, R-1, Array, IdxTable );
    }
 
 } // FUNCTION : Mis_Heapsort
@@ -65,14 +65,14 @@ void Mis_Heapsort( const int N, T Array[], int IdxTable[] )
 //                Array    :  Array to be sorted into ascending numerical order
 //                IdxTable :  Index table
 //-------------------------------------------------------------------------------------------------------
-template <typename T>
-void Heapsort_SiftDown( const int L, const int R, T Array[], int IdxTable[] )
+template <typename U, typename T>
+void Heapsort_SiftDown( const U L, const U R, T Array[], U IdxTable[] )
 {
 
-   int  Idx_up    = L;
-   int  Idx_down  = 2*Idx_up + 1;
-   T    Target    = Array[Idx_up];
-   int  TargetIdx = ( IdxTable == NULL ) ? -1 : IdxTable[Idx_up];
+   U  Idx_up    = L;
+   U  Idx_down  = 2*Idx_up + 1;
+   T  Target    = Array[Idx_up];
+   U  TargetIdx = ( IdxTable == NULL ) ? -1 : IdxTable[Idx_up];
 
    while ( Idx_down <= R )
    {
@@ -100,9 +100,15 @@ void Heapsort_SiftDown( const int L, const int R, T Array[], int IdxTable[] )
 
 
 // explicit template instantiation
-template void Mis_Heapsort <int>    ( const int N, int    Array[], int IdxTable[] );
-template void Mis_Heapsort <long>   ( const int N, long   Array[], int IdxTable[] );
-template void Mis_Heapsort <ulong>  ( const int N, ulong  Array[], int IdxTable[] );
-template void Mis_Heapsort <float>  ( const int N, float  Array[], int IdxTable[] );
-template void Mis_Heapsort <double> ( const int N, double Array[], int IdxTable[] );
+template void Mis_Heapsort <int,int>     ( const int N, int    Array[], int IdxTable[] );
+template void Mis_Heapsort <int,long>    ( const int N, long   Array[], int IdxTable[] );
+template void Mis_Heapsort <int,ulong>   ( const int N, ulong  Array[], int IdxTable[] );
+template void Mis_Heapsort <int,float>   ( const int N, float  Array[], int IdxTable[] );
+template void Mis_Heapsort <int,double>  ( const int N, double Array[], int IdxTable[] );
+
+template void Mis_Heapsort <long,int>    ( const long N, int    Array[], long IdxTable[] );
+template void Mis_Heapsort <long,long>   ( const long N, long   Array[], long IdxTable[] );
+template void Mis_Heapsort <long,ulong>  ( const long N, ulong  Array[], long IdxTable[] );
+template void Mis_Heapsort <long,float>  ( const long N, float  Array[], long IdxTable[] );
+template void Mis_Heapsort <long,double> ( const long N, double Array[], long IdxTable[] );
 

--- a/src/Miscellaneous/Mis_Heapsort.cpp
+++ b/src/Miscellaneous/Mis_Heapsort.cpp
@@ -100,11 +100,11 @@ void Heapsort_SiftDown( const U L, const U R, T Array[], U IdxTable[] )
 
 
 // explicit template instantiation
-template void Mis_Heapsort <int,int>     ( const int N, int    Array[], int IdxTable[] );
-template void Mis_Heapsort <int,long>    ( const int N, long   Array[], int IdxTable[] );
-template void Mis_Heapsort <int,ulong>   ( const int N, ulong  Array[], int IdxTable[] );
-template void Mis_Heapsort <int,float>   ( const int N, float  Array[], int IdxTable[] );
-template void Mis_Heapsort <int,double>  ( const int N, double Array[], int IdxTable[] );
+template void Mis_Heapsort <int,int>     ( const int  N, int    Array[], int  IdxTable[] );
+template void Mis_Heapsort <int,long>    ( const int  N, long   Array[], int  IdxTable[] );
+template void Mis_Heapsort <int,ulong>   ( const int  N, ulong  Array[], int  IdxTable[] );
+template void Mis_Heapsort <int,float>   ( const int  N, float  Array[], int  IdxTable[] );
+template void Mis_Heapsort <int,double>  ( const int  N, double Array[], int  IdxTable[] );
 
 template void Mis_Heapsort <long,int>    ( const long N, int    Array[], long IdxTable[] );
 template void Mis_Heapsort <long,long>   ( const long N, long   Array[], long IdxTable[] );

--- a/src/Miscellaneous/Mis_Matching.cpp
+++ b/src/Miscellaneous/Mis_Matching.cpp
@@ -59,13 +59,14 @@ int Mis_Matching_char( const int N, const T Array[], const int M, const T Key[],
 //-------------------------------------------------------------------------------------------------------
 // for int Match[]
 //-------------------------------------------------------------------------------------------------------
-template <typename T>
-int Mis_Matching_int( const int N, const T Array[], const int M, const T Key[], int Match[] )
+template <typename U, typename T>
+int Mis_Matching_int( const U N, const T Array[], const U M, const T Key[], U Match[] )
 {
 
-   int Min = 0, NMatch = 0;
+   U Min      = 0;
+   int NMatch = 0;
 
-   for (int t=0; t<M; t++)
+   for (long t=0; t<M; t++)
    {
       Match[t] = Mis_BinarySearch( Array, Min, N-1, Key[t] );
 
@@ -83,9 +84,13 @@ int Mis_Matching_int( const int N, const T Array[], const int M, const T Key[], 
 
 
 // explicit template instantiation
-template int Mis_Matching_char <int>   ( const int N, const int   Array[], const int M, const int   Key[], char Match[] );
-template int Mis_Matching_char <long>  ( const int N, const long  Array[], const int M, const long  Key[], char Match[] );
-template int Mis_Matching_char <ulong> ( const int N, const ulong Array[], const int M, const ulong Key[], char Match[] );
-template int Mis_Matching_int  <int>   ( const int N, const int   Array[], const int M, const int   Key[], int  Match[] );
-template int Mis_Matching_int  <long>  ( const int N, const long  Array[], const int M, const long  Key[], int  Match[] );
-template int Mis_Matching_int  <ulong> ( const int N, const ulong Array[], const int M, const ulong Key[], int  Match[] );
+template int Mis_Matching_char <int>    ( const int N, const int   Array[], const int M, const int   Key[], char Match[] );
+template int Mis_Matching_char <long>   ( const int N, const long  Array[], const int M, const long  Key[], char Match[] );
+template int Mis_Matching_char <ulong>  ( const int N, const ulong Array[], const int M, const ulong Key[], char Match[] );
+template int Mis_Matching_int  <int,int>    ( const int N, const int   Array[], const int M, const int   Key[], int  Match[] );
+template int Mis_Matching_int  <int,long>   ( const int N, const long  Array[], const int M, const long  Key[], int  Match[] );
+template int Mis_Matching_int  <int,ulong>  ( const int N, const ulong Array[], const int M, const ulong Key[], int  Match[] );
+
+template int Mis_Matching_int  <long,int>   ( const long N, const int   Array[], const long M, const int   Key[], long  Match[] );
+template int Mis_Matching_int  <long,long>  ( const long N, const long  Array[], const long M, const long  Key[], long  Match[] );
+template int Mis_Matching_int  <long,ulong> ( const long N, const ulong Array[], const long M, const ulong Key[], long  Match[] );

--- a/src/Miscellaneous/Mis_Matching.cpp
+++ b/src/Miscellaneous/Mis_Matching.cpp
@@ -60,11 +60,11 @@ int Mis_Matching_char( const int N, const T Array[], const int M, const T Key[],
 // for int Match[]
 //-------------------------------------------------------------------------------------------------------
 template <typename U, typename T>
-int Mis_Matching_int( const U N, const T Array[], const U M, const T Key[], U Match[] )
+U Mis_Matching_int( const U N, const T Array[], const U M, const T Key[], U Match[] )
 {
 
-   U Min      = 0;
-   int NMatch = 0;
+   U Min    = 0;
+   U NMatch = 0;
 
    for (U t=0; t<M; t++)
    {
@@ -84,13 +84,13 @@ int Mis_Matching_int( const U N, const T Array[], const U M, const T Key[], U Ma
 
 
 // explicit template instantiation
-template int Mis_Matching_char <int>    ( const int N, const int   Array[], const int M, const int   Key[], char Match[] );
-template int Mis_Matching_char <long>   ( const int N, const long  Array[], const int M, const long  Key[], char Match[] );
-template int Mis_Matching_char <ulong>  ( const int N, const ulong Array[], const int M, const ulong Key[], char Match[] );
-template int Mis_Matching_int  <int,int>    ( const int N, const int   Array[], const int M, const int   Key[], int  Match[] );
-template int Mis_Matching_int  <int,long>   ( const int N, const long  Array[], const int M, const long  Key[], int  Match[] );
-template int Mis_Matching_int  <int,ulong>  ( const int N, const ulong Array[], const int M, const ulong Key[], int  Match[] );
+template int  Mis_Matching_char <int>        ( const int N,  const int   Array[], const int M,  const int   Key[], char Match[]  );
+template int  Mis_Matching_char <long>       ( const int N,  const long  Array[], const int M,  const long  Key[], char Match[]  );
+template int  Mis_Matching_char <ulong>      ( const int N,  const ulong Array[], const int M,  const ulong Key[], char Match[]  );
+template int  Mis_Matching_int  <int,int>    ( const int N,  const int   Array[], const int M,  const int   Key[], int  Match[]  );
+template int  Mis_Matching_int  <int,long>   ( const int N,  const long  Array[], const int M,  const long  Key[], int  Match[]  );
+template int  Mis_Matching_int  <int,ulong>  ( const int N,  const ulong Array[], const int M,  const ulong Key[], int  Match[]  );
 
-template int Mis_Matching_int  <long,int>   ( const long N, const int   Array[], const long M, const int   Key[], long  Match[] );
-template int Mis_Matching_int  <long,long>  ( const long N, const long  Array[], const long M, const long  Key[], long  Match[] );
-template int Mis_Matching_int  <long,ulong> ( const long N, const ulong Array[], const long M, const ulong Key[], long  Match[] );
+template long Mis_Matching_int  <long,int>   ( const long N, const int   Array[], const long M, const int   Key[], long  Match[] );
+template long Mis_Matching_int  <long,long>  ( const long N, const long  Array[], const long M, const long  Key[], long  Match[] );
+template long Mis_Matching_int  <long,ulong> ( const long N, const ulong Array[], const long M, const ulong Key[], long  Match[] );

--- a/src/Miscellaneous/Mis_Matching.cpp
+++ b/src/Miscellaneous/Mis_Matching.cpp
@@ -84,13 +84,13 @@ U Mis_Matching_int( const U N, const T Array[], const U M, const T Key[], U Matc
 
 
 // explicit template instantiation
-template int  Mis_Matching_char <int>        ( const int N,  const int   Array[], const int M,  const int   Key[], char Match[]  );
-template int  Mis_Matching_char <long>       ( const int N,  const long  Array[], const int M,  const long  Key[], char Match[]  );
-template int  Mis_Matching_char <ulong>      ( const int N,  const ulong Array[], const int M,  const ulong Key[], char Match[]  );
-template int  Mis_Matching_int  <int,int>    ( const int N,  const int   Array[], const int M,  const int   Key[], int  Match[]  );
-template int  Mis_Matching_int  <int,long>   ( const int N,  const long  Array[], const int M,  const long  Key[], int  Match[]  );
-template int  Mis_Matching_int  <int,ulong>  ( const int N,  const ulong Array[], const int M,  const ulong Key[], int  Match[]  );
+template int  Mis_Matching_char <int>        ( const int N,  const int   Array[], const int  M, const int   Key[], char Match[] );
+template int  Mis_Matching_char <long>       ( const int N,  const long  Array[], const int  M, const long  Key[], char Match[] );
+template int  Mis_Matching_char <ulong>      ( const int N,  const ulong Array[], const int  M, const ulong Key[], char Match[] );
+template int  Mis_Matching_int  <int,int>    ( const int N,  const int   Array[], const int  M, const int   Key[], int  Match[] );
+template int  Mis_Matching_int  <int,long>   ( const int N,  const long  Array[], const int  M, const long  Key[], int  Match[] );
+template int  Mis_Matching_int  <int,ulong>  ( const int N,  const ulong Array[], const int  M, const ulong Key[], int  Match[] );
 
-template long Mis_Matching_int  <long,int>   ( const long N, const int   Array[], const long M, const int   Key[], long  Match[] );
-template long Mis_Matching_int  <long,long>  ( const long N, const long  Array[], const long M, const long  Key[], long  Match[] );
-template long Mis_Matching_int  <long,ulong> ( const long N, const ulong Array[], const long M, const ulong Key[], long  Match[] );
+template long Mis_Matching_int  <long,int>   ( const long N, const int   Array[], const long M, const int   Key[], long Match[] );
+template long Mis_Matching_int  <long,long>  ( const long N, const long  Array[], const long M, const long  Key[], long Match[] );
+template long Mis_Matching_int  <long,ulong> ( const long N, const ulong Array[], const long M, const ulong Key[], long Match[] );

--- a/src/Miscellaneous/Mis_Matching.cpp
+++ b/src/Miscellaneous/Mis_Matching.cpp
@@ -66,7 +66,7 @@ int Mis_Matching_int( const U N, const T Array[], const U M, const T Key[], U Ma
    U Min      = 0;
    int NMatch = 0;
 
-   for (long t=0; t<M; t++)
+   for (U t=0; t<M; t++)
    {
       Match[t] = Mis_BinarySearch( Array, Min, N-1, Key[t] );
 

--- a/src/Model_Hydro/MHD_LB_Refine_GetCoarseFineInterfaceBField.cpp
+++ b/src/Model_Hydro/MHD_LB_Refine_GetCoarseFineInterfaceBField.cpp
@@ -155,11 +155,11 @@ void MHD_LB_Refine_GetCoarseFineInterfaceBField(
 //    --> but it's not a real issue since the mapped PID is deterministic
       Mis_Heapsort( SendEachRank_N[r], RecvPtr_LBIdx, RecvPtr_LBIdx_IdxTable );
 
-      Mis_Matching_int( amr->NPatchComma[SonLv][1], amr->LB->IdxList_Real[SonLv], SendEachRank_N[r], RecvPtr_LBIdx, Match );
+      Mis_Matching_int( (long)amr->NPatchComma[SonLv][1], amr->LB->IdxList_Real[SonLv], SendEachRank_N[r], RecvPtr_LBIdx, Match );
 
 //    all target patches must be found
 #     ifdef GAMER_DEBUG
-      for (long t=0; long<SendEachRank_N[r]; t++)
+      for (long t=0; t<SendEachRank_N[r]; t++)
          if ( Match[t] == -1L )
             Aux_Error( ERROR_INFO, "SonLv %d, TRank %d, LBIdx %ld found no matching patches !!\n",
                        SonLv, r, RecvPtr_LBIdx[t] );

--- a/src/Model_Hydro/MHD_LB_Refine_GetCoarseFineInterfaceBField.cpp
+++ b/src/Model_Hydro/MHD_LB_Refine_GetCoarseFineInterfaceBField.cpp
@@ -37,9 +37,9 @@ void MHD_LB_Refine_GetCoarseFineInterfaceBField(
 
    int   MemSize              [MPI_NRank];
    long  RecvEachRank_N       [MPI_NRank];
-   long  SendEachRank_N       [MPI_NRank];
    int  *RecvEachRank_SibID   [MPI_NRank];
    long *RecvEachRank_SibLBIdx[MPI_NRank];
+   long  SendEachRank_N       [MPI_NRank];
    int  *SendEachRank_SibID   [MPI_NRank];
    int  *SendEachRank_PID     [MPI_NRank];
 
@@ -133,11 +133,11 @@ void MHD_LB_Refine_GetCoarseFineInterfaceBField(
 
 
 // 2.2. send --> recv
-   MPI_Alltoallv( SendBuf_SibID, Send_NList, Send_Disp, MPI_INT,
-                  RecvBuf_SibID, Recv_NList, Recv_Disp, MPI_INT,  MPI_COMM_WORLD );
+   MPI_Alltoallv_GAMER( SendBuf_SibID, Send_NList, Send_Disp, MPI_INT,
+                        RecvBuf_SibID, Recv_NList, Recv_Disp, MPI_INT,  MPI_COMM_WORLD );
 
-   MPI_Alltoallv( SendBuf_LBIdx, Send_NList, Send_Disp, MPI_LONG,
-                  RecvBuf_LBIdx, Recv_NList, Recv_Disp, MPI_LONG, MPI_COMM_WORLD );
+   MPI_Alltoallv_GAMER( SendBuf_LBIdx, Send_NList, Send_Disp, MPI_LONG,
+                        RecvBuf_LBIdx, Recv_NList, Recv_Disp, MPI_LONG, MPI_COMM_WORLD );
 
 
 // 2.3. record the received info
@@ -160,7 +160,7 @@ void MHD_LB_Refine_GetCoarseFineInterfaceBField(
 //    all target patches must be found
 #     ifdef GAMER_DEBUG
       for (long t=0; long<SendEachRank_N[r]; t++)
-         if ( Match[t] == -1 )
+         if ( Match[t] == -1L )
             Aux_Error( ERROR_INFO, "SonLv %d, TRank %d, LBIdx %ld found no matching patches !!\n",
                        SonLv, r, RecvPtr_LBIdx[t] );
 #     endif

--- a/src/Model_Hydro/MHD_LB_Refine_GetCoarseFineInterfaceBField.cpp
+++ b/src/Model_Hydro/MHD_LB_Refine_GetCoarseFineInterfaceBField.cpp
@@ -94,8 +94,10 @@ void MHD_LB_Refine_GetCoarseFineInterfaceBField(
 
 
 // 2. set the parameters for sending fine-grid B field to other ranks
-   int   Send_Disp[MPI_NRank], Recv_Disp[MPI_NRank], Send_NList[MPI_NRank], Recv_NList[MPI_NRank];
-   int   Send_NTotal, Recv_NTotal, Counter;
+   int   Send_NList[MPI_NRank], Recv_NList[MPI_NRank];
+   int   Counter;
+   long  Send_NTotal, Recv_NTotal;
+   long  Send_Disp[MPI_NRank], Recv_Disp[MPI_NRank];
    int  *SendBuf_SibID=NULL, *RecvBuf_SibID=NULL;
    long *SendBuf_LBIdx=NULL, *RecvBuf_LBIdx=NULL;
 
@@ -105,15 +107,15 @@ void MHD_LB_Refine_GetCoarseFineInterfaceBField(
    memcpy( Send_NList, RecvEachRank_N, MPI_NRank*sizeof(int) );
    memcpy( Recv_NList, SendEachRank_N, MPI_NRank*sizeof(int) );
 
-   Send_Disp[0] = 0;
-   Recv_Disp[0] = 0;
+   Send_Disp[0] = 0L;
+   Recv_Disp[0] = 0L;
    for (int r=1; r<MPI_NRank; r++)
    {
-      Send_Disp[r] = Send_Disp[r-1] + Send_NList[r-1];
-      Recv_Disp[r] = Recv_Disp[r-1] + Recv_NList[r-1];
+      Send_Disp[r] = Send_Disp[r-1] + (long)Send_NList[r-1];
+      Recv_Disp[r] = Recv_Disp[r-1] + (long)Recv_NList[r-1];
    }
-   Send_NTotal = Send_Disp[MPI_NRank-1] + Send_NList[MPI_NRank-1];
-   Recv_NTotal = Recv_Disp[MPI_NRank-1] + Recv_NList[MPI_NRank-1];
+   Send_NTotal = Send_Disp[MPI_NRank-1] + (long)Send_NList[MPI_NRank-1];
+   Recv_NTotal = Recv_Disp[MPI_NRank-1] + (long)Recv_NList[MPI_NRank-1];
 
    SendBuf_SibID = new int  [Send_NTotal];
    RecvBuf_SibID = new int  [Recv_NTotal];
@@ -201,17 +203,17 @@ void MHD_LB_Refine_GetCoarseFineInterfaceBField(
        Recv_NList[r] = RecvEachRank_N[r]*SQR( PS2 );
    }
 
-   Send_Disp[0] = 0;
-   Recv_Disp[0] = 0;
+   Send_Disp[0] = 0L;
+   Recv_Disp[0] = 0L;
 
    for (int r=1; r<MPI_NRank; r++)
    {
-      Send_Disp[r] = Send_Disp[r-1] + Send_NList[r-1];
-      Recv_Disp[r] = Recv_Disp[r-1] + Recv_NList[r-1];
+      Send_Disp[r] = Send_Disp[r-1] + (long)Send_NList[r-1];
+      Recv_Disp[r] = Recv_Disp[r-1] + (long)Recv_NList[r-1];
    }
 
-   Send_NTotal = Send_Disp[ MPI_NRank-1 ] + Send_NList[ MPI_NRank-1 ];
-   Recv_NTotal = Recv_Disp[ MPI_NRank-1 ] + Recv_NList[ MPI_NRank-1 ];
+   Send_NTotal = Send_Disp[ MPI_NRank-1 ] + (long)Send_NList[ MPI_NRank-1 ];
+   Recv_NTotal = Recv_Disp[ MPI_NRank-1 ] + (long)Recv_NList[ MPI_NRank-1 ];
 
    SendBuf_FineB = new real [Send_NTotal];
    RecvBuf_FineB = new real [Recv_NTotal];
@@ -275,13 +277,8 @@ void MHD_LB_Refine_GetCoarseFineInterfaceBField(
 
 
 // 3.3. invoke MPI
-#  ifdef FLOAT8
-   MPI_Alltoallv( SendBuf_FineB, Send_NList, Send_Disp, MPI_DOUBLE,
-                  RecvBuf_FineB, Recv_NList, Recv_Disp, MPI_DOUBLE, MPI_COMM_WORLD );
-#  else
-   MPI_Alltoallv( SendBuf_FineB, Send_NList, Send_Disp, MPI_FLOAT,
-                  RecvBuf_FineB, Recv_NList, Recv_Disp, MPI_FLOAT,  MPI_COMM_WORLD );
-#  endif
+   MPI_Alltoallv_GAMER( SendBuf_FineB, Send_NList, Send_Disp, MPI_GAMER_REAL,
+                        RecvBuf_FineB, Recv_NList, Recv_Disp, MPI_GAMER_REAL, MPI_COMM_WORLD );
 
 
 // 3.4. set the data to be returned by this function

--- a/src/Model_Hydro/MHD_LB_Refine_GetCoarseFineInterfaceBField.cpp
+++ b/src/Model_Hydro/MHD_LB_Refine_GetCoarseFineInterfaceBField.cpp
@@ -175,7 +175,7 @@ void MHD_LB_Refine_GetCoarseFineInterfaceBField(
          SendEachRank_SibID[r][t] = RecvPtr_SibID[t];
 
 //       use index table since RecvPtr_LBIdx[] has been sorted
-         const int sorted_idx = RecvPtr_LBIdx_IdxTable[t];
+         const long sorted_idx = RecvPtr_LBIdx_IdxTable[t];
          SendEachRank_PID[r][sorted_idx]  = amr->LB->IdxList_Real_IdxTable[SonLv][ Match[t] ];
          SendEachRank_PID[r][sorted_idx] -= SendEachRank_PID[r][sorted_idx] % 8; // store the PID with LocalID=0
       }

--- a/src/Output/Output_BasePowerSpectrum.cpp
+++ b/src/Output/Output_BasePowerSpectrum.cpp
@@ -97,8 +97,8 @@ void Output_BasePowerSpectrum( const char *FileName, const long TVar )
 
    int  *List_PID    [MPI_NRank];   // PID of each patch slice sent to each rank
    int  *List_k      [MPI_NRank];   // local z coordinate of each patch slice sent to each rank
-   int   List_NSend  [MPI_NRank];   // size of data sent to each rank
-   int   List_NRecv  [MPI_NRank];   // size of data received from each rank
+   long  List_NSend  [MPI_NRank];   // size of data sent to each rank
+   long  List_NRecv  [MPI_NRank];   // size of data received from each rank
    const bool ForPoisson  = false;  // preparing the density field for the Poisson solver
    const bool InPlacePad  = true;   // pad the array for in-place real-to-complex FFT
 

--- a/src/Particle/LoadBalance/Par_LB_CollectParticle2OneLevel.cpp
+++ b/src/Particle/LoadBalance/Par_LB_CollectParticle2OneLevel.cpp
@@ -250,12 +250,13 @@ void Par_LB_CollectParticle2OneLevel( const int FaLv, const long AttBitIdx, cons
 
 // 1-2. allocate the send buffers
 // both NSendPatchTotal and NSendParTotal do NOT include patches without particles
-   int NSendPatchTotal=0, NSendParTotal=0;
+   int  NSendPatchTotal = 0;
+   long NSendParTotal   = 0L;
 
    for (int r=0; r<MPI_NRank; r++)
    {
       NSendPatchTotal += NPatchForEachRank[r];
-      NSendParTotal   += NParForEachRank  [r];
+      NSendParTotal   += (long)NParForEachRank[r];
    }
 
    SendBuf_NParEachPatch  = new int  [NSendPatchTotal];
@@ -385,7 +386,8 @@ void Par_LB_CollectParticle2OneLevel( const int FaLv, const long AttBitIdx, cons
    const bool Exchange_NPatchEachRank_Yes = true;
    const bool Exchange_LBIdxEachRank_Yes  = true;
    const bool Exchange_ParDataEachRank    = !JustCountNPar;
-   int  NRecvPatchTotal, NRecvParTotal;
+   int  NRecvPatchTotal;
+   long NRecvParTotal;
 
    char Timer_Comment[50];
    sprintf( Timer_Comment, "%3d %15s", FaLv, "Par_Collect" );

--- a/src/Particle/LoadBalance/Par_LB_CollectParticle2OneLevel.cpp
+++ b/src/Particle/LoadBalance/Par_LB_CollectParticle2OneLevel.cpp
@@ -255,8 +255,8 @@ void Par_LB_CollectParticle2OneLevel( const int FaLv, const long AttBitIdx, cons
 
    for (int r=0; r<MPI_NRank; r++)
    {
-      NSendPatchTotal += NPatchForEachRank[r];
-      NSendParTotal   += (long)NParForEachRank[r];
+      NSendPatchTotal +=       NPatchForEachRank[r];
+      NSendParTotal   += (long)NParForEachRank  [r];
    }
 
    SendBuf_NParEachPatch  = new int  [NSendPatchTotal];

--- a/src/Particle/LoadBalance/Par_LB_CollectParticleFromRealPatch.cpp
+++ b/src/Particle/LoadBalance/Par_LB_CollectParticleFromRealPatch.cpp
@@ -169,7 +169,8 @@ void Par_LB_CollectParticleFromRealPatch( const int lv, const long AttBitIdx,
    int  *SendBuf_NParEachPatch = new int  [Real_NPatchTotal];
    long *SendBuf_Offset        = new long [Real_NPatchTotal];
 
-   int PID, NParThisPatch, NSendParTotal = 0;
+   int PID, NParThisPatch;
+   long NSendParTotal = 0L;
 
 // loop over all target real patches
 #  pragma omp parallel for private( PID, NParThisPatch ) reduction( +:NSendParTotal ) schedule( PAR_OMP_SCHED, PAR_OMP_SCHED_CHUNK )
@@ -187,7 +188,7 @@ void Par_LB_CollectParticleFromRealPatch( const int lv, const long AttBitIdx,
                     NParThisPatch, lv, PID );
 #     endif
 
-      NSendParTotal            += NParThisPatch;
+      NSendParTotal            += (long)NParThisPatch;
       SendBuf_NParEachPatch[t]  = NParThisPatch;
    } // for (int t=0; t<Real_NPatchTotal; t++)
 
@@ -281,7 +282,8 @@ void Par_LB_CollectParticleFromRealPatch( const int lv, const long AttBitIdx,
    long *SendBuf_LBIdxEachRank    = NULL;   // useless and does not need to be allocated
    long *RecvBuf_LBIdxEachRank    = NULL;   // useless and will not be allocated by Par_LB_SendParticleData
 
-   int NRecvPatchTotal, NRecvParTotal;  // returned from Par_LB_SendParticleData
+   int  NRecvPatchTotal; // returned from Par_LB_SendParticleData
+   long NRecvParTotal;   // returned from Par_LB_SendParticleData
 
 // note that we don't exchange NPatchEachRank (which is already known) and LBIdxEachRank (which is useless here)
    Par_LB_SendParticleData(

--- a/src/Particle/LoadBalance/Par_LB_CollectParticleFromRealPatch.cpp
+++ b/src/Particle/LoadBalance/Par_LB_CollectParticleFromRealPatch.cpp
@@ -282,8 +282,8 @@ void Par_LB_CollectParticleFromRealPatch( const int lv, const long AttBitIdx,
    long *SendBuf_LBIdxEachRank    = NULL;   // useless and does not need to be allocated
    long *RecvBuf_LBIdxEachRank    = NULL;   // useless and will not be allocated by Par_LB_SendParticleData
 
-   int  NRecvPatchTotal; // returned from Par_LB_SendParticleData
-   long NRecvParTotal;   // returned from Par_LB_SendParticleData
+   int  NRecvPatchTotal;                    // returned from Par_LB_SendParticleData
+   long NRecvParTotal;                      // returned from Par_LB_SendParticleData
 
 // note that we don't exchange NPatchEachRank (which is already known) and LBIdxEachRank (which is useless here)
    Par_LB_SendParticleData(

--- a/src/Particle/LoadBalance/Par_LB_CollectParticleFromRealPatch.cpp
+++ b/src/Particle/LoadBalance/Par_LB_CollectParticleFromRealPatch.cpp
@@ -169,7 +169,7 @@ void Par_LB_CollectParticleFromRealPatch( const int lv, const long AttBitIdx,
    int  *SendBuf_NParEachPatch = new int  [Real_NPatchTotal];
    long *SendBuf_Offset        = new long [Real_NPatchTotal];
 
-   int PID, NParThisPatch;
+   int  PID, NParThisPatch;
    long NSendParTotal = 0L;
 
 // loop over all target real patches
@@ -189,7 +189,7 @@ void Par_LB_CollectParticleFromRealPatch( const int lv, const long AttBitIdx,
 #     endif
 
       NSendParTotal            += (long)NParThisPatch;
-      SendBuf_NParEachPatch[t]  = NParThisPatch;
+      SendBuf_NParEachPatch[t]  =       NParThisPatch;
    } // for (int t=0; t<Real_NPatchTotal; t++)
 
 // get the array offset of each patch (mainly for the OpenMP parallelization)

--- a/src/Particle/LoadBalance/Par_LB_ExchangeParticleBetweenPatch.cpp
+++ b/src/Particle/LoadBalance/Par_LB_ExchangeParticleBetweenPatch.cpp
@@ -132,7 +132,7 @@ void Par_LB_ExchangeParticleBetweenPatch( const int lv,
 #     endif
 
       NSendParTotal            += (long)NParThisPatch;
-      SendBuf_NParEachPatch[t]  = NParThisPatch;
+      SendBuf_NParEachPatch[t]  =       NParThisPatch;
    } // for (int t=0; t<Send_NPatchTotal; t++)
 
 

--- a/src/Particle/LoadBalance/Par_LB_ExchangeParticleBetweenPatch.cpp
+++ b/src/Particle/LoadBalance/Par_LB_ExchangeParticleBetweenPatch.cpp
@@ -116,7 +116,8 @@ void Par_LB_ExchangeParticleBetweenPatch( const int lv,
 // 1. get the number of particles to be sent
    int *SendBuf_NParEachPatch = new int [Send_NPatchTotal];
 
-   int PID, NParThisPatch, NSendParTotal = 0;
+   int  PID, NParThisPatch;
+   long NSendParTotal = 0L;
 
 // loop over all target send patches
    for (int t=0; t<Send_NPatchTotal; t++)
@@ -130,7 +131,7 @@ void Par_LB_ExchangeParticleBetweenPatch( const int lv,
                     NParThisPatch, lv, PID );
 #     endif
 
-      NSendParTotal            += NParThisPatch;
+      NSendParTotal            += (long)NParThisPatch;
       SendBuf_NParEachPatch[t]  = NParThisPatch;
    } // for (int t=0; t<Send_NPatchTotal; t++)
 
@@ -193,7 +194,8 @@ void Par_LB_ExchangeParticleBetweenPatch( const int lv,
    long *SendBuf_LBIdxEachRank    = NULL;    // useless and does not need to be allocated
    long *RecvBuf_LBIdxEachRank    = NULL;    // useless and will not be allocated by Par_LB_SendParticleData
 
-   int NRecvPatchTotal, NRecvParTotal;       // returned from Par_LB_SendParticleData
+   int  NRecvPatchTotal;     // returned from Par_LB_SendParticleData
+   long NRecvParTotal;       // returned from Par_LB_SendParticleData
 
 // note that we don't exchange NPatchEachRank (which is already known) and LBIdxEachRank (which is useless here)
    Par_LB_SendParticleData(

--- a/src/Particle/LoadBalance/Par_LB_ExchangeParticleBetweenPatch.cpp
+++ b/src/Particle/LoadBalance/Par_LB_ExchangeParticleBetweenPatch.cpp
@@ -194,8 +194,8 @@ void Par_LB_ExchangeParticleBetweenPatch( const int lv,
    long *SendBuf_LBIdxEachRank    = NULL;    // useless and does not need to be allocated
    long *RecvBuf_LBIdxEachRank    = NULL;    // useless and will not be allocated by Par_LB_SendParticleData
 
-   int  NRecvPatchTotal;     // returned from Par_LB_SendParticleData
-   long NRecvParTotal;       // returned from Par_LB_SendParticleData
+   int  NRecvPatchTotal;                     // returned from Par_LB_SendParticleData
+   long NRecvParTotal;                       // returned from Par_LB_SendParticleData
 
 // note that we don't exchange NPatchEachRank (which is already known) and LBIdxEachRank (which is useless here)
    Par_LB_SendParticleData(

--- a/src/Particle/LoadBalance/Par_LB_RecordExchangeParticlePatchID.cpp
+++ b/src/Particle/LoadBalance/Par_LB_RecordExchangeParticlePatchID.cpp
@@ -215,7 +215,7 @@ void Par_LB_RecordExchangeParticlePatchID( const int MainLv )
 //    4-1. R2B list
       Buff_NPatchTotal_Dup = amr->Par->R2B_Buff_NPatchTotal[MainLv][t];
 
-      Mis_Heapsort( Buff_NPatchTotal_Dup, amr->Par->R2B_Buff_PIDList[MainLv][t], NULL );
+      Mis_Heapsort<int,int>( Buff_NPatchTotal_Dup, amr->Par->R2B_Buff_PIDList[MainLv][t], NULL );
 
       amr->Par->R2B_Buff_NPatchTotal[MainLv][t] = ( Buff_NPatchTotal_Dup > 0 ) ? 1 : 0;
 
@@ -235,7 +235,7 @@ void Par_LB_RecordExchangeParticlePatchID( const int MainLv )
 //    4-2. B2R list
       Buff_NPatchTotal_Dup = amr->Par->B2R_Buff_NPatchTotal[MainLv][t];
 
-      Mis_Heapsort( Buff_NPatchTotal_Dup, amr->Par->B2R_Buff_PIDList[MainLv][t], NULL );
+      Mis_Heapsort<int,int>( Buff_NPatchTotal_Dup, amr->Par->B2R_Buff_PIDList[MainLv][t], NULL );
 
       amr->Par->B2R_Buff_NPatchTotal[MainLv][t] = ( Buff_NPatchTotal_Dup > 0 ) ? 1 : 0;
 

--- a/src/Particle/LoadBalance/Par_LB_SendParticleData.cpp
+++ b/src/Particle/LoadBalance/Par_LB_SendParticleData.cpp
@@ -148,8 +148,8 @@ void Par_LB_SendParticleData( const int NParAtt, int *SendBuf_NPatchEachRank, in
 // 4. collect particle attributes from all ranks
    if ( Exchange_ParDataEachRank )
    {
-      int  *SendCount_ParDataEachPatch = new int  [MPI_NRank];
-      int  *RecvCount_ParDataEachPatch = new int  [MPI_NRank];
+      long *SendCount_ParDataEachPatch = new long [MPI_NRank];
+      long *RecvCount_ParDataEachPatch = new long [MPI_NRank];
       long *SendDisp_ParDataEachPatch  = new long [MPI_NRank];
       long *RecvDisp_ParDataEachPatch  = new long [MPI_NRank];
 
@@ -159,19 +159,19 @@ void Par_LB_SendParticleData( const int NParAtt, int *SendBuf_NPatchEachRank, in
 
       for (int r=0; r<MPI_NRank; r++)
       {
-         SendCount_ParDataEachPatch[r] = 0;
-         RecvCount_ParDataEachPatch[r] = 0;
+         SendCount_ParDataEachPatch[r] = 0L;
+         RecvCount_ParDataEachPatch[r] = 0L;
 
          SendPtr = SendBuf_NParEachPatch + SendDisp_NParEachPatch[r];
          RecvPtr = RecvBuf_NParEachPatch + RecvDisp_NParEachPatch[r];
 
-         for (int p=0; p<SendBuf_NPatchEachRank[r]; p++)    SendCount_ParDataEachPatch[r] += SendPtr[p];
-         for (int p=0; p<RecvBuf_NPatchEachRank[r]; p++)    RecvCount_ParDataEachPatch[r] += RecvPtr[p];
+         for (int p=0; p<SendBuf_NPatchEachRank[r]; p++)    SendCount_ParDataEachPatch[r] += (long)SendPtr[p];
+         for (int p=0; p<RecvBuf_NPatchEachRank[r]; p++)    RecvCount_ParDataEachPatch[r] += (long)RecvPtr[p];
 
          NRecvParTotal += RecvCount_ParDataEachPatch[r];
 
-         SendCount_ParDataEachPatch[r] *= NParAtt;
-         RecvCount_ParDataEachPatch[r] *= NParAtt;
+         SendCount_ParDataEachPatch[r] *= (long)NParAtt;
+         RecvCount_ParDataEachPatch[r] *= (long)NParAtt;
       }
 
 //    send/recv displacement
@@ -179,8 +179,8 @@ void Par_LB_SendParticleData( const int NParAtt, int *SendBuf_NPatchEachRank, in
       RecvDisp_ParDataEachPatch[0] = 0L;
       for (int r=1; r<MPI_NRank; r++)
       {
-         SendDisp_ParDataEachPatch[r] = SendDisp_ParDataEachPatch[r-1] + (long)SendCount_ParDataEachPatch[r-1];
-         RecvDisp_ParDataEachPatch[r] = RecvDisp_ParDataEachPatch[r-1] + (long)RecvCount_ParDataEachPatch[r-1];
+         SendDisp_ParDataEachPatch[r] = SendDisp_ParDataEachPatch[r-1] + SendCount_ParDataEachPatch[r-1];
+         RecvDisp_ParDataEachPatch[r] = RecvDisp_ParDataEachPatch[r-1] + RecvCount_ParDataEachPatch[r-1];
       }
 
 //    reuse the MPI recv buffer declared in LB_GetBufferData for better MPI performance

--- a/src/Particle/LoadBalance/Par_LB_SendParticleData.cpp
+++ b/src/Particle/LoadBalance/Par_LB_SendParticleData.cpp
@@ -50,9 +50,9 @@
 //                NRecvPatchTotal, NRecvPatchTotal
 //-------------------------------------------------------------------------------------------------------
 void Par_LB_SendParticleData( const int NParAtt, int *SendBuf_NPatchEachRank, int *SendBuf_NParEachPatch,
-                              long *SendBuf_LBIdxEachPatch, real *SendBuf_ParDataEachPatch, const int NSendParTotal,
+                              long *SendBuf_LBIdxEachPatch, real *SendBuf_ParDataEachPatch, const long NSendParTotal,
                               int *&RecvBuf_NPatchEachRank, int *&RecvBuf_NParEachPatch, long *&RecvBuf_LBIdxEachPatch,
-                              real *&RecvBuf_ParDataEachPatch, int &NRecvPatchTotal, int &NRecvParTotal,
+                              real *&RecvBuf_ParDataEachPatch, int &NRecvPatchTotal, long &NRecvParTotal,
                               const bool Exchange_NPatchEachRank, const bool Exchange_LBIdxEachRank,
                               const bool Exchange_ParDataEachRank, Timer_t *Timer, const char *Timer_Comment )
 {
@@ -148,14 +148,14 @@ void Par_LB_SendParticleData( const int NParAtt, int *SendBuf_NPatchEachRank, in
 // 4. collect particle attributes from all ranks
    if ( Exchange_ParDataEachRank )
    {
-      int *SendCount_ParDataEachPatch = new int [MPI_NRank];
-      int *RecvCount_ParDataEachPatch = new int [MPI_NRank];
-      int *SendDisp_ParDataEachPatch  = new int [MPI_NRank];
-      int *RecvDisp_ParDataEachPatch  = new int [MPI_NRank];
+      int  *SendCount_ParDataEachPatch = new int  [MPI_NRank];
+      int  *RecvCount_ParDataEachPatch = new int  [MPI_NRank];
+      long *SendDisp_ParDataEachPatch  = new long [MPI_NRank];
+      long *RecvDisp_ParDataEachPatch  = new long [MPI_NRank];
 
 //    send/recv count
       const int *SendPtr = NULL, *RecvPtr = NULL;
-      NRecvParTotal = 0;
+      NRecvParTotal = 0L;
 
       for (int r=0; r<MPI_NRank; r++)
       {
@@ -175,25 +175,20 @@ void Par_LB_SendParticleData( const int NParAtt, int *SendBuf_NPatchEachRank, in
       }
 
 //    send/recv displacement
-      SendDisp_ParDataEachPatch[0] = 0;
-      RecvDisp_ParDataEachPatch[0] = 0;
+      SendDisp_ParDataEachPatch[0] = 0L;
+      RecvDisp_ParDataEachPatch[0] = 0L;
       for (int r=1; r<MPI_NRank; r++)
       {
-         SendDisp_ParDataEachPatch[r] = SendDisp_ParDataEachPatch[r-1] + SendCount_ParDataEachPatch[r-1];
-         RecvDisp_ParDataEachPatch[r] = RecvDisp_ParDataEachPatch[r-1] + RecvCount_ParDataEachPatch[r-1];
+         SendDisp_ParDataEachPatch[r] = SendDisp_ParDataEachPatch[r-1] + (long)SendCount_ParDataEachPatch[r-1];
+         RecvDisp_ParDataEachPatch[r] = RecvDisp_ParDataEachPatch[r-1] + (long)RecvCount_ParDataEachPatch[r-1];
       }
 
 //    reuse the MPI recv buffer declared in LB_GetBufferData for better MPI performance
       RecvBuf_ParDataEachPatch = LB_GetBufferData_MemAllocate_Recv( NRecvParTotal*NParAtt );
 
 //    exchange data
-#     ifdef FLOAT8
-      MPI_Alltoallv( SendBuf_ParDataEachPatch, SendCount_ParDataEachPatch, SendDisp_ParDataEachPatch, MPI_DOUBLE,
-                     RecvBuf_ParDataEachPatch, RecvCount_ParDataEachPatch, RecvDisp_ParDataEachPatch, MPI_DOUBLE, MPI_COMM_WORLD );
-#     else
-      MPI_Alltoallv( SendBuf_ParDataEachPatch, SendCount_ParDataEachPatch, SendDisp_ParDataEachPatch, MPI_FLOAT,
-                     RecvBuf_ParDataEachPatch, RecvCount_ParDataEachPatch, RecvDisp_ParDataEachPatch, MPI_FLOAT,  MPI_COMM_WORLD );
-#     endif
+      MPI_Alltoallv_GAMER( SendBuf_ParDataEachPatch, SendCount_ParDataEachPatch, SendDisp_ParDataEachPatch, MPI_GAMER_REAL,
+                           RecvBuf_ParDataEachPatch, RecvCount_ParDataEachPatch, RecvDisp_ParDataEachPatch, MPI_GAMER_REAL, MPI_COMM_WORLD );
 
 //    free memory
       delete [] SendCount_ParDataEachPatch;

--- a/src/Particle/Par_FindHomePatch_UniformGrid.cpp
+++ b/src/Particle/Par_FindHomePatch_UniformGrid.cpp
@@ -70,9 +70,9 @@ void Par_FindHomePatch_UniformGrid( const int lv, const bool OldParOnly,
    real TParPos[3];
 
    long *HomeLBIdx          = new long [NTarPar];
-   int  *HomeLBIdx_IdxTable = new int  [NTarPar];
+   long *HomeLBIdx_IdxTable = new long [NTarPar];
    int  *HomePID            = new int  [NTarPar];
-   int  *MatchIdx           = new int  [NTarPar];
+   long *MatchIdx           = new long [NTarPar];
 
 // get the load-balance index of the particle's home patch
    for (long t=0; t<NTarPar; t++)
@@ -94,13 +94,13 @@ void Par_FindHomePatch_UniformGrid( const int lv, const bool OldParOnly,
    Mis_Heapsort( NReal, RealPatchLBIdx, RealPatchLBIdx_IdxTable );
 
 // LBIdx --> home (real) patch indices
-   Mis_Matching_int( NReal, RealPatchLBIdx, NTarPar, HomeLBIdx, MatchIdx );
+   Mis_Matching_int( (long)NReal, RealPatchLBIdx, NTarPar, HomeLBIdx, MatchIdx );
 
 // check: every particle must have a home patch
 #  ifdef DEBUG_PARTICLE
    for (long t=0; t<NTarPar; t++)
    {
-      if ( MatchIdx[t] == -1 )
+      if ( MatchIdx[t] == -1L )
       {
          const long ParID = NewParID0 + HomeLBIdx_IdxTable[t];
 
@@ -201,7 +201,7 @@ void SendParticle2HomeRank( const int lv, const bool OldParOnly,
    real *Mass   = NULL;
    real *Pos[3] = { NULL, NULL, NULL };
 
-   int  Send_Count[MPI_NRank], Recv_Count[MPI_NRank];
+   long Send_Count[MPI_NRank], Recv_Count[MPI_NRank];
    long Send_Disp[MPI_NRank], Recv_Disp[MPI_NRank];
    long Send_Count_Sum, Recv_Count_Sum;
 
@@ -221,7 +221,7 @@ void SendParticle2HomeRank( const int lv, const bool OldParOnly,
       Pos[2] = NewParAtt[PAR_POSZ];
    }
 
-   for (int r=0; r<MPI_NRank; r++)  Send_Count[r] = 0;
+   for (int r=0; r<MPI_NRank; r++)  Send_Count[r] = 0L;
 
 
 // 1. get the target MPI rank of each particle
@@ -255,19 +255,19 @@ void SendParticle2HomeRank( const int lv, const bool OldParOnly,
 
 
 // 2. construct the MPI send and recv data list
-   MPI_Alltoall( Send_Count, 1, MPI_INT, Recv_Count, 1, MPI_INT, MPI_COMM_WORLD );
+   MPI_Alltoall( Send_Count, 1, MPI_LONG, Recv_Count, 1, MPI_LONG, MPI_COMM_WORLD );
 
    Send_Disp[0] = 0L;
    Recv_Disp[0] = 0L;
 
    for (int r=1; r<MPI_NRank; r++)
    {
-      Send_Disp[r] = Send_Disp[r-1] + (long)Send_Count[r-1];
-      Recv_Disp[r] = Recv_Disp[r-1] + (long)Recv_Count[r-1];
+      Send_Disp[r] = Send_Disp[r-1] + Send_Count[r-1];
+      Recv_Disp[r] = Recv_Disp[r-1] + Recv_Count[r-1];
    }
 
-   Send_Count_Sum = Send_Disp[ MPI_NRank-1 ] + (long)Send_Count[ MPI_NRank-1 ];
-   Recv_Count_Sum = Recv_Disp[ MPI_NRank-1 ] + (long)Recv_Count[ MPI_NRank-1 ];
+   Send_Count_Sum = Send_Disp[ MPI_NRank-1 ] + Send_Count[ MPI_NRank-1 ];
+   Recv_Count_Sum = Recv_Disp[ MPI_NRank-1 ] + Recv_Count[ MPI_NRank-1 ];
 
 #  ifdef DEBUG_PARTICLE
    if ( OldParOnly  &&  Send_Count_Sum != amr->Par->NPar_Active )
@@ -327,8 +327,8 @@ void SendParticle2HomeRank( const int lv, const bool OldParOnly,
    {
       free( amr->Par->InactiveParList );
 
-      amr->Par->NPar_AcPlusInac     = (long)Recv_Count_Sum;
-      amr->Par->NPar_Active         = (long)Recv_Count_Sum;
+      amr->Par->NPar_AcPlusInac     = Recv_Count_Sum;
+      amr->Par->NPar_Active         = Recv_Count_Sum;
       amr->Par->NPar_Inactive       = 0;                       // since we don't redistribute inactive particles
       amr->Par->ParListSize         = UpdatedParListSize;
       amr->Par->InactiveParListSize = (long)MAX( 1, UpdatedParListSize/100 );
@@ -337,8 +337,8 @@ void SendParticle2HomeRank( const int lv, const bool OldParOnly,
 
    else
    {
-      amr->Par->NPar_AcPlusInac    += (long)Recv_Count_Sum;
-      amr->Par->NPar_Active        += (long)Recv_Count_Sum;
+      amr->Par->NPar_AcPlusInac    += Recv_Count_Sum;
+      amr->Par->NPar_Active        += Recv_Count_Sum;
       amr->Par->ParListSize         = UpdatedParListSize;
 
 //    update the total number of active particles in all MPI ranks

--- a/src/Particle/Par_MassAssignment.cpp
+++ b/src/Particle/Par_MassAssignment.cpp
@@ -157,7 +157,7 @@ void Par_MassAssignment( const long *ParList, const long NPar, const ParInterp_t
 // 3-1/2: sort particles by their position to fix the order of mass assignment
 //        --> necessary for achieving bitwise reproducibility
 #  ifdef BITWISE_REPRODUCIBILITY
-   int *Sort_IdxTable = new int [NPar];   // it will fail if "long" is actually required for NPar
+   long *Sort_IdxTable = new long [NPar];   // it will fail if "long" is actually required for NPar
 
    Par_SortByPos( NPar, Pos[0], Pos[1], Pos[2], Sort_IdxTable );
 #  endif

--- a/src/Particle/Par_MassAssignment.cpp
+++ b/src/Particle/Par_MassAssignment.cpp
@@ -157,7 +157,7 @@ void Par_MassAssignment( const long *ParList, const long NPar, const ParInterp_t
 // 3-1/2: sort particles by their position to fix the order of mass assignment
 //        --> necessary for achieving bitwise reproducibility
 #  ifdef BITWISE_REPRODUCIBILITY
-   long *Sort_IdxTable = new long [NPar];   // it will fail if "long" is actually required for NPar
+   long *Sort_IdxTable = new long [NPar];
 
    Par_SortByPos( NPar, Pos[0], Pos[1], Pos[2], Sort_IdxTable );
 #  endif

--- a/src/Particle/Par_Sort.cpp
+++ b/src/Particle/Par_Sort.cpp
@@ -49,8 +49,8 @@ void Par_SortByPos( const long NPar, const real *PosX, const real *PosY, const r
 
       if ( NParSameX > 1 )
       {
-         long *SortByX_IdxTable = new long [NParSameX];  // it will fail if "long" is actually required
-         long *SortByY_IdxTable = new long [NParSameX];  // it will fail if "long" is actually required
+         long *SortByX_IdxTable = new long [NParSameX];
+         long *SortByY_IdxTable = new long [NParSameX];
          real *PosY_Sorted      = new real [NParSameX];
 
          for (long y=0; y<NParSameX; y++)
@@ -74,7 +74,7 @@ void Par_SortByPos( const long NPar, const real *PosX, const real *PosY, const r
 
             if ( NParSameY > 1 )
             {
-               long *SortByZ_IdxTable = new long [NParSameY];  // it will fail if "long" is actually required
+               long *SortByZ_IdxTable = new long [NParSameY];
                real *PosZ_Sorted      = new real [NParSameY];
 
                for (long z=0; z<NParSameY; z++)

--- a/src/Particle/Par_Sort.cpp
+++ b/src/Particle/Par_Sort.cpp
@@ -24,7 +24,7 @@
 //
 // Return      :  IdxTable
 //-------------------------------------------------------------------------------------------------------
-void Par_SortByPos( const long NPar, const real *PosX, const real *PosY, const real *PosZ, int *IdxTable )
+void Par_SortByPos( const long NPar, const real *PosX, const real *PosY, const real *PosZ, long *IdxTable )
 {
 
    long NParSameX, NParSameY;
@@ -49,8 +49,8 @@ void Par_SortByPos( const long NPar, const real *PosX, const real *PosY, const r
 
       if ( NParSameX > 1 )
       {
-         int  *SortByX_IdxTable = new int  [NParSameX];  // it will fail if "long" is actually required
-         int  *SortByY_IdxTable = new int  [NParSameX];  // it will fail if "long" is actually required
+         long *SortByX_IdxTable = new long [NParSameX];  // it will fail if "long" is actually required
+         long *SortByY_IdxTable = new long [NParSameX];  // it will fail if "long" is actually required
          real *PosY_Sorted      = new real [NParSameX];
 
          for (long y=0; y<NParSameX; y++)
@@ -74,7 +74,7 @@ void Par_SortByPos( const long NPar, const real *PosX, const real *PosY, const r
 
             if ( NParSameY > 1 )
             {
-               int  *SortByZ_IdxTable = new int  [NParSameY];  // it will fail if "long" is actually required
+               long *SortByZ_IdxTable = new long [NParSameY];  // it will fail if "long" is actually required
                real *PosZ_Sorted      = new real [NParSameY];
 
                for (long z=0; z<NParSameY; z++)

--- a/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_FFT.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_PoissonSolver_FFT.cpp
@@ -244,8 +244,8 @@ void CPU_PoissonSolver_FFT( const real Poi_Coeff, const int SaveSg, const double
 
    int  *List_PID    [MPI_NRank];   // PID of each patch slice sent to each rank
    int  *List_k      [MPI_NRank];   // local z coordinate of each patch slice sent to each rank
-   int   List_NSend  [MPI_NRank];   // size of data (density/potential) sent to each rank
-   int   List_NRecv  [MPI_NRank];   // size of data (density/potential) received from each rank
+   long  List_NSend  [MPI_NRank];   // size of data (density/potential) sent to each rank
+   long  List_NRecv  [MPI_NRank];   // size of data (density/potential) received from each rank
    const bool ForPoisson  = true;   // preparing the density field for the Poisson solver
    const bool InPlacePad  = true;   // pad the array for in-place real-to-complex FFT
 

--- a/src/SelfGravity/Poi_GetAverageDensity.cpp
+++ b/src/SelfGravity/Poi_GetAverageDensity.cpp
@@ -166,7 +166,7 @@ void Poi_GetAverageDensity()
    if ( MPI_Rank == 0 )
    {
 //    sort
-      Mis_Heapsort( NPar_AcPlusInac_Sum, ParMass_AllRank, NULL );
+      Mis_Heapsort<long,real_par>( NPar_AcPlusInac_Sum, ParMass_AllRank, NULL );
 
 //    add average particle density
       ParMassSum = 0.0;

--- a/src/SelfGravity/Poi_GetAverageDensity.cpp
+++ b/src/SelfGravity/Poi_GetAverageDensity.cpp
@@ -155,13 +155,8 @@ void Poi_GetAverageDensity()
    }
 
 // collect particle mass from all ranks
-#  ifdef FLOAT8
-   MPI_Gatherv( amr->Par->Mass, amr->Par->NPar_AcPlusInac, MPI_DOUBLE,
-                ParMass_AllRank, Count, Disp, MPI_DOUBLE, 0, MPI_COMM_WORLD );
-#  else
-   MPI_Gatherv( amr->Par->Mass, amr->Par->NPar_AcPlusInac, MPI_FLOAT,
-                ParMass_AllRank, Count, Disp, MPI_FLOAT,  0, MPI_COMM_WORLD );
-#  endif
+   MPI_Gatherv( amr->Par->Mass, amr->Par->NPar_AcPlusInac, MPI_GAMER_REAL,
+                ParMass_AllRank, Count, Disp, MPI_GAMER_REAL, 0, MPI_COMM_WORLD );
 
    if ( MPI_Rank == 0 )
    {

--- a/src/SelfGravity/Poi_GetAverageDensity.cpp
+++ b/src/SelfGravity/Poi_GetAverageDensity.cpp
@@ -166,7 +166,7 @@ void Poi_GetAverageDensity()
    if ( MPI_Rank == 0 )
    {
 //    sort
-      Mis_Heapsort<long,real_par>( NPar_AcPlusInac_Sum, ParMass_AllRank, NULL );
+      Mis_Heapsort<long,real>( NPar_AcPlusInac_Sum, ParMass_AllRank, NULL );
 
 //    add average particle density
       ParMassSum = 0.0;

--- a/src/SelfGravity/Poi_GetAverageDensity.cpp
+++ b/src/SelfGravity/Poi_GetAverageDensity.cpp
@@ -155,8 +155,13 @@ void Poi_GetAverageDensity()
    }
 
 // collect particle mass from all ranks
-   MPI_Gatherv( amr->Par->Mass, amr->Par->NPar_AcPlusInac, MPI_GAMER_REAL,
-                ParMass_AllRank, Count, Disp, MPI_GAMER_REAL, 0, MPI_COMM_WORLD );
+#  ifdef FLOAT8
+   MPI_Gatherv( amr->Par->Mass, amr->Par->NPar_AcPlusInac, MPI_DOUBLE,
+                ParMass_AllRank, Count, Disp, MPI_DOUBLE, 0, MPI_COMM_WORLD );
+#  else
+   MPI_Gatherv( amr->Par->Mass, amr->Par->NPar_AcPlusInac, MPI_FLOAT,
+                ParMass_AllRank, Count, Disp, MPI_FLOAT,  0, MPI_COMM_WORLD );
+#  endif
 
    if ( MPI_Rank == 0 )
    {

--- a/src/configure.py
+++ b/src/configure.py
@@ -23,7 +23,8 @@ PYTHON_VER = [sys.version_info.major, sys.version_info.minor]
 
 GAMER_CONFIG_DIR  = "../configs"
 GAMER_MAKE_BASE   = "Makefile_base"
-GAMER_MAKE_OUT    = "Makefile"
+#GAMER_MAKE_OUT    = "Makefile"
+GAMER_MAKE_OUT    = "Makefile_MPI_Alltoallv_wrapper"
 GAMER_DESCRIPTION = "Prepare a customized Makefile for GAMER.\nDefault values are marked by '*'.\nUse -lh to show a detailed help message.\n"
 GAMER_EPILOG      = "2023 Computational Astrophysics Lab, NTU. All rights reserved.\n"
 

--- a/src/configure.py
+++ b/src/configure.py
@@ -23,8 +23,7 @@ PYTHON_VER = [sys.version_info.major, sys.version_info.minor]
 
 GAMER_CONFIG_DIR  = "../configs"
 GAMER_MAKE_BASE   = "Makefile_base"
-#GAMER_MAKE_OUT    = "Makefile"
-GAMER_MAKE_OUT    = "Makefile_MPI_Alltoallv_wrapper"
+GAMER_MAKE_OUT    = "Makefile"
 GAMER_DESCRIPTION = "Prepare a customized Makefile for GAMER.\nDefault values are marked by '*'.\nUse -lh to show a detailed help message.\n"
 GAMER_EPILOG      = "2023 Computational Astrophysics Lab, NTU. All rights reserved.\n"
 


### PR DESCRIPTION
Define `MPI_Alltoallv_GAMER` wrapper with:
* Support `long` type Recv/Send element arrays and displacement arrays
* With sanity check against Recv/Send elements array; if their size exceed `__INT_MAX__`, error message will rise
