### PR TITLE
PPM data reconstruction improvement

### DIFF
--- a/doc/deprecated/README_User.txt
+++ b/doc/deprecated/README_User.txt
@@ -471,6 +471,7 @@ II. Perform Simulation
             3 -> generalized MinMod + van Leer limiter
                  (please set the parameter "MINMOD_COEFF" for this limiter)
             4 -> extrema-preserving limiter (not well tested yet)
+            7 -> Athena++ PPM slope limiter
 
       OPT__WAF_LIMITER :
          The flux limiter in WAF scheme.

--- a/example/test_problem/Hydro/AGORA_IsolatedGalaxy/Input__Parameter
+++ b/example/test_problem/Hydro/AGORA_IsolatedGalaxy/Input__Parameter
@@ -153,7 +153,7 @@ MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently o
 MINMOD_COEFF                  1.0         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/AcousticWave/Input__Parameter
+++ b/example/test_problem/Hydro/AcousticWave/Input__Parameter
@@ -90,7 +90,7 @@ MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently o
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/BlastWave/Input__Parameter
+++ b/example/test_problem/Hydro/BlastWave/Input__Parameter
@@ -102,7 +102,7 @@ MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently o
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/BlastWave/plot_script/plot_slice_B.py
+++ b/example/test_problem/Hydro/BlastWave/plot_script/plot_slice_B.py
@@ -29,7 +29,8 @@ didx        = args.didx
 prefix      = args.prefix
 
 colormap    = 'arbre'
-field       = 'magnetic_energy'    # to change the target field, one must modify set_unit() accordingly
+# to change the target field, one must modify set_unit() accordingly
+field       = ('gas', 'magnetic_energy_density') if yt.__version__.split(".")[0] == "4" else ('gas', 'magnetic_energy')
 center_mode = 'c'
 dpi         = 150
 

--- a/example/test_problem/Hydro/Bondi/Input__Parameter
+++ b/example/test_problem/Hydro/Bondi/Input__Parameter
@@ -112,7 +112,7 @@ ISO_TEMP                      1.0e4       # isothermal temperature in kelvin ##E
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (-1=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/CDM_LSS/Input__Parameter
+++ b/example/test_problem/Hydro/CDM_LSS/Input__Parameter
@@ -126,7 +126,7 @@ ISO_TEMP                      1.0e4       # isothermal temperature in kelvin ##E
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (-1=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/CMZ/Input__Parameter
+++ b/example/test_problem/Hydro/CMZ/Input__Parameter
@@ -163,7 +163,7 @@ ISO_TEMP                      1.5455e4    # isothermal temperature in kelvin ##E
 MINMOD_COEFF                  1.0         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (-1=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/Caustic/Input__Parameter
+++ b/example/test_problem/Hydro/Caustic/Input__Parameter
@@ -109,7 +109,7 @@ MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently o
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/ClusterMerger/Input__Parameter
+++ b/example/test_problem/Hydro/ClusterMerger/Input__Parameter
@@ -130,7 +130,7 @@ MOLECULAR_WEIGHT              0.59242761692650336  # mean molecular weight -> cu
 MINMOD_COEFF                  2.0         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER               1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/EnergyPowerSpectrum/Input__Parameter
+++ b/example/test_problem/Hydro/EnergyPowerSpectrum/Input__Parameter
@@ -88,7 +88,7 @@ MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently o
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/Gravity/Input__Parameter
+++ b/example/test_problem/Hydro/Gravity/Input__Parameter
@@ -106,7 +106,7 @@ MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently o
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/JeansInstability/Input__Parameter
+++ b/example/test_problem/Hydro/JeansInstability/Input__Parameter
@@ -102,7 +102,7 @@ MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently o
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/Jet/Input__Parameter
+++ b/example/test_problem/Hydro/Jet/Input__Parameter
@@ -106,7 +106,7 @@ MOLECULAR_WEIGHT              0.65        # mean molecular weight -> currently o
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/KelvinHelmholtzInstability/Input__Parameter
+++ b/example/test_problem/Hydro/KelvinHelmholtzInstability/Input__Parameter
@@ -97,7 +97,7 @@ MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently o
 MINMOD_COEFF                  2.0         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/MHD_ABC/Input__Parameter
+++ b/example/test_problem/Hydro/MHD_ABC/Input__Parameter
@@ -103,7 +103,7 @@ MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently o
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/MHD_LinearWave/Input__Parameter
+++ b/example/test_problem/Hydro/MHD_LinearWave/Input__Parameter
@@ -99,7 +99,7 @@ MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently o
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/MHD_OrszagTangVortex/Input__Parameter
+++ b/example/test_problem/Hydro/MHD_OrszagTangVortex/Input__Parameter
@@ -103,7 +103,7 @@ MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently o
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/ParticleEquilibriumIC/Input__Parameter
+++ b/example/test_problem/Hydro/ParticleEquilibriumIC/Input__Parameter
@@ -127,7 +127,7 @@ ISO_TEMP                      1.0e4       # isothermal temperature in kelvin ##E
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (-1=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/ParticleTest/Input__Parameter
+++ b/example/test_problem/Hydro/ParticleTest/Input__Parameter
@@ -119,7 +119,7 @@ GAMMA                         1.666666667 # ratio of specific heats (i.e., adiab
 MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently only for post-processing [0.6]
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/Plummer/Input__Parameter
+++ b/example/test_problem/Hydro/Plummer/Input__Parameter
@@ -125,7 +125,7 @@ MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently o
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/Riemann/Input__Parameter
+++ b/example/test_problem/Hydro/Riemann/Input__Parameter
@@ -97,7 +97,7 @@ MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently o
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/SphericalCollapse/Input__Parameter
+++ b/example/test_problem/Hydro/SphericalCollapse/Input__Parameter
@@ -120,7 +120,7 @@ MOLECULAR_WEIGHT              0.6         # mean molecular weight -> currently o
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (<0=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Hydro/Zeldovich/Input__Parameter
+++ b/example/test_problem/Hydro/Zeldovich/Input__Parameter
@@ -123,7 +123,7 @@ ISO_TEMP                      1.0e4       # isothermal temperature in kelvin ##E
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (-1=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/example/test_problem/Template/Input__Parameter
+++ b/example/test_problem/Template/Input__Parameter
@@ -208,7 +208,7 @@ ISO_TEMP                      1.0e4       # isothermal temperature in kelvin ##E
 MINMOD_COEFF                  1.5         # coefficient of the generalized MinMod limiter (1.0~2.0) [1.5]
 MINMOD_MAX_ITER               0           # maximum number of iterations to reduce MINMOD_COEFF when data reconstruction fails (0=off) [0]
 OPT__LR_LIMITER              -1           # slope limiter of data reconstruction in the MHM/MHM_RP/CTU schemes:
-                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central) [-1]
+                                          # (-1=auto, 0=none, 1=vanLeer, 2=generalized MinMod, 3=vanAlbada, 4=vanLeer+generalized MinMod, 6=central, 7=Athena) [-1]
 OPT__1ST_FLUX_CORR           -1           # correct unphysical results (defined by MIN_DENS/PRES) by the 1st-order fluxes:
                                           # (<0=auto, 0=off, 1=3D, 2=3D+1D) [-1] ##MHM/MHM_RP/CTU ONLY##
 OPT__1ST_FLUX_CORR_SCHEME    -1           # Riemann solver for OPT__1ST_FLUX_CORR (-1=auto, 0=none, 1=Roe, 2=HLLC, 3=HLLE, 4=HLLD) [-1]

--- a/include/CUFLU.h
+++ b/include/CUFLU.h
@@ -242,8 +242,8 @@
 //       MHD on : 3 for all EoS
 //       MHD off: none
 
-//#  define HLLC_WAVESPEED   HLL_WAVESPEED_DAVIS
-#  define HLLC_WAVESPEED   HLL_WAVESPEED_PVRS
+#  define HLLC_WAVESPEED   HLL_WAVESPEED_DAVIS
+//#  define HLLC_WAVESPEED   HLL_WAVESPEED_PVRS
 #ifdef MHD
 #  define HLLE_WAVESPEED   HLL_WAVESPEED_DAVIS
 #else

--- a/include/CUFLU.h
+++ b/include/CUFLU.h
@@ -242,8 +242,8 @@
 //       MHD on : 3 for all EoS
 //       MHD off: none
 
-#  define HLLC_WAVESPEED   HLL_WAVESPEED_DAVIS
-//#  define HLLC_WAVESPEED   HLL_WAVESPEED_PVRS
+//#  define HLLC_WAVESPEED   HLL_WAVESPEED_DAVIS
+#  define HLLC_WAVESPEED   HLL_WAVESPEED_PVRS
 #ifdef MHD
 #  define HLLE_WAVESPEED   HLL_WAVESPEED_DAVIS
 #else

--- a/src/Auxiliary/Aux_Check_Parameter.cpp
+++ b/src/Auxiliary/Aux_Check_Parameter.cpp
@@ -871,6 +871,11 @@ void Aux_Check_Parameter()
         OPT__LR_LIMITER != LR_LIMITER_ATHENA )
       Aux_Error( ERROR_INFO, "unsupported data reconstruction limiter (OPT__LR_IMITER = %d) !!\n",
                  OPT__LR_LIMITER );
+#  if ( LR_SCHEME == PLM )
+   if ( OPT__LR_LIMITER == LR_LIMITER_ATHENA )
+      Aux_Error( ERROR, "ERROR : OPT__LR_LIMITER = %d (LR_LIMITER_ATHENA) is not supported for PLM !!\n",
+                   OPT__LR_ATHENA );
+#  endif
 
 
 // warnings
@@ -881,6 +886,12 @@ void Aux_Check_Parameter()
       if ( OPT__LR_LIMITER != LR_LIMITER_CENTRAL )
          Aux_Message( stderr, "WARNING : OPT__LR_LIMITER = %d (LR_LIMITER_CENTRAL) is recommended for MHM_RP+PPM !!\n",
                       LR_LIMITER_CENTRAL );
+#     endif
+
+#     if ( FLU_SCHEME == MHM  &&  defined MHD )
+      if ( OPT__LR_LIMITER == LR_LIMITER_ATHENA )
+         Aux_Message( stderr, "WARNING : OPT__LR_LIMITER = %d (LR_LIMITER_ATHENA) is not recommended for MHM+MHD !!\n",
+                      LR_LIMITER_ATHENA );
 #     endif
 
 #     if ( LR_SCHEME == PLM )

--- a/src/Auxiliary/Aux_Check_Parameter.cpp
+++ b/src/Auxiliary/Aux_Check_Parameter.cpp
@@ -871,10 +871,11 @@ void Aux_Check_Parameter()
         OPT__LR_LIMITER != LR_LIMITER_ATHENA )
       Aux_Error( ERROR_INFO, "unsupported data reconstruction limiter (OPT__LR_IMITER = %d) !!\n",
                  OPT__LR_LIMITER );
+
 #  if ( LR_SCHEME == PLM )
    if ( OPT__LR_LIMITER == LR_LIMITER_ATHENA )
-      Aux_Error( ERROR, "ERROR : OPT__LR_LIMITER = %d (LR_LIMITER_ATHENA) is not supported for PLM !!\n",
-                   OPT__LR_ATHENA );
+      Aux_Error( ERROR_INFO, "ERROR : OPT__LR_LIMITER = %d (LR_LIMITER_ATHENA) is not supported for PLM !!\n",
+                 OPT__LR_LIMITER );
 #  endif
 
 

--- a/src/Init/Init_ResetParameter.cpp
+++ b/src/Init/Init_ResetParameter.cpp
@@ -64,7 +64,7 @@ void Init_ResetParameter()
       DT__FLUID = 0.40;
 #     elif ( FLU_SCHEME == MHM_RP )
 //    CFL factor is recommened to be larger than 0.4 for the Athena limiter
-      DT__FLUID = ( OPT__LR_LIMITER == LR_ATHENA ) 0.4 : 0.3;
+      DT__FLUID = ( OPT__LR_LIMITER == LR_LIMITER_ATHENA ) 0.4 : 0.3;
 #     elif ( FLU_SCHEME == CTU )
       DT__FLUID = 0.50;
 #     else

--- a/src/Init/Init_ResetParameter.cpp
+++ b/src/Init/Init_ResetParameter.cpp
@@ -63,7 +63,7 @@ void Init_ResetParameter()
 #     elif ( FLU_SCHEME == MHM )
       DT__FLUID = 0.40;
 #     elif ( FLU_SCHEME == MHM_RP )
-//    CFL factor is recommened to be larger than 0.4 for the Athena limiter
+//    CFL factor is recommended to be larger than 0.4 for the Athena limiter
       DT__FLUID = ( OPT__LR_LIMITER == LR_LIMITER_ATHENA ) 0.4 : 0.3;
 #     elif ( FLU_SCHEME == CTU )
       DT__FLUID = 0.50;

--- a/src/Init/Init_ResetParameter.cpp
+++ b/src/Init/Init_ResetParameter.cpp
@@ -64,7 +64,7 @@ void Init_ResetParameter()
       DT__FLUID = 0.40;
 #     elif ( FLU_SCHEME == MHM_RP )
 //    CFL factor is recommended to be larger than 0.4 for the Athena limiter
-      DT__FLUID = ( OPT__LR_LIMITER == LR_LIMITER_ATHENA ) 0.4 : 0.3;
+      DT__FLUID = ( OPT__LR_LIMITER == LR_LIMITER_ATHENA ) ? 0.4 : 0.3;
 #     elif ( FLU_SCHEME == CTU )
       DT__FLUID = 0.50;
 #     else

--- a/src/Init/Init_ResetParameter.cpp
+++ b/src/Init/Init_ResetParameter.cpp
@@ -63,7 +63,8 @@ void Init_ResetParameter()
 #     elif ( FLU_SCHEME == MHM )
       DT__FLUID = 0.40;
 #     elif ( FLU_SCHEME == MHM_RP )
-      DT__FLUID = 0.30;
+//    CFL factor is recommened to be larger than 0.4 for the Athena limiter
+      DT__FLUID = ( OPT__LR_LIMITER == LR_ATHENA ) 0.4 : 0.3;
 #     elif ( FLU_SCHEME == CTU )
       DT__FLUID = 0.50;
 #     else

--- a/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_MHM.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_MHM.cpp
@@ -352,6 +352,7 @@ void CPU_FluidSolver_MHM(
 #     endif
 #     endif // #if ( FLU_SCHEME == MHM )
 
+
 //    loop over all patch groups
 //    --> CPU/GPU solver: use different (OpenMP threads) / (CUDA thread blocks)
 //        to work on different patch groups

--- a/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_MHM.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_MHM.cpp
@@ -352,8 +352,6 @@ void CPU_FluidSolver_MHM(
 #     endif
 #     endif // #if ( FLU_SCHEME == MHM )
 
-      const bool debug = false;
-
 //    loop over all patch groups
 //    --> CPU/GPU solver: use different (OpenMP threads) / (CUDA thread blocks)
 //        to work on different patch groups
@@ -390,17 +388,6 @@ void CPU_FluidSolver_MHM(
             g_PriVar_1PG[1][idx] = g_Flu_Array_In[P][1][idx]*_Dens;
             g_PriVar_1PG[2][idx] = g_Flu_Array_In[P][2][idx]*_Dens;
             g_PriVar_1PG[3][idx] = g_Flu_Array_In[P][3][idx]*_Dens;
-
-            //if ( j==8 && k==8 && debug )
-            //{
-            //   printf( "i=%02d, j=%02d, k=%02d", i, j, k);
-            //   printf( "| %+.16e %+.16e %+.16e | ", g_Flu_Array_In[P][0][idx], g_Flu_Array_In[P][0][idx], g_Flu_Array_In[P][0][idx] );
-            //   printf( "| %+.16e %+.16e %+.16e | ", g_Flu_Array_In[P][1][idx], g_Flu_Array_In[P][1][idx], g_Flu_Array_In[P][1][idx] );
-            //   printf( "| %+.16e %+.16e %+.16e | ", g_Flu_Array_In[P][2][idx], g_Flu_Array_In[P][2][idx], g_Flu_Array_In[P][2][idx] );
-            //   printf( "| %+.16e %+.16e %+.16e | ", g_Flu_Array_In[P][3][idx], g_Flu_Array_In[P][3][idx], g_Flu_Array_In[P][3][idx] );
-            //   printf( "| %+.16e %+.16e %+.16e | ", g_Flu_Array_In[P][4][idx], g_Flu_Array_In[P][4][idx], g_Flu_Array_In[P][4][idx] );
-            //   printf("\n");
-            //}
 
 //          magnetic field
             MHD_GetCellCenteredBField( CC_B, g_Mag_Array_In[P][0], g_Mag_Array_In[P][1], g_Mag_Array_In[P][2],
@@ -584,37 +571,6 @@ void Hydro_RiemannPredict_Flux( const real g_ConVar[][ CUBE(FLU_NXT) ],
 
    const int didx_cvar[3] = { 1, FLU_NXT, SQR(FLU_NXT) };
    real ConVar_L[NCOMP_TOTAL_PLUS_MAG], ConVar_R[NCOMP_TOTAL_PLUS_MAG], Flux_1Face[NCOMP_TOTAL_PLUS_MAG];
-   const bool debug = false;
-   // if (debug) printf("PCM (con, pri, pri) : \n");
-   CGPU_LOOP( idx, CUBE(FLU_NXT) )
-   {
-      const int i_cvar   = idx % FLU_NXT;
-      const int j_cvar   = idx % SQR(FLU_NXT) / FLU_NXT;
-      const int k_cvar   = idx / SQR(FLU_NXT);
-
-      // if ( j_cvar == 8 && k_cvar == 8 && debug )
-      // {
-      //    real out_con[NCOMP_TOTAL_PLUS_MAG], out_pri[NCOMP_TOTAL_PLUS_MAG];
-      //    for (int v=0; v<NCOMP_TOTAL_PLUS_MAG; v++)   out_con[v] = g_ConVar[v][idx];
-      //    Hydro_Con2Pri( out_con, out_pri, MinPres, false, NULL, NULL, NULL, NULL,
-      //                EoS->DensEint2Pres_FuncPtr, EoS->DensPres2Eint_FuncPtr, EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int,
-      //                EoS->Table, NULL );
-      //    real Dens = out_pri[0];
-      //    real Velx = out_pri[1];
-      //    real Vely = out_pri[2];
-      //    real Velz = out_pri[3];
-      //    real Pres = out_pri[4];
-      //    printf( "i=%02d, j=%02d, k=%02d", i_cvar, j_cvar, k_cvar);
-      //    printf( "| %+.16e %+.16e %+.16e | ", g_ConVar[0][idx], Dens, Dens );
-      //    printf( "| %+.16e %+.16e %+.16e | ", g_ConVar[1][idx], Velx, Velx );
-      //    printf( "| %+.16e %+.16e %+.16e | ", g_ConVar[2][idx], Vely, Vely );
-      //    printf( "| %+.16e %+.16e %+.16e | ", g_ConVar[3][idx], Velz, Velz );
-      //    printf( "| %+.16e %+.16e %+.16e | ", g_ConVar[4][idx], Pres, Pres );
-      //    printf("\n");
-      // }
-   }
-
-
 
 // loop over different spatial directions
    for (int d=0; d<3; d++)
@@ -830,43 +786,6 @@ void Hydro_RiemannPredict( const real g_ConVar_In[][ CUBE(FLU_NXT) ],
    const real dt_dh2       = (real)0.5*dt/dh;
 
    const int N_HF_VAR2 = SQR(N_HF_VAR);
-   const bool debug = false;
-   // if (debug) printf("Half flux laft and right\n");
-   CGPU_LOOP( idx_out, CUBE(N_HF_VAR) )
-   {
-      const int i_out    = idx_out % N_HF_VAR;
-      const int j_out    = idx_out % N_HF_VAR2 / N_HF_VAR;
-      const int k_out    = idx_out / N_HF_VAR2;
-
-//    for MHD, one additional flux is evaluated along each transverse direction for computing the CT electric field
-#     ifdef MHD
-      const int i_flux   = i_out + 1;
-      const int j_flux   = j_out + 1;
-      const int k_flux   = k_out + 1;
-#     else
-      const int i_flux   = i_out;
-      const int j_flux   = j_out;
-      const int k_flux   = k_out;
-#     endif
-      const int idx_flux = IDX321( i_flux, j_flux, k_flux, N_HF_FLUX, N_HF_FLUX );
-
-      const int i_in     = i_out + 1;
-      const int j_in     = j_out + 1;
-      const int k_in     = k_out + 1;
-      const int idx_in   = IDX321( i_in, j_in, k_in, FLU_NXT, FLU_NXT );
-
-      //if ( j_in == 8 && k_in == 8 && debug )
-      //{
-      //   printf("%02d ", i_in);
-      //   printf("%+.16e %+.16e ", g_Flux_Half[0][DENS][idx_flux], g_Flux_Half[0][DENS][idx_flux + didx_flux[0]]);
-      //   printf("%+.16e %+.16e ", g_Flux_Half[0][MOMX][idx_flux], g_Flux_Half[0][MOMX][idx_flux + didx_flux[0]]);
-      //   printf("%+.16e %+.16e ", g_Flux_Half[0][MOMY][idx_flux], g_Flux_Half[0][MOMY][idx_flux + didx_flux[0]]);
-      //   printf("%+.16e %+.16e ", g_Flux_Half[0][MOMZ][idx_flux], g_Flux_Half[0][MOMZ][idx_flux + didx_flux[0]]);
-      //   printf("%+.16e %+.16e ", g_Flux_Half[0][ENGY][idx_flux], g_Flux_Half[0][ENGY][idx_flux + didx_flux[0]]);
-      //   printf("\n");
-      //}
-   }
-
    CGPU_LOOP( idx_out, CUBE(N_HF_VAR) )
    {
       const int i_out    = idx_out % N_HF_VAR;

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
@@ -133,6 +133,15 @@ static void Hydro_Char2Pri( real InOut[], const real Dens, const real Pres, cons
 //                9. Support applying data reconstruction to internal energy and using that instead of pressure
 //                   for converting primitive variables to conserved variables
 //                   --> Controlled by the option "LR_EINT" in CUFLU.h; see the description thereof for details
+//                10. (PPM) Reference:
+//                   a. The Athena++ Adaptive Mesh Refinement Framework: Design and Magnetohydrodynamic Solvers
+//                      Stone J. M., Tomida K., White C. J., Felker K. G., 2020, ApJS, 249, 4.
+//                   b. The Piecewise Parabolic Method (PPM) for gas-dynamical simulations
+//                      Colella P., Woodward P. R., 1984, JCoPh, 54, 174. doi:10.1016/0021-9991(84)90143-8
+//                   c. A limiter for PPM that preserves accuracy at smooth extrema
+//                      Colella P., Sekora M. D., 2008, JCoPh, 227, 7069. doi:10.1016/j.jcp.2008.03.034
+//                   d. A high-order finite-volume method for conservation laws on locally refined grids
+//                      Peter McCorquodale. Phillip Colella. Commun. Appl. Math. Comput. Sci. 6 (1) 1 - 25, 2011.
 //
 // Parameter   :  g_ConVar           : Array storing the input cell-centered conserved variables
 //                                     --> Should contain NCOMP_TOTAL variables

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
@@ -1031,7 +1031,7 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
                      tmp = (real)0.0;
                   } // if ( SIGN(dd_L) == SIGN(ddh_L)  &&  SIGN(ddh_L) == SIGN(dd_C) ) ... else ...
                   fc_L  = (real)0.5*(cc_L+cc_C) - tmp/(real)6.0;
-                  dh_LL = fc_L - cc_L;
+                  dh_L  = cc_C - fc_L;
                   ddh_C = fc_L - (real)2.*cc_C + fc_R;
                } // if ( dh_LL*dh_L < (real)0.0 )
 

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
@@ -1999,10 +1999,6 @@ void Hydro_LimitSlope( const real L[], const real C[], const real R[], const LR_
                Slope_Limiter[v] *= SIGN( Slope_C[v] );
                break;
 
-            case LR_LIMITER_ATHENA:   // ATHENA++ limiter
-               Slope_Limiter[v] = Slope_C[v];
-               break;
-
             default :
 #              ifdef GAMER_DEBUG
                printf( "ERROR : incorrect parameter %s = %d !!\n", "LR_Limiter", LR_Limiter );

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
@@ -1047,12 +1047,12 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
                   rho = (real)0.0;
                } // if ( FABS(ddh_C) > round_error*cc_abs_max ) ... else ...
 
-               if ( dh_L*dh_R < (real)0.0 || d_L*d_R < (real)0.0 ) {
+               if ( dh_L*dh_R < (real)0.0  ||  d_L*d_R < (real)0.0 ) {
                   if ( rho < (real)1.-round_err ) { fc_L = cc_C - rho * dh_L; fc_R = cc_C + rho * dh_R; }
                } else {
                   if ( FABS(dh_L) >= (real)2.*FABS(dh_R) ) fc_L = cc_C - (real)2.*dh_R;
                   if ( FABS(dh_R) >= (real)2.*FABS(dh_L) ) fc_R = cc_C + (real)2.*dh_L;
-               } // if ( dh_L*dh_R < 0.0 && d_L*d_R < 0.0 )
+               } // if ( dh_L*dh_R < (real)0.0  ||  d_L*d_R < (real)0.0 )
 
             } else // if ( LR_Limiter == LR_LIMITER_ATHENA )
             {

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
@@ -908,6 +908,728 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
    int idx_B[NCOMP_MAG];
 #  endif
 
+   // printf("PPM (con, pri, con)\n");
+   CGPU_LOOP( idx_fc, CUBE(N_FC_VAR) )
+   {
+      const int i_fc      = idx_fc%N_FC_VAR;
+      const int j_fc      = idx_fc%N_FC_VAR2/N_FC_VAR;
+      const int k_fc      = idx_fc/N_FC_VAR2;
+
+      const int i_cc      = i_fc + NGhost;
+      const int j_cc      = j_fc + NGhost;
+      const int k_cc      = k_fc + NGhost;
+      const int idx_cc    = IDX321( i_cc, j_cc, k_cc, NIn, NIn );
+
+      const int i_slope   = i_fc + 1;   // because N_SLOPE_PPM = N_FC_VAR + 2
+      const int j_slope   = j_fc + 1;
+      const int k_slope   = k_fc + 1;
+      const int idx_slope = IDX321( i_slope, j_slope, k_slope, N_SLOPE_PPM, N_SLOPE_PPM );
+
+#     ifdef MHD
+//    assuming that g_FC_B[] is accessed with the strides NIn/NIn+1 along the transverse/longitudinal directions
+      idx_B[0] = IDX321( i_cc, j_cc, k_cc, NIn_p1, NIn    );
+      idx_B[1] = IDX321( i_cc, j_cc, k_cc, NIn,    NIn_p1 );
+      idx_B[2] = IDX321( i_cc, j_cc, k_cc, NIn,    NIn    );
+#     endif
+
+ //   cc/fc: cell/face-centered variables; _C_ncomp: central cell with all NCOMP_LR variables
+      real cc_C_ncomp[NCOMP_LR], fc[6][NCOMP_LR], dfc[NCOMP_LR], dfc6[NCOMP_LR];
+
+      for (int v=0; v<NCOMP_LR; v++)   cc_C_ncomp[v] = g_PriVar[v][idx_cc];
+
+
+//    2-a. evaluate the eigenvalues and eigenvectors along all three directions for the pure-hydro CTU integrator
+#     if ( !defined MHD  &&  FLU_SCHEME == CTU )
+      Hydro_GetEigenSystem( cc_C_ncomp, EigenVal, LEigenVec, REigenVec, EoS );
+#     endif
+
+
+//    loop over different spatial directions
+      for (int d=0; d<3; d++)
+      {
+//       2-b. evaluate the eigenvalues and eigenvectors along the target direction for the MHD CTU integrator
+#        if (  defined MHD  &&  ( FLU_SCHEME == CTU || defined CHAR_RECONSTRUCTION )  )
+         MHD_GetEigenSystem( cc_C_ncomp, EigenVal[d], LEigenVec, REigenVec, EoS, d );
+#        endif
+
+
+//       3. get the face-centered primitive variables
+         const int faceL      = 2*d;      // left and right face indices
+         const int faceR      = faceL+1;
+         const int idx_ccLL   = idx_cc - 2*didx_cc[d];
+         const int idx_ccL    = idx_cc - didx_cc[d];
+         const int idx_ccC    = idx_cc;
+         const int idx_ccR    = idx_cc + didx_cc[d];
+         const int idx_ccRR   = idx_cc + 2*didx_cc[d];
+
+         const real C_factor = 1.25;
+         const real round_err = 1.e-12;
+
+         const bool debug = false;
+
+         for (int v=0; v<NCOMP_LR; v++)
+         {
+            real tmp, rho, cc_abs_max;
+
+            real fc_L, fc_R;                     // face center value
+            real cc_LL, cc_L, cc_C, cc_R, cc_RR; // cell center value
+            real d_LL, d_L, d_R, d_RR;           // slope at face center
+            real dd_L, dd_C, dd_R;               // curverture at cell center
+
+//          3-1. get all the value needed
+            cc_LL = g_PriVar[v][idx_ccLL];
+            cc_L  = g_PriVar[v][idx_ccL ];
+            cc_C  = g_PriVar[v][idx_cc  ];
+            cc_R  = g_PriVar[v][idx_ccR ];
+            cc_RR = g_PriVar[v][idx_ccRR];
+
+            d_LL  = cc_L  - cc_LL;
+            d_L   = cc_C  - cc_L ;
+            d_R   = cc_R  - cc_C ;
+            d_RR  = cc_RR - cc_R ;
+
+            dd_L  = cc_LL - (real)2.*cc_L + cc_C ;
+            dd_C  = cc_L  - (real)2.*cc_C + cc_R ;
+            dd_R  = cc_C  - (real)2.*cc_R + cc_RR;
+
+            cc_abs_max = MAX( FABS(cc_LL),
+                              MAX( FABS(cc_L),
+                                   MAX( FABS(cc_C),
+                                        MAX( FABS(cc_R), FABS(cc_RR) )
+                                      )
+                                 )
+                            );
+
+           // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf(" CC: %+.16e %+.16e %+.16e %+.16e %+.16e\n", cc_LL, cc_L, cc_C, cc_R, cc_RR);
+           // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf(" dC: %+.16e %+.16e %+.16e %+.16e\n", d_LL, d_L, d_R, d_RR);
+           // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("ddC: %+.16e %+.16e %+.16e\n", dd_L, dd_C, dd_R);
+           // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("cc_abs_max: %+.16e\n", cc_abs_max);
+
+//          3-2. interpolate the face value
+            fc_L = ( -cc_LL + (real)7.*cc_L + (real)7.*cc_C - cc_R  ) / (real)12.0;
+            fc_R = ( -cc_L  + (real)7.*cc_C + (real)7.*cc_R - cc_RR ) / (real)12.0;
+            // fc_L = ((real)6.*(cc_L + cc_C) + cc_C - cc_LL - cc_R  + cc_L ) / (real)12.;
+            // fc_R = ((real)6.*(cc_C + cc_R) + cc_R - cc_L  - cc_RR + cc_C ) / (real)12.;
+            // real qa = cc_C - cc_L;
+            // real qb = cc_R - cc_C;
+            // real dd_im1 = qa / (real)2. + (cc_L - cc_LL) / (real)2.;
+            // real dd     = qb / (real)2. + qa / (real)2.;
+            // real dd_ip1 = (cc_RR - cc_R) / (real)2. + qb / (real)2.;
+            // fc_L = cc_L/(real)2. + cc_C/(real)2. + dd_im1/(real)6. - dd    /(real)6.;
+            // fc_R = cc_C/(real)2. + cc_R/(real)2. + dd    /(real)6. - dd_ip1/(real)6.;
+
+           // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("1 => %02d: %+.16e %+.16e\n", i_cc, fc_L, fc_R);
+
+//          3-3. prepare half value
+            real dh_LL, dh_L, dh_R, dh_RR;
+            real ddh_L, ddh_C, ddh_R;
+
+            dh_LL = fc_L - cc_L;
+            dh_L  = cc_C - fc_L;
+            dh_R  = fc_R - cc_C;
+            dh_RR = cc_R - fc_R;
+
+            ddh_L = cc_L - (real)2.*fc_L + cc_C;
+            ddh_C = fc_L - (real)2.*cc_C + fc_R;
+            ddh_R = cc_C - (real)2.*fc_R + cc_R;
+
+            // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf(" dh: %+.16e %+.16e %+.16e %+.16e\n", dh_LL, dh_L, dh_R, dh_RR);
+            // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("ddh: %+.16e %+.16e %+.16e\n", ddh_L, ddh_C, ddh_R);
+
+//          3-4. limit slope of L&R
+            if ( dh_LL*dh_L < 0.0 ) {
+               if ( SIGN(dd_L) == SIGN(ddh_L) && SIGN(ddh_L) == SIGN(dd_C) ) {
+                  tmp = SIGN(dd_C) * MIN( C_factor*FABS(dd_L),
+                                          MIN( (real)3.*FABS(ddh_L), C_factor*FABS(dd_C) )
+                                        );
+               } else {
+                  tmp = 0.0;
+               } // if ( SIGN(dd_L) == SIGN(ddh_L) && SIGN(ddh_L) == SIGN(dd_C) ) ... else ...
+               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("extrma at i-1/2, %+.16e => %+.16e ", fc_L, (real)0.5*(cc_L+cc_C) - tmp/(real)6.0);
+               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("tmp = %+.16e\n", tmp);
+               fc_L = (real)0.5*(cc_L+cc_C) - tmp/(real)6.0;
+            } // if ( dh_LL*dh_L < 0.0 )
+
+            if ( dh_R*dh_RR < 0.0 ) {
+               if ( SIGN(dd_C) == SIGN(ddh_R) && SIGN(ddh_R) == SIGN(dd_R) ) {
+                  tmp = SIGN(dd_C) * MIN( C_factor*FABS(dd_C),
+                                          MIN( (real)3.*FABS(ddh_R), C_factor*FABS(dd_R) )
+                                        );
+               } else {
+                  tmp = 0.0;
+               } // if ( SIGN(dd_C) == SIGN(ddh_R) && SIGN(ddh_R) == SIGN(dd_R) ) ... else ...
+               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("extrma at i+1/2, %+.16e => %+.16e ", fc_R, (real)0.5*(cc_R+cc_C) - tmp/(real)6.0);
+               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("tmp = %+.16e\n", tmp);
+               fc_R = (real)0.5*(cc_C+cc_R) - tmp/(real)6.0;
+            } // if ( dh_R*dh_RR < 0.0 )
+
+           // if (debug)  if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("2 => %02d: %+.16e %+.16e\n", i_cc, fc_L, fc_R);
+
+//          3.4.1 test update the half value
+            dh_LL = fc_L - cc_L;
+            dh_L  = cc_C - fc_L;
+            dh_R  = fc_R - cc_C;
+            dh_RR = cc_R - fc_R;
+
+//          3-5. reduce error to round-off error
+            if ( SIGN(dd_L) == SIGN(dd_C) && SIGN(dd_C) == SIGN(dd_R) && SIGN(dd_R) == SIGN(ddh_C) ) {
+               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("same dd at i => ");
+               tmp = SIGN(dd_C) * MIN( C_factor*FABS(dd_L),
+                                       MIN( C_factor*FABS(dd_C),
+                                            MIN( C_factor*FABS(dd_L), (real)6.0*FABS(ddh_C))
+                                          )
+                                     );
+            } else {
+               tmp = 0.0;
+            } // if ( SIGN(dd_L) == SIGN(dd_C) && SIGN(dd_C) == SIGN(dd_R) && SIGN(dd_R) == SIGN(ddh_C) ) ... else ...
+            // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("tmp = %+.16e\n", tmp);
+
+            if ( (real)6.*FABS(ddh_C) > round_err*cc_abs_max ) {
+               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("big dd => ");
+               rho = tmp / ddh_C / (real)6.;
+            } else {
+               rho = 0.0;
+            } // if ( FABS(ddh_C) > round_error*cc_abs_max ) ... else ...
+            // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("rho = %+.16e\n", rho);
+
+            if ( dh_L*dh_R < 0.0 || d_L*d_R < 0.0 ) {
+               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("Extrema at i: ");
+               if ( rho < 1.-round_err )   {
+                  fc_L = cc_C - rho * dh_L;
+                  // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("fix left ");
+               }
+               if ( rho < 1.-round_err )   {
+                  fc_R = cc_C + rho * dh_R;
+                  // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("fix right ");
+               }
+               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("\n");
+            } else {
+               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("No extrema at i: ");
+               if ( FABS(dh_L) >= (real)2.*FABS(dh_R) )   {
+                  fc_L = cc_C - (real)2.*dh_R;
+                  // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("fix left ");
+               }
+               if ( FABS(dh_R) >= (real)2.*FABS(dh_L) )   {
+                  fc_R = cc_C + (real)2.*dh_L;
+                  // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("fix right ");
+               }
+               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("\n");
+            } // if ( dh_L*dh_R < 0.0 && d_L*d_R < 0.0 )
+
+//          3-6. store the value
+            fc[faceL][v] = fc_L;
+            fc[faceR][v] = fc_R;
+            // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("Final: %+.16e %+.16e\n", fc_L, fc_R);
+
+         } // for (int v=0; v<NCOMP_LR; v++)
+
+
+//       4. advance the face-centered variables by half time-step for the CTU integrator
+#        if ( FLU_SCHEME == CTU )
+
+#        ifdef LR_EINT
+#           error : CTU does NOT support LR_EINT !!
+#        endif
+
+         real Coeff_L, Coeff_R;
+         real Correct_L[NCOMP_LR], Correct_R[NCOMP_LR];
+
+//       4-1. compute the PPM coefficient (for the passive scalars as well)
+         for (int v=0; v<NCOMP_LR; v++)
+         {
+            dfc [v] = fc[faceR][v] - fc[faceL][v];
+            dfc6[v] = (real)6.0*(  cc_C_ncomp[v] - (real)0.5*( fc[faceL][v] + fc[faceR][v] )  );
+         }
+
+//       4-2. re-order variables for the y/z directions
+         Hydro_Rotate3D( dfc,  d, true, MAG_OFFSET );
+         Hydro_Rotate3D( dfc6, d, true, MAG_OFFSET );
+
+
+//       =====================================================================================
+//       a. for the HLL solvers (HLLE/HLLC/HLLD)
+//       =====================================================================================
+#        if (  ( RSOLVER == HLLE || RSOLVER == HLLC || RSOLVER == HLLD )  &&  defined HLL_NO_REF_STATE  )
+
+//       4-2-a1. evaluate the corrections to the left and right face-centered variables
+         for (int v=0; v<NWAVE; v++)
+         {
+            Correct_L[ idx_wave[v] ] = (real)0.0;
+            Correct_R[ idx_wave[v] ] = (real)0.0;
+         }
+
+         for (int Mode=0; Mode<NWAVE; Mode++)
+         {
+            Coeff_L = (real)0.0;
+            Coeff_R = (real)0.0;
+
+            if ( HLL_Include_All_Waves  ||  EigenVal[d][Mode] <= (real)0.0 )
+            {
+               const real Coeff_C = -dt_dh2*EigenVal[d][Mode];
+               const real Coeff_D = real(-4.0/3.0)*SQR(Coeff_C);
+
+               for (int v=0; v<NWAVE; v++)
+                  Coeff_L += LEigenVec[Mode][v]*(  Coeff_C*( dfc[ idx_wave[v] ] + dfc6[ idx_wave[v] ] ) +
+                                                   Coeff_D*( dfc6[ idx_wave[v] ]                      )  );
+
+               for (int v=0; v<NWAVE; v++)
+                  Correct_L[ idx_wave[v] ] += Coeff_L*REigenVec[Mode][v];
+            }
+
+            if ( HLL_Include_All_Waves  ||  EigenVal[d][Mode] >= (real)0.0 )
+            {
+               const real Coeff_A = -dt_dh2*EigenVal[d][Mode];
+               const real Coeff_B = real(-4.0/3.0)*SQR(Coeff_A);
+
+               for (int v=0; v<NWAVE; v++)
+                  Coeff_R += LEigenVec[Mode][v]*(  Coeff_A*( dfc[ idx_wave[v] ] - dfc6[ idx_wave[v] ] ) +
+                                                   Coeff_B*( dfc6[ idx_wave[v] ]                      )  );
+
+               for (int v=0; v<NWAVE; v++)
+                  Correct_R[ idx_wave[v] ] += Coeff_R*REigenVec[Mode][v];
+            }
+         } // for (int Mode=0; Mode<NWAVE; Mode++)
+
+
+//       =====================================================================================
+//       b. for the Roe's and exact solvers
+//       =====================================================================================
+#        else // ( RSOLVER == ROE/EXACT || ifndef HLL_NO_REF_STATE )
+
+//       4-2-b1. evaluate the reference states
+         Coeff_L = -dt_dh2*FMIN( EigenVal[d][       0 ], (real)0.0 );
+         Coeff_R = -dt_dh2*FMAX( EigenVal[d][ NWAVE-1 ], (real)0.0 );
+
+         for (int v=0; v<NWAVE; v++)
+         {
+            Correct_L[ idx_wave[v] ] = Coeff_L*(  dfc[ idx_wave[v] ] + ( (real)1.0 - real(4.0/3.0)*Coeff_L )*dfc6[ idx_wave[v] ]  );
+            Correct_R[ idx_wave[v] ] = Coeff_R*(  dfc[ idx_wave[v] ] - ( (real)1.0 + real(4.0/3.0)*Coeff_R )*dfc6[ idx_wave[v] ]  );
+         }
+
+
+//       4-2-b2. evaluate the corrections to the left and right face-centered variables
+         for (int Mode=0; Mode<NWAVE; Mode++)
+         {
+            Coeff_L = (real)0.0;
+            Coeff_R = (real)0.0;
+
+            if ( EigenVal[d][Mode] <= (real)0.0 )
+            {
+               const real Coeff_C = dt_dh2*( EigenVal[d][0] - EigenVal[d][Mode] );
+//             write as (a-b)*(a+b) instead of a^2-b^2 to ensure that Coeff_D=0 when Coeff_C=0
+//             Coeff_D = real(4.0/3.0)*dt_dh2*dt_dh2* ( EigenVal[d][   0]*EigenVal[d][   0] -
+//                                                      EigenVal[d][Mode]*EigenVal[d][Mode]   );
+               const real Coeff_D = real(4.0/3.0)*dt_dh2*Coeff_C*( EigenVal[d][0] + EigenVal[d][Mode] );
+
+               for (int v=0; v<NWAVE; v++)
+                  Coeff_L += LEigenVec[Mode][v]*(  Coeff_C*( dfc[ idx_wave[v] ] + dfc6[ idx_wave[v] ] ) +
+                                                   Coeff_D*( dfc6[ idx_wave[v] ]                      )  );
+
+               for (int v=0; v<NWAVE; v++)
+                  Correct_L[ idx_wave[v] ] += Coeff_L*REigenVec[Mode][v];
+            }
+
+            if ( EigenVal[d][Mode] >= (real)0.0 )
+            {
+               const real Coeff_A = dt_dh2*( EigenVal[d][ NWAVE-1 ] - EigenVal[d][Mode] );
+//             write as (a-b)*(a+b) instead of a^2-b^2 to ensure that Coeff_B=0 when Coeff_A=0
+//             Coeff_B = real(4.0/3.0)*dt_dh2*dt_dh2* ( EigenVal[d][NWAVE-1]*EigenVal[d][NWAVE-1] -
+//                                                      EigenVal[d][Mode   ]*EigenVal[d][Mode   ]   );
+               const real Coeff_B = real(4.0/3.0)*dt_dh2*Coeff_A*( EigenVal[d][ NWAVE-1 ] + EigenVal[d][Mode] );
+
+               for (int v=0; v<NWAVE; v++)
+                  Coeff_R += LEigenVec[Mode][v]*(  Coeff_A*( dfc[ idx_wave[v] ] - dfc6[ idx_wave[v] ] ) +
+                                                   Coeff_B*( dfc6[ idx_wave[v] ]                      )  );
+
+               for (int v=0; v<NWAVE; v++)
+                  Correct_R[ idx_wave[v] ] += Coeff_R*REigenVec[Mode][v];
+            }
+         } // for (int Mode=0; Mode<NWAVE; Mode++)
+
+#        endif // if (  ( RSOLVER == HLLE || RSOLVER == HLLC || RSOLVER == HLLD )  &&  defined HLL_NO_REF_STATE  ) ... else ...
+
+
+//       4-3. evaluate the corrections to the left and right face-centered passive scalars
+//            --> passive scalars travel with fluid velocity (i.e., entropy mode)
+#        if ( NCOMP_PASSIVE > 0 )
+         Coeff_L = -dt_dh2*FMIN( EigenVal[d][1], (real)0.0 );
+         Coeff_R = -dt_dh2*FMAX( EigenVal[d][1], (real)0.0 );
+
+         for (int v=NCOMP_FLUID; v<NCOMP_TOTAL; v++)
+         {
+            Correct_L[v] = Coeff_L*(  dfc[v] + ( (real)1.0 - real(4.0/3.0)*Coeff_L )*dfc6[v]  );
+            Correct_R[v] = Coeff_R*(  dfc[v] - ( (real)1.0 + real(4.0/3.0)*Coeff_R )*dfc6[v]  );
+         }
+#        endif
+
+
+//       4-4. add the MHD source terms
+#        ifdef MHD
+         const int t1 = (d+1)%3;    // transverse direction 1
+         const int t2 = (d+2)%3;    // transverse direction 2
+         real B_nL, B_nR, B_t1L, B_t1R, B_t2L, B_t2R;
+         real dB_n, dB_t1, dB_t2, v_t1, v_t2, src_t1, src_t2;
+
+         B_nL   = g_FC_B[d ][ idx_B[d ] ];
+         B_t1L  = g_FC_B[t1][ idx_B[t1] ];
+         B_t2L  = g_FC_B[t2][ idx_B[t2] ];
+         B_nR   = g_FC_B[d ][ idx_B[d ] + didx_cc[d ] ];
+         B_t1R  = g_FC_B[t1][ idx_B[t1] + didx_cc[t1] ];
+         B_t2R  = g_FC_B[t2][ idx_B[t2] + didx_cc[t2] ];
+
+         dB_n   = B_nR  - B_nL;
+         dB_t1  = B_t1R - B_t1L;
+         dB_t2  = B_t2R - B_t2L;
+
+         v_t1   = cc_C_ncomp[ 1 + t1 ];
+         v_t2   = cc_C_ncomp[ 1 + t2 ];
+
+         src_t1 = dt_dh2*v_t1*MINMOD( dB_n, -dB_t1 );
+         src_t2 = dt_dh2*v_t2*MINMOD( dB_n, -dB_t2 );
+
+         Correct_L[ MAG_OFFSET + 1 ] += src_t1;
+         Correct_R[ MAG_OFFSET + 1 ] += src_t1;
+         Correct_L[ MAG_OFFSET + 2 ] += src_t2;
+         Correct_R[ MAG_OFFSET + 2 ] += src_t2;
+#        endif // #ifdef MHD
+
+
+//       4-5. evaluate the face-centered variables at the half time-step
+         Hydro_Rotate3D( Correct_L, d, false, MAG_OFFSET );
+         Hydro_Rotate3D( Correct_R, d, false, MAG_OFFSET );
+
+         for (int v=0; v<NCOMP_LR; v++)
+         {
+            fc[faceL][v] += Correct_L[v];
+            fc[faceR][v] += Correct_R[v];
+         }
+
+
+//       4-6. apply density and pressure floors
+         fc[faceL][0] = FMAX( fc[faceL][0], MinDens );
+         fc[faceR][0] = FMAX( fc[faceR][0], MinDens );
+
+         fc[faceL][4] = Hydro_CheckMinPres( fc[faceL][4], MinPres );
+         fc[faceR][4] = Hydro_CheckMinPres( fc[faceR][4], MinPres );
+
+#        if ( NCOMP_PASSIVE > 0 )
+         for (int v=NCOMP_FLUID; v<NCOMP_TOTAL; v++) {
+         fc[faceL][v] = FMAX( fc[faceL][v], TINY_NUMBER );
+         fc[faceR][v] = FMAX( fc[faceR][v], TINY_NUMBER ); }
+#        endif
+
+#        endif // #if ( FLU_SCHEME == CTU )
+
+
+//       5. reset the longitudinal B field to the input face-centered values
+//          --> actually no data reconstruction is required for that
+//###OPTIMIZARION: do not perform data reconstruction for the longitudinal B field
+#        ifdef MHD
+#        if ( FLU_SCHEME != CTU )
+         const real B_nL = g_FC_B[d][ idx_B[d]              ];
+         const real B_nR = g_FC_B[d][ idx_B[d] + didx_cc[d] ];
+#        endif
+         fc[faceL][ MAG_OFFSET + d ] = B_nL;
+         fc[faceR][ MAG_OFFSET + d ] = B_nR;
+#        endif // #ifdef MHD
+
+
+//       6. primitive variables --> conserved variables
+//          --> When LR_EINT is on, use the reconstructed internal energy instead of pressure in Hydro_Pri2Con()
+//              to skip expensive EoS conversion
+         real tmp[NCOMP_LR];  // input and output arrays must not overlap for Pri2Con()
+#        ifdef LR_EINT
+         real* const EintPtr = tmp + NCOMP_TOTAL_PLUS_MAG;
+#        else
+         real* const EintPtr = NULL;
+#        endif
+
+         for (int v=0; v<NCOMP_LR; v++)   tmp[v] = fc[faceL][v];
+         Hydro_Pri2Con( tmp, fc[faceL], FracPassive, NFrac, FracIdx, EoS->DensPres2Eint_FuncPtr,
+                        EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, EintPtr );
+
+         for (int v=0; v<NCOMP_LR; v++)   tmp[v] = fc[faceR][v];
+         Hydro_Pri2Con( tmp, fc[faceR], FracPassive, NFrac, FracIdx, EoS->DensPres2Eint_FuncPtr,
+                        EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, EintPtr );
+
+      } // for (int d=0; d<3; d++)
+
+
+#     if ( FLU_SCHEME == MHM )
+//    7. advance the face-centered variables by half time-step for the MHM integrator
+      Hydro_HancockPredict( fc, dt, dh, g_ConVar, idx_cc, i_cc, j_cc, k_cc, g_FC_B, g_EC_Ele, NGhost, N_HF_ELE,
+                            MinDens, MinPres, MinEint, EoS );
+#     endif // # if ( FLU_SCHEME == MHM )
+
+
+//    8. store the face-centered values to the output array
+//       --> use NCOMP_TOTAL_PLUS_MAG instead of LR_EINT since we don't need to store internal energy in g_FC_Var[]
+      for (int f=0; f<6; f++)
+      for (int v=0; v<NCOMP_TOTAL_PLUS_MAG; v++)
+         g_FC_Var[f][v][idx_fc] = fc[f][v];
+
+      // if ( j_cc == 8 && k_cc == 8 )
+      // {
+      //    printf( "i=%02d, j=%02d, k=%02d", i_cc, j_cc, k_cc);
+      //    printf( "| %+.16e %+.16e %+.16e | ", fc[0][0], g_PriVar[0][idx_cc], fc[1][0] );
+      //    printf( "| %+.16e %+.16e %+.16e | ", fc[0][1], g_PriVar[1][idx_cc], fc[1][1] );
+      //    printf( "| %+.16e %+.16e %+.16e | ", fc[0][2], g_PriVar[2][idx_cc], fc[1][2] );
+      //    printf( "| %+.16e %+.16e %+.16e | ", fc[0][3], g_PriVar[3][idx_cc], fc[1][3] );
+      //    printf( "| %+.16e %+.16e %+.16e | ", fc[0][4], g_PriVar[4][idx_cc], fc[1][4] );
+      //    printf("\n");
+      // }
+
+   } // CGPU_LOOP( idx_fc, CUBE(N_FC_VAR) )
+
+#  ifdef __CUDACC__
+   __syncthreads();
+#  endif
+
+#  if ( FLU_SCHEME == MHM  &&  defined MHD )
+// 9. Store the half-step primitive variables for MHM+MHD
+//    --> must be done after the CGPU_LOOP( idx_fc, CUBE(N_FC_VAR) ) loop since it will update g_PriVar[]
+   Hydro_ConFC2PriCC_MHM( g_PriVar, g_FC_Var, MinDens, MinPres, MinEint, FracPassive, NFrac, FracIdx,
+                          JeansMinPres, JeansMinPres_Coeff, EoS );
+
+#  endif // #if ( FLU_SCHEME == MHM  &&  defined MHD )
+
+} // FUNCTION : Hydro_DataReconstruction (PPM)
+#endif // #if ( LR_SCHEME == PPM )
+
+
+
+#if ( LR_SCHEME == PPM_OLD )
+//-------------------------------------------------------------------------------------------------------
+// Function    :  Hydro_DataReconstruction
+// Description :  Reconstruct the face-centered variables by the piecewise-parabolic method (PPM)
+//
+// Note        :  See the PLM routine
+//
+// Parameter   :  See the PLM routine
+//------------------------------------------------------------------------------------------------------
+GPU_DEVICE
+void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
+                               const real g_FC_B     [][ SQR(FLU_NXT)*FLU_NXT_P1 ],
+                                     real g_PriVar   [][ CUBE(FLU_NXT) ],
+                                     real g_FC_Var   [][NCOMP_TOTAL_PLUS_MAG][ CUBE(N_FC_VAR) ],
+                                     real g_Slope_PPM[][NCOMP_LR            ][ CUBE(N_SLOPE_PPM) ],
+                                     real g_EC_Ele   [][ CUBE(N_EC_ELE) ],
+                               const bool Con2Pri, const LR_Limiter_t LR_Limiter, const real MinMod_Coeff,
+                               const real dt, const real dh,
+                               const real MinDens, const real MinPres, const real MinEint,
+                               const bool FracPassive, const int NFrac, const int FracIdx[],
+                               const bool JeansMinPres, const real JeansMinPres_Coeff,
+                               const EoS_t *EoS )
+{
+
+//### NOTE: temporary solution to the bug in cuda 10.1 and 10.2 that incorrectly overwrites didx_cc[]
+#  if   ( FLU_SCHEME == MHM )
+   const int NIn    = FLU_NXT;
+#  elif ( FLU_SCHEME == MHM_RP )
+   const int NIn    = N_HF_VAR;
+#  elif ( FLU_SCHEME == CTU )
+   const int NIn    = FLU_NXT;
+#  else
+#  error : ERROR : unsupported FLU_SCHEME !!
+#  endif
+   const int NGhost = LR_GHOST_SIZE;
+
+
+// check
+#  ifdef GAMER_DEBUG
+   if ( NIn - 2*NGhost != N_FC_VAR )
+      printf( "ERROR : NIn - 2*NGhost != N_FC_VAR (NIn %d, NGhost %d, N_FC_VAR %d) !!\n",
+              NIn, NGhost, N_FC_VAR );
+
+#  if ( N_SLOPE_PPM != N_FC_VAR + 2 )
+#     error : ERROR : N_SLOPE_PPM != N_FC_VAR + 2 !!
+#  endif
+
+#  if ( defined LR_EINT  &&  FLU_SCHEME == CTU )
+#     error : CTU does NOT support LR_EINT !!
+#  endif
+#  endif // GAMER_DEBUG
+
+
+   const int  didx_cc   [3]  = { 1, NIn, SQR(NIn) };
+   const int  didx_slope[3]  = { 1, N_SLOPE_PPM, SQR(N_SLOPE_PPM) };
+
+#  if ( FLU_SCHEME == CTU )
+   const real dt_dh2         = (real)0.5*dt/dh;
+
+// index mapping between arrays with size NWAVE and NCOMP_TOTAL_PLUS_MAG/NCOMP_LR
+#  ifdef MHD
+   const int idx_wave[NWAVE] = { 0, 1, 2, 3, 4, MAG_OFFSET+1, MAG_OFFSET+2 };
+#  else
+   const int idx_wave[NWAVE] = { 0, 1, 2, 3, 4 };
+#  endif
+
+// include waves both from left and right directions during the data reconstruction, as suggested in ATHENA
+#  if (  ( RSOLVER == HLLE || RSOLVER == HLLC || RSOLVER == HLLD )  &&  defined HLL_NO_REF_STATE  )
+#  ifdef HLL_INCLUDE_ALL_WAVES
+   const bool HLL_Include_All_Waves = true;
+#  else
+   const bool HLL_Include_All_Waves = false;
+#  endif
+#  endif // if (  ( RSOLVER == HLLE || RSOLVER == HLLC || RSOLVER == HLLD )  &&  defined HLL_NO_REF_STATE  )
+#  endif // #if ( FLU_SCHEME == CTU )
+
+// eigenvalues and eigenvectors
+// --> constant components of the left and right eigenvector matrices must be initialized
+#  if ( FLU_SCHEME == CTU )
+   real EigenVal[3][NWAVE];
+#  ifdef MHD
+   real REigenVec[NWAVE][NWAVE] = { { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
+                                    {       0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
+                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
+                                    {       1.0,       0.0,       0.0,       0.0,       0.0,       0.0,       0.0 },
+                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
+                                    {       0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
+                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL } };
+   real LEigenVec[NWAVE][NWAVE] = { { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
+                                    { 0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
+                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
+                                    { 1.0,       0.0,       0.0,       0.0, NULL_REAL,       0.0,       0.0 },
+                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
+                                    { 0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
+                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL } };
+
+#  else
+   real LEigenVec[NWAVE][NWAVE] = { { 0.0, NULL_REAL, 0.0, 0.0, NULL_REAL },
+                                    { 1.0,       0.0, 0.0, 0.0, NULL_REAL },
+                                    { 0.0,       0.0, 1.0, 0.0,       0.0 },
+                                    { 0.0,       0.0, 0.0, 1.0,       0.0 },
+                                    { 0.0, NULL_REAL, 0.0, 0.0, NULL_REAL } };
+
+   real REigenVec[NWAVE][NWAVE] = { { 1.0, NULL_REAL, 0.0, 0.0, NULL_REAL },
+                                    { 1.0,       0.0, 0.0, 0.0,       0.0 },
+                                    { 0.0,       0.0, 1.0, 0.0,       0.0 },
+                                    { 0.0,       0.0, 0.0, 1.0,       0.0 },
+                                    { 1.0, NULL_REAL, 0.0, 0.0, NULL_REAL } };
+#  endif // #ifdef MHD ... else ...
+
+#  elif ( defined MHD  &&  defined CHAR_RECONSTRUCTION ) // #if ( FLU_SCHEME == CTU )
+   real EigenVal[3][NWAVE];
+   real REigenVec[NWAVE][NWAVE] = { { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
+                                    {       0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
+                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
+                                    {       1.0,       0.0,       0.0,       0.0,       0.0,       0.0,       0.0 },
+                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
+                                    {       0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
+                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL } };
+   real LEigenVec[NWAVE][NWAVE] = { { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
+                                    { 0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
+                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
+                                    { 1.0,       0.0,       0.0,       0.0, NULL_REAL,       0.0,       0.0 },
+                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
+                                    { 0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
+                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL } };
+
+#  else // #if ( FLU_SCHEME == CTU ) ... elif ...
+   real (*const REigenVec)[NWAVE] = NULL;
+   real (*const LEigenVec)[NWAVE] = NULL;
+#  endif // #if ( FLU_SCHEME ==  CTU ) ... elif ... else ...
+
+
+// 0. conserved --> primitive variables
+   if ( Con2Pri )
+   {
+      real ConVar_1Cell[NCOMP_TOTAL_PLUS_MAG], PriVar_1Cell[NCOMP_TOTAL_PLUS_MAG];
+#     ifdef LR_EINT
+      real Eint;
+      real* const EintPtr = &Eint;
+#     else
+      real* const EintPtr = NULL;
+#     endif
+
+      CGPU_LOOP( idx, CUBE(NIn) )
+      {
+         for (int v=0; v<NCOMP_TOTAL; v++)   ConVar_1Cell[v] = g_ConVar[v][idx];
+
+#        ifdef MHD
+//       assuming that g_FC_B[] is accessed with the strides NIn/NIn+1 along the transverse/longitudinal directions
+         const int size_ij = SQR( NIn );
+         const int i       = idx % NIn;
+         const int j       = idx % size_ij / NIn;
+         const int k       = idx / size_ij;
+
+         MHD_GetCellCenteredBField( ConVar_1Cell+NCOMP_TOTAL, g_FC_B[0], g_FC_B[1], g_FC_B[2], NIn, NIn, NIn, i, j, k );
+#        endif
+
+         Hydro_Con2Pri( ConVar_1Cell, PriVar_1Cell, MinPres, FracPassive, NFrac, FracIdx,
+                        JeansMinPres, JeansMinPres_Coeff, EoS->DensEint2Pres_FuncPtr, EoS->DensPres2Eint_FuncPtr,
+                        EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, EintPtr );
+
+         for (int v=0; v<NCOMP_TOTAL_PLUS_MAG; v++)   g_PriVar[v][idx] = PriVar_1Cell[v];
+
+#        ifdef LR_EINT
+         g_PriVar[NCOMP_TOTAL_PLUS_MAG][idx] = Hydro_CheckMinEint( Eint, MinEint ); // store Eint in the last variable
+#        endif
+      } // CGPU_LOOP( idx, CUBE(NIn) )
+
+#     ifdef __CUDACC__
+      __syncthreads();
+#     endif
+   } // if ( Con2Pri )
+
+
+// 1. evaluate the monotonic slope of all cells
+   const int N_SLOPE_PPM2 = SQR( N_SLOPE_PPM );
+   CGPU_LOOP( idx_slope, CUBE(N_SLOPE_PPM) )
+   {
+      const int i_cc   = NGhost - 1 + idx_slope%N_SLOPE_PPM;
+      const int j_cc   = NGhost - 1 + idx_slope%N_SLOPE_PPM2/N_SLOPE_PPM;
+      const int k_cc   = NGhost - 1 + idx_slope/N_SLOPE_PPM2;
+      const int idx_cc = IDX321( i_cc, j_cc, k_cc, NIn, NIn );
+
+//    cc_C/L/R: cell-centered variables of the Central/Left/Right cells
+      real cc_C[NCOMP_LR], cc_L[NCOMP_LR], cc_R[NCOMP_LR], Slope_Limiter[NCOMP_LR];
+
+      for (int v=0; v<NCOMP_LR; v++)   cc_C[v] = g_PriVar[v][idx_cc];
+
+//    loop over different spatial directions
+      for (int d=0; d<3; d++)
+      {
+         const int idx_ccL = idx_cc - didx_cc[d];
+         const int idx_ccR = idx_cc + didx_cc[d];
+
+#        if ( defined MHD  &&  defined CHAR_RECONSTRUCTION )
+         MHD_GetEigenSystem( cc_C, EigenVal[d], LEigenVec, REigenVec, EoS, d );
+#        endif
+
+         for (int v=0; v<NCOMP_LR; v++)
+         {
+            cc_L[v] = g_PriVar[v][idx_ccL];
+            cc_R[v] = g_PriVar[v][idx_ccR];
+         }
+
+         Hydro_LimitSlope( cc_L, cc_C, cc_R, LR_Limiter, MinMod_Coeff, d,
+                           LEigenVec, REigenVec, Slope_Limiter, EoS );
+
+//       store the results to g_Slope_PPM[]
+         for (int v=0; v<NCOMP_LR; v++)   g_Slope_PPM[d][v][idx_slope] = Slope_Limiter[v];
+
+      } // for (int d=0; d<3; d++)
+   } // CGPU_LOOP( idx_slope, CUBE(N_SLOPE_PPM) )
+
+#  ifdef __CUDACC__
+   __syncthreads();
+#  endif
+
+
+// compute electric field for MHM
+#  if ( FLU_SCHEME == MHM  &&  defined MHD )
+   MHD_ComputeElectric_Half( g_EC_Ele, g_ConVar, g_FC_B, N_HF_ELE, NIn, NGhost );
+#  endif
+
+
+// data reconstruction
+   const int N_FC_VAR2 = SQR( N_FC_VAR );
+#  ifdef MHD
+   const int NIn_p1    = NIn + 1;
+   int idx_B[NCOMP_MAG];
+#  endif
+
    CGPU_LOOP( idx_fc, CUBE(N_FC_VAR) )
    {
       const int i_fc      = idx_fc%N_FC_VAR;
@@ -1275,8 +1997,8 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
 
 #  endif // #if ( FLU_SCHEME == MHM  &&  defined MHD )
 
-} // FUNCTION : Hydro_DataReconstruction (PPM)
-#endif // #if ( LR_SCHEME == PPM )
+} // FUNCTION : Hydro_DataReconstruction (PPM_OLD)
+#endif // #if ( LR_SCHEME == PPM_OLD )
 
 
 

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
@@ -957,1407 +957,152 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
          const int faceR      = faceL+1;
          const int idx_ccLL   = idx_cc - 2*didx_cc[d];
          const int idx_ccL    = idx_cc - didx_cc[d];
-         const int idx_ccC    = idx_cc;
          const int idx_ccR    = idx_cc + didx_cc[d];
          const int idx_ccRR   = idx_cc + 2*didx_cc[d];
-
-         const real C_factor = 1.25;
-         const real round_err = 1.e-12;
-
-         const bool debug = false;
-
-         for (int v=0; v<NCOMP_LR; v++)
-         {
-            real tmp, rho, cc_abs_max;
-
-            real fc_L, fc_R;                     // face center value
-            real cc_LL, cc_L, cc_C, cc_R, cc_RR; // cell center value
-            real d_LL, d_L, d_R, d_RR;           // slope at face center
-            real dd_L, dd_C, dd_R;               // curverture at cell center
-
-//          3-1. get all the value needed
-            cc_LL = g_PriVar[v][idx_ccLL];
-            cc_L  = g_PriVar[v][idx_ccL ];
-            cc_C  = g_PriVar[v][idx_cc  ];
-            cc_R  = g_PriVar[v][idx_ccR ];
-            cc_RR = g_PriVar[v][idx_ccRR];
-
-            d_LL  = cc_L  - cc_LL;
-            d_L   = cc_C  - cc_L ;
-            d_R   = cc_R  - cc_C ;
-            d_RR  = cc_RR - cc_R ;
-
-            dd_L  = cc_LL - (real)2.*cc_L + cc_C ;
-            dd_C  = cc_L  - (real)2.*cc_C + cc_R ;
-            dd_R  = cc_C  - (real)2.*cc_R + cc_RR;
-
-            cc_abs_max = MAX( FABS(cc_LL),
-                              MAX( FABS(cc_L),
-                                   MAX( FABS(cc_C),
-                                        MAX( FABS(cc_R), FABS(cc_RR) )
-                                      )
-                                 )
-                            );
-
-//          3-2. interpolate the face value
-            fc_L = ( -cc_LL + (real)7.*cc_L + (real)7.*cc_C - cc_R  ) / (real)12.0;
-            fc_R = ( -cc_L  + (real)7.*cc_C + (real)7.*cc_R - cc_RR ) / (real)12.0;
-            // fc_L = ((real)6.*(cc_L + cc_C) + cc_C - cc_LL - cc_R  + cc_L ) / (real)12.;
-            // fc_R = ((real)6.*(cc_C + cc_R) + cc_R - cc_L  - cc_RR + cc_C ) / (real)12.;
-            // real qa = cc_C - cc_L;
-            // real qb = cc_R - cc_C;
-            // real dd_im1 = qa / (real)2. + (cc_L - cc_LL) / (real)2.;
-            // real dd     = qb / (real)2. + qa / (real)2.;
-            // real dd_ip1 = (cc_RR - cc_R) / (real)2. + qb / (real)2.;
-            // fc_L = cc_L/(real)2. + cc_C/(real)2. + dd_im1/(real)6. - dd    /(real)6.;
-            // fc_R = cc_C/(real)2. + cc_R/(real)2. + dd    /(real)6. - dd_ip1/(real)6.;
-
-//          3-3. prepare half value
-            real dh_LL, dh_L, dh_R, dh_RR;
-            real ddh_L, ddh_C, ddh_R;
-
-            dh_LL = fc_L - cc_L;
-            dh_L  = cc_C - fc_L;
-            dh_R  = fc_R - cc_C;
-            dh_RR = cc_R - fc_R;
-
-            ddh_L = cc_L - (real)2.*fc_L + cc_C;
-            ddh_C = fc_L - (real)2.*cc_C + fc_R;
-            ddh_R = cc_C - (real)2.*fc_R + cc_R;
-
-//          3-4. limit slope of L&R
-            if ( dh_LL*dh_L < 0.0 ) {
-               if ( SIGN(dd_L) == SIGN(ddh_L) && SIGN(ddh_L) == SIGN(dd_C) ) {
-                  tmp = SIGN(dd_C) * MIN( C_factor*FABS(dd_L),
-                                          MIN( (real)3.*FABS(ddh_L), C_factor*FABS(dd_C) )
-                                        );
-               } else {
-                  tmp = 0.0;
-               } // if ( SIGN(dd_L) == SIGN(ddh_L) && SIGN(ddh_L) == SIGN(dd_C) ) ... else ...
-               fc_L = (real)0.5*(cc_L+cc_C) - tmp/(real)6.0;
-            } // if ( dh_LL*dh_L < 0.0 )
-
-            if ( dh_R*dh_RR < 0.0 ) {
-               if ( SIGN(dd_C) == SIGN(ddh_R) && SIGN(ddh_R) == SIGN(dd_R) ) {
-                  tmp = SIGN(dd_C) * MIN( C_factor*FABS(dd_C),
-                                          MIN( (real)3.*FABS(ddh_R), C_factor*FABS(dd_R) )
-                                        );
-               } else {
-                  tmp = 0.0;
-               } // if ( SIGN(dd_C) == SIGN(ddh_R) && SIGN(ddh_R) == SIGN(dd_R) ) ... else ...
-               fc_R = (real)0.5*(cc_C+cc_R) - tmp/(real)6.0;
-            } // if ( dh_R*dh_RR < 0.0 )
-
-//          3.4.1 test update the half value
-            dh_LL = fc_L - cc_L;
-            dh_L  = cc_C - fc_L;
-            dh_R  = fc_R - cc_C;
-            dh_RR = cc_R - fc_R;
-
-//          3-5. reduce error to round-off error
-            if ( SIGN(dd_L) == SIGN(dd_C) && SIGN(dd_C) == SIGN(dd_R) && SIGN(dd_R) == SIGN(ddh_C) ) {
-               tmp = SIGN(dd_C) * MIN( C_factor*FABS(dd_L),
-                                       MIN( C_factor*FABS(dd_C),
-                                            MIN( C_factor*FABS(dd_L), (real)6.0*FABS(ddh_C))
-                                          )
-                                     );
-            } else {
-               tmp = 0.0;
-            } // if ( SIGN(dd_L) == SIGN(dd_C) && SIGN(dd_C) == SIGN(dd_R) && SIGN(dd_R) == SIGN(ddh_C) ) ... else ...
-
-            if ( (real)6.*FABS(ddh_C) > round_err*cc_abs_max ) {
-               rho = tmp / ddh_C / (real)6.;
-            } else {
-               rho = 0.0;
-            } // if ( FABS(ddh_C) > round_error*cc_abs_max ) ... else ...
-
-            if ( dh_L*dh_R < 0.0 || d_L*d_R < 0.0 ) {
-               if ( rho < 1.-round_err )   {
-                  fc_L = cc_C - rho * dh_L;
-               }
-               if ( rho < 1.-round_err )   {
-                  fc_R = cc_C + rho * dh_R;
-               }
-            } else {
-               if ( FABS(dh_L) >= (real)2.*FABS(dh_R) )   {
-                  fc_L = cc_C - (real)2.*dh_R;
-               }
-               if ( FABS(dh_R) >= (real)2.*FABS(dh_L) )   {
-                  fc_R = cc_C + (real)2.*dh_L;
-               }
-            } // if ( dh_L*dh_R < 0.0 && d_L*d_R < 0.0 )
-
-//          3-6. store the value
-            fc[faceL][v] = fc_L;
-            fc[faceR][v] = fc_R;
-
-         } // for (int v=0; v<NCOMP_LR; v++)
-
-
-//       4. advance the face-centered variables by half time-step for the CTU integrator
-#        if ( FLU_SCHEME == CTU )
-
-#        ifdef LR_EINT
-#           error : CTU does NOT support LR_EINT !!
-#        endif
-
-         real Coeff_L, Coeff_R;
-         real Correct_L[NCOMP_LR], Correct_R[NCOMP_LR];
-
-//       4-1. compute the PPM coefficient (for the passive scalars as well)
-         for (int v=0; v<NCOMP_LR; v++)
-         {
-            dfc [v] = fc[faceR][v] - fc[faceL][v];
-            dfc6[v] = (real)6.0*(  cc_C_ncomp[v] - (real)0.5*( fc[faceL][v] + fc[faceR][v] )  );
-         }
-
-//       4-2. re-order variables for the y/z directions
-         Hydro_Rotate3D( dfc,  d, true, MAG_OFFSET );
-         Hydro_Rotate3D( dfc6, d, true, MAG_OFFSET );
-
-
-//       =====================================================================================
-//       a. for the HLL solvers (HLLE/HLLC/HLLD)
-//       =====================================================================================
-#        if (  ( RSOLVER == HLLE || RSOLVER == HLLC || RSOLVER == HLLD )  &&  defined HLL_NO_REF_STATE  )
-
-//       4-2-a1. evaluate the corrections to the left and right face-centered variables
-         for (int v=0; v<NWAVE; v++)
-         {
-            Correct_L[ idx_wave[v] ] = (real)0.0;
-            Correct_R[ idx_wave[v] ] = (real)0.0;
-         }
-
-         for (int Mode=0; Mode<NWAVE; Mode++)
-         {
-            Coeff_L = (real)0.0;
-            Coeff_R = (real)0.0;
-
-            if ( HLL_Include_All_Waves  ||  EigenVal[d][Mode] <= (real)0.0 )
-            {
-               const real Coeff_C = -dt_dh2*EigenVal[d][Mode];
-               const real Coeff_D = real(-4.0/3.0)*SQR(Coeff_C);
-
-               for (int v=0; v<NWAVE; v++)
-                  Coeff_L += LEigenVec[Mode][v]*(  Coeff_C*( dfc[ idx_wave[v] ] + dfc6[ idx_wave[v] ] ) +
-                                                   Coeff_D*( dfc6[ idx_wave[v] ]                      )  );
-
-               for (int v=0; v<NWAVE; v++)
-                  Correct_L[ idx_wave[v] ] += Coeff_L*REigenVec[Mode][v];
-            }
-
-            if ( HLL_Include_All_Waves  ||  EigenVal[d][Mode] >= (real)0.0 )
-            {
-               const real Coeff_A = -dt_dh2*EigenVal[d][Mode];
-               const real Coeff_B = real(-4.0/3.0)*SQR(Coeff_A);
-
-               for (int v=0; v<NWAVE; v++)
-                  Coeff_R += LEigenVec[Mode][v]*(  Coeff_A*( dfc[ idx_wave[v] ] - dfc6[ idx_wave[v] ] ) +
-                                                   Coeff_B*( dfc6[ idx_wave[v] ]                      )  );
-
-               for (int v=0; v<NWAVE; v++)
-                  Correct_R[ idx_wave[v] ] += Coeff_R*REigenVec[Mode][v];
-            }
-         } // for (int Mode=0; Mode<NWAVE; Mode++)
-
-
-//       =====================================================================================
-//       b. for the Roe's and exact solvers
-//       =====================================================================================
-#        else // ( RSOLVER == ROE/EXACT || ifndef HLL_NO_REF_STATE )
-
-//       4-2-b1. evaluate the reference states
-         Coeff_L = -dt_dh2*FMIN( EigenVal[d][       0 ], (real)0.0 );
-         Coeff_R = -dt_dh2*FMAX( EigenVal[d][ NWAVE-1 ], (real)0.0 );
-
-         for (int v=0; v<NWAVE; v++)
-         {
-            Correct_L[ idx_wave[v] ] = Coeff_L*(  dfc[ idx_wave[v] ] + ( (real)1.0 - real(4.0/3.0)*Coeff_L )*dfc6[ idx_wave[v] ]  );
-            Correct_R[ idx_wave[v] ] = Coeff_R*(  dfc[ idx_wave[v] ] - ( (real)1.0 + real(4.0/3.0)*Coeff_R )*dfc6[ idx_wave[v] ]  );
-         }
-
-
-//       4-2-b2. evaluate the corrections to the left and right face-centered variables
-         for (int Mode=0; Mode<NWAVE; Mode++)
-         {
-            Coeff_L = (real)0.0;
-            Coeff_R = (real)0.0;
-
-            if ( EigenVal[d][Mode] <= (real)0.0 )
-            {
-               const real Coeff_C = dt_dh2*( EigenVal[d][0] - EigenVal[d][Mode] );
-//             write as (a-b)*(a+b) instead of a^2-b^2 to ensure that Coeff_D=0 when Coeff_C=0
-//             Coeff_D = real(4.0/3.0)*dt_dh2*dt_dh2* ( EigenVal[d][   0]*EigenVal[d][   0] -
-//                                                      EigenVal[d][Mode]*EigenVal[d][Mode]   );
-               const real Coeff_D = real(4.0/3.0)*dt_dh2*Coeff_C*( EigenVal[d][0] + EigenVal[d][Mode] );
-
-               for (int v=0; v<NWAVE; v++)
-                  Coeff_L += LEigenVec[Mode][v]*(  Coeff_C*( dfc[ idx_wave[v] ] + dfc6[ idx_wave[v] ] ) +
-                                                   Coeff_D*( dfc6[ idx_wave[v] ]                      )  );
-
-               for (int v=0; v<NWAVE; v++)
-                  Correct_L[ idx_wave[v] ] += Coeff_L*REigenVec[Mode][v];
-            }
-
-            if ( EigenVal[d][Mode] >= (real)0.0 )
-            {
-               const real Coeff_A = dt_dh2*( EigenVal[d][ NWAVE-1 ] - EigenVal[d][Mode] );
-//             write as (a-b)*(a+b) instead of a^2-b^2 to ensure that Coeff_B=0 when Coeff_A=0
-//             Coeff_B = real(4.0/3.0)*dt_dh2*dt_dh2* ( EigenVal[d][NWAVE-1]*EigenVal[d][NWAVE-1] -
-//                                                      EigenVal[d][Mode   ]*EigenVal[d][Mode   ]   );
-               const real Coeff_B = real(4.0/3.0)*dt_dh2*Coeff_A*( EigenVal[d][ NWAVE-1 ] + EigenVal[d][Mode] );
-
-               for (int v=0; v<NWAVE; v++)
-                  Coeff_R += LEigenVec[Mode][v]*(  Coeff_A*( dfc[ idx_wave[v] ] - dfc6[ idx_wave[v] ] ) +
-                                                   Coeff_B*( dfc6[ idx_wave[v] ]                      )  );
-
-               for (int v=0; v<NWAVE; v++)
-                  Correct_R[ idx_wave[v] ] += Coeff_R*REigenVec[Mode][v];
-            }
-         } // for (int Mode=0; Mode<NWAVE; Mode++)
-
-#        endif // if (  ( RSOLVER == HLLE || RSOLVER == HLLC || RSOLVER == HLLD )  &&  defined HLL_NO_REF_STATE  ) ... else ...
-
-
-//       4-3. evaluate the corrections to the left and right face-centered passive scalars
-//            --> passive scalars travel with fluid velocity (i.e., entropy mode)
-#        if ( NCOMP_PASSIVE > 0 )
-         Coeff_L = -dt_dh2*FMIN( EigenVal[d][1], (real)0.0 );
-         Coeff_R = -dt_dh2*FMAX( EigenVal[d][1], (real)0.0 );
-
-         for (int v=NCOMP_FLUID; v<NCOMP_TOTAL; v++)
-         {
-            Correct_L[v] = Coeff_L*(  dfc[v] + ( (real)1.0 - real(4.0/3.0)*Coeff_L )*dfc6[v]  );
-            Correct_R[v] = Coeff_R*(  dfc[v] - ( (real)1.0 + real(4.0/3.0)*Coeff_R )*dfc6[v]  );
-         }
-#        endif
-
-
-//       4-4. add the MHD source terms
-#        ifdef MHD
-         const int t1 = (d+1)%3;    // transverse direction 1
-         const int t2 = (d+2)%3;    // transverse direction 2
-         real B_nL, B_nR, B_t1L, B_t1R, B_t2L, B_t2R;
-         real dB_n, dB_t1, dB_t2, v_t1, v_t2, src_t1, src_t2;
-
-         B_nL   = g_FC_B[d ][ idx_B[d ] ];
-         B_t1L  = g_FC_B[t1][ idx_B[t1] ];
-         B_t2L  = g_FC_B[t2][ idx_B[t2] ];
-         B_nR   = g_FC_B[d ][ idx_B[d ] + didx_cc[d ] ];
-         B_t1R  = g_FC_B[t1][ idx_B[t1] + didx_cc[t1] ];
-         B_t2R  = g_FC_B[t2][ idx_B[t2] + didx_cc[t2] ];
-
-         dB_n   = B_nR  - B_nL;
-         dB_t1  = B_t1R - B_t1L;
-         dB_t2  = B_t2R - B_t2L;
-
-         v_t1   = cc_C_ncomp[ 1 + t1 ];
-         v_t2   = cc_C_ncomp[ 1 + t2 ];
-
-         src_t1 = dt_dh2*v_t1*MINMOD( dB_n, -dB_t1 );
-         src_t2 = dt_dh2*v_t2*MINMOD( dB_n, -dB_t2 );
-
-         Correct_L[ MAG_OFFSET + 1 ] += src_t1;
-         Correct_R[ MAG_OFFSET + 1 ] += src_t1;
-         Correct_L[ MAG_OFFSET + 2 ] += src_t2;
-         Correct_R[ MAG_OFFSET + 2 ] += src_t2;
-#        endif // #ifdef MHD
-
-
-//       4-5. evaluate the face-centered variables at the half time-step
-         Hydro_Rotate3D( Correct_L, d, false, MAG_OFFSET );
-         Hydro_Rotate3D( Correct_R, d, false, MAG_OFFSET );
-
-         for (int v=0; v<NCOMP_LR; v++)
-         {
-            fc[faceL][v] += Correct_L[v];
-            fc[faceR][v] += Correct_R[v];
-         }
-
-
-//       4-6. apply density and pressure floors
-         fc[faceL][0] = FMAX( fc[faceL][0], MinDens );
-         fc[faceR][0] = FMAX( fc[faceR][0], MinDens );
-
-         fc[faceL][4] = Hydro_CheckMinPres( fc[faceL][4], MinPres );
-         fc[faceR][4] = Hydro_CheckMinPres( fc[faceR][4], MinPres );
-
-#        if ( NCOMP_PASSIVE > 0 )
-         for (int v=NCOMP_FLUID; v<NCOMP_TOTAL; v++) {
-         fc[faceL][v] = FMAX( fc[faceL][v], TINY_NUMBER );
-         fc[faceR][v] = FMAX( fc[faceR][v], TINY_NUMBER ); }
-#        endif
-
-#        endif // #if ( FLU_SCHEME == CTU )
-
-
-//       5. reset the longitudinal B field to the input face-centered values
-//          --> actually no data reconstruction is required for that
-//###OPTIMIZARION: do not perform data reconstruction for the longitudinal B field
-#        ifdef MHD
-#        if ( FLU_SCHEME != CTU )
-         const real B_nL = g_FC_B[d][ idx_B[d]              ];
-         const real B_nR = g_FC_B[d][ idx_B[d] + didx_cc[d] ];
-#        endif
-         fc[faceL][ MAG_OFFSET + d ] = B_nL;
-         fc[faceR][ MAG_OFFSET + d ] = B_nR;
-#        endif // #ifdef MHD
-
-
-//       6. primitive variables --> conserved variables
-//          --> When LR_EINT is on, use the reconstructed internal energy instead of pressure in Hydro_Pri2Con()
-//              to skip expensive EoS conversion
-         real tmp[NCOMP_LR];  // input and output arrays must not overlap for Pri2Con()
-#        ifdef LR_EINT
-         real* const EintPtr = tmp + NCOMP_TOTAL_PLUS_MAG;
-#        else
-         real* const EintPtr = NULL;
-#        endif
-
-         for (int v=0; v<NCOMP_LR; v++)   tmp[v] = fc[faceL][v];
-         Hydro_Pri2Con( tmp, fc[faceL], FracPassive, NFrac, FracIdx, EoS->DensPres2Eint_FuncPtr,
-                        EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, EintPtr );
-
-         for (int v=0; v<NCOMP_LR; v++)   tmp[v] = fc[faceR][v];
-         Hydro_Pri2Con( tmp, fc[faceR], FracPassive, NFrac, FracIdx, EoS->DensPres2Eint_FuncPtr,
-                        EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, EintPtr );
-
-      } // for (int d=0; d<3; d++)
-
-
-#     if ( FLU_SCHEME == MHM )
-//    7. advance the face-centered variables by half time-step for the MHM integrator
-      Hydro_HancockPredict( fc, dt, dh, g_ConVar, idx_cc, i_cc, j_cc, k_cc, g_FC_B, g_EC_Ele, NGhost, N_HF_ELE,
-                            MinDens, MinPres, MinEint, EoS );
-#     endif // # if ( FLU_SCHEME == MHM )
-
-
-//    8. store the face-centered values to the output array
-//       --> use NCOMP_TOTAL_PLUS_MAG instead of LR_EINT since we don't need to store internal energy in g_FC_Var[]
-      for (int f=0; f<6; f++)
-      for (int v=0; v<NCOMP_TOTAL_PLUS_MAG; v++)
-         g_FC_Var[f][v][idx_fc] = fc[f][v];
-
-   } // CGPU_LOOP( idx_fc, CUBE(N_FC_VAR) )
-
-#  ifdef __CUDACC__
-   __syncthreads();
-#  endif
-
-#  if ( FLU_SCHEME == MHM  &&  defined MHD )
-// 9. Store the half-step primitive variables for MHM+MHD
-//    --> must be done after the CGPU_LOOP( idx_fc, CUBE(N_FC_VAR) ) loop since it will update g_PriVar[]
-   Hydro_ConFC2PriCC_MHM( g_PriVar, g_FC_Var, MinDens, MinPres, MinEint, FracPassive, NFrac, FracIdx,
-                          JeansMinPres, JeansMinPres_Coeff, EoS );
-
-#  endif // #if ( FLU_SCHEME == MHM  &&  defined MHD )
-
-} // FUNCTION : Hydro_DataReconstruction (PPM)
-#endif // #if ( LR_SCHEME == PPM )
-
-
-
-#if ( LR_SCHEME == PPM_OLD )
-//-------------------------------------------------------------------------------------------------------
-// Function    :  Hydro_DataReconstruction
-// Description :  Reconstruct the face-centered variables by the piecewise-parabolic method (PPM)
-//
-// Note        :  See the PLM routine
-//
-// Parameter   :  See the PLM routine
-//------------------------------------------------------------------------------------------------------
-GPU_DEVICE
-void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
-                               const real g_FC_B     [][ SQR(FLU_NXT)*FLU_NXT_P1 ],
-                                     real g_PriVar   [][ CUBE(FLU_NXT) ],
-                                     real g_FC_Var   [][NCOMP_TOTAL_PLUS_MAG][ CUBE(N_FC_VAR) ],
-                                     real g_Slope_PPM[][NCOMP_LR            ][ CUBE(N_SLOPE_PPM) ],
-                                     real g_EC_Ele   [][ CUBE(N_EC_ELE) ],
-                               const bool Con2Pri, const LR_Limiter_t LR_Limiter, const real MinMod_Coeff,
-                               const real dt, const real dh,
-                               const real MinDens, const real MinPres, const real MinEint,
-                               const bool FracPassive, const int NFrac, const int FracIdx[],
-                               const bool JeansMinPres, const real JeansMinPres_Coeff,
-                               const EoS_t *EoS )
-{
-
-//### NOTE: temporary solution to the bug in cuda 10.1 and 10.2 that incorrectly overwrites didx_cc[]
-#  if   ( FLU_SCHEME == MHM )
-   const int NIn    = FLU_NXT;
-#  elif ( FLU_SCHEME == MHM_RP )
-   const int NIn    = N_HF_VAR;
-#  elif ( FLU_SCHEME == CTU )
-   const int NIn    = FLU_NXT;
-#  else
-#  error : ERROR : unsupported FLU_SCHEME !!
-#  endif
-   const int NGhost = LR_GHOST_SIZE;
-
-
-// check
-#  ifdef GAMER_DEBUG
-   if ( NIn - 2*NGhost != N_FC_VAR )
-      printf( "ERROR : NIn - 2*NGhost != N_FC_VAR (NIn %d, NGhost %d, N_FC_VAR %d) !!\n",
-              NIn, NGhost, N_FC_VAR );
-
-#  if ( N_SLOPE_PPM != N_FC_VAR + 2 )
-#     error : ERROR : N_SLOPE_PPM != N_FC_VAR + 2 !!
-#  endif
-
-#  if ( defined LR_EINT  &&  FLU_SCHEME == CTU )
-#     error : CTU does NOT support LR_EINT !!
-#  endif
-#  endif // GAMER_DEBUG
-
-
-   const int  didx_cc   [3]  = { 1, NIn, SQR(NIn) };
-   const int  didx_slope[3]  = { 1, N_SLOPE_PPM, SQR(N_SLOPE_PPM) };
-
-#  if ( FLU_SCHEME == CTU )
-   const real dt_dh2         = (real)0.5*dt/dh;
-
-// index mapping between arrays with size NWAVE and NCOMP_TOTAL_PLUS_MAG/NCOMP_LR
-#  ifdef MHD
-   const int idx_wave[NWAVE] = { 0, 1, 2, 3, 4, MAG_OFFSET+1, MAG_OFFSET+2 };
-#  else
-   const int idx_wave[NWAVE] = { 0, 1, 2, 3, 4 };
-#  endif
-
-// include waves both from left and right directions during the data reconstruction, as suggested in ATHENA
-#  if (  ( RSOLVER == HLLE || RSOLVER == HLLC || RSOLVER == HLLD )  &&  defined HLL_NO_REF_STATE  )
-#  ifdef HLL_INCLUDE_ALL_WAVES
-   const bool HLL_Include_All_Waves = true;
-#  else
-   const bool HLL_Include_All_Waves = false;
-#  endif
-#  endif // if (  ( RSOLVER == HLLE || RSOLVER == HLLC || RSOLVER == HLLD )  &&  defined HLL_NO_REF_STATE  )
-#  endif // #if ( FLU_SCHEME == CTU )
-
-// eigenvalues and eigenvectors
-// --> constant components of the left and right eigenvector matrices must be initialized
-#  if ( FLU_SCHEME == CTU )
-   real EigenVal[3][NWAVE];
-#  ifdef MHD
-   real REigenVec[NWAVE][NWAVE] = { { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    {       0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    {       1.0,       0.0,       0.0,       0.0,       0.0,       0.0,       0.0 },
-                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    {       0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL } };
-   real LEigenVec[NWAVE][NWAVE] = { { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    { 0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    { 1.0,       0.0,       0.0,       0.0, NULL_REAL,       0.0,       0.0 },
-                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    { 0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL } };
-
-#  else
-   real LEigenVec[NWAVE][NWAVE] = { { 0.0, NULL_REAL, 0.0, 0.0, NULL_REAL },
-                                    { 1.0,       0.0, 0.0, 0.0, NULL_REAL },
-                                    { 0.0,       0.0, 1.0, 0.0,       0.0 },
-                                    { 0.0,       0.0, 0.0, 1.0,       0.0 },
-                                    { 0.0, NULL_REAL, 0.0, 0.0, NULL_REAL } };
-
-   real REigenVec[NWAVE][NWAVE] = { { 1.0, NULL_REAL, 0.0, 0.0, NULL_REAL },
-                                    { 1.0,       0.0, 0.0, 0.0,       0.0 },
-                                    { 0.0,       0.0, 1.0, 0.0,       0.0 },
-                                    { 0.0,       0.0, 0.0, 1.0,       0.0 },
-                                    { 1.0, NULL_REAL, 0.0, 0.0, NULL_REAL } };
-#  endif // #ifdef MHD ... else ...
-
-#  elif ( defined MHD  &&  defined CHAR_RECONSTRUCTION ) // #if ( FLU_SCHEME == CTU )
-   real EigenVal[3][NWAVE];
-   real REigenVec[NWAVE][NWAVE] = { { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    {       0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    {       1.0,       0.0,       0.0,       0.0,       0.0,       0.0,       0.0 },
-                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    {       0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL } };
-   real LEigenVec[NWAVE][NWAVE] = { { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    { 0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    { 1.0,       0.0,       0.0,       0.0, NULL_REAL,       0.0,       0.0 },
-                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    { 0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL } };
-
-#  else // #if ( FLU_SCHEME == CTU ) ... elif ...
-   real (*const REigenVec)[NWAVE] = NULL;
-   real (*const LEigenVec)[NWAVE] = NULL;
-#  endif // #if ( FLU_SCHEME ==  CTU ) ... elif ... else ...
-
-
-// 0. conserved --> primitive variables
-   if ( Con2Pri )
-   {
-      real ConVar_1Cell[NCOMP_TOTAL_PLUS_MAG], PriVar_1Cell[NCOMP_TOTAL_PLUS_MAG];
-#     ifdef LR_EINT
-      real Eint;
-      real* const EintPtr = &Eint;
-#     else
-      real* const EintPtr = NULL;
-#     endif
-
-      CGPU_LOOP( idx, CUBE(NIn) )
-      {
-         for (int v=0; v<NCOMP_TOTAL; v++)   ConVar_1Cell[v] = g_ConVar[v][idx];
-
-#        ifdef MHD
-//       assuming that g_FC_B[] is accessed with the strides NIn/NIn+1 along the transverse/longitudinal directions
-         const int size_ij = SQR( NIn );
-         const int i       = idx % NIn;
-         const int j       = idx % size_ij / NIn;
-         const int k       = idx / size_ij;
-
-         MHD_GetCellCenteredBField( ConVar_1Cell+NCOMP_TOTAL, g_FC_B[0], g_FC_B[1], g_FC_B[2], NIn, NIn, NIn, i, j, k );
-#        endif
-
-         Hydro_Con2Pri( ConVar_1Cell, PriVar_1Cell, MinPres, FracPassive, NFrac, FracIdx,
-                        JeansMinPres, JeansMinPres_Coeff, EoS->DensEint2Pres_FuncPtr, EoS->DensPres2Eint_FuncPtr,
-                        EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, EintPtr );
-
-         for (int v=0; v<NCOMP_TOTAL_PLUS_MAG; v++)   g_PriVar[v][idx] = PriVar_1Cell[v];
-
-#        ifdef LR_EINT
-         g_PriVar[NCOMP_TOTAL_PLUS_MAG][idx] = Hydro_CheckMinEint( Eint, MinEint ); // store Eint in the last variable
-#        endif
-      } // CGPU_LOOP( idx, CUBE(NIn) )
-
-#     ifdef __CUDACC__
-      __syncthreads();
-#     endif
-   } // if ( Con2Pri )
-
-
-// 1. evaluate the monotonic slope of all cells
-   const int N_SLOPE_PPM2 = SQR( N_SLOPE_PPM );
-   CGPU_LOOP( idx_slope, CUBE(N_SLOPE_PPM) )
-   {
-      const int i_cc   = NGhost - 1 + idx_slope%N_SLOPE_PPM;
-      const int j_cc   = NGhost - 1 + idx_slope%N_SLOPE_PPM2/N_SLOPE_PPM;
-      const int k_cc   = NGhost - 1 + idx_slope/N_SLOPE_PPM2;
-      const int idx_cc = IDX321( i_cc, j_cc, k_cc, NIn, NIn );
-
-//    cc_C/L/R: cell-centered variables of the Central/Left/Right cells
-      real cc_C[NCOMP_LR], cc_L[NCOMP_LR], cc_R[NCOMP_LR], Slope_Limiter[NCOMP_LR];
-
-      for (int v=0; v<NCOMP_LR; v++)   cc_C[v] = g_PriVar[v][idx_cc];
-
-//    loop over different spatial directions
-      for (int d=0; d<3; d++)
-      {
-         const int idx_ccL = idx_cc - didx_cc[d];
-         const int idx_ccR = idx_cc + didx_cc[d];
-
-#        if ( defined MHD  &&  defined CHAR_RECONSTRUCTION )
-         MHD_GetEigenSystem( cc_C, EigenVal[d], LEigenVec, REigenVec, EoS, d );
-#        endif
-
-         for (int v=0; v<NCOMP_LR; v++)
-         {
-            cc_L[v] = g_PriVar[v][idx_ccL];
-            cc_R[v] = g_PriVar[v][idx_ccR];
-         }
-
-         Hydro_LimitSlope( cc_L, cc_C, cc_R, LR_Limiter, MinMod_Coeff, d,
-                           LEigenVec, REigenVec, Slope_Limiter, EoS );
-
-//       store the results to g_Slope_PPM[]
-         for (int v=0; v<NCOMP_LR; v++)   g_Slope_PPM[d][v][idx_slope] = Slope_Limiter[v];
-
-      } // for (int d=0; d<3; d++)
-   } // CGPU_LOOP( idx_slope, CUBE(N_SLOPE_PPM) )
-
-#  ifdef __CUDACC__
-   __syncthreads();
-#  endif
-
-
-// compute electric field for MHM
-#  if ( FLU_SCHEME == MHM  &&  defined MHD )
-   MHD_ComputeElectric_Half( g_EC_Ele, g_ConVar, g_FC_B, N_HF_ELE, NIn, NGhost );
-#  endif
-
-
-// data reconstruction
-   const int N_FC_VAR2 = SQR( N_FC_VAR );
-#  ifdef MHD
-   const int NIn_p1    = NIn + 1;
-   int idx_B[NCOMP_MAG];
-#  endif
-
-   CGPU_LOOP( idx_fc, CUBE(N_FC_VAR) )
-   {
-      const int i_fc      = idx_fc%N_FC_VAR;
-      const int j_fc      = idx_fc%N_FC_VAR2/N_FC_VAR;
-      const int k_fc      = idx_fc/N_FC_VAR2;
-
-      const int i_cc      = i_fc + NGhost;
-      const int j_cc      = j_fc + NGhost;
-      const int k_cc      = k_fc + NGhost;
-      const int idx_cc    = IDX321( i_cc, j_cc, k_cc, NIn, NIn );
-
-      const int i_slope   = i_fc + 1;   // because N_SLOPE_PPM = N_FC_VAR + 2
-      const int j_slope   = j_fc + 1;
-      const int k_slope   = k_fc + 1;
-      const int idx_slope = IDX321( i_slope, j_slope, k_slope, N_SLOPE_PPM, N_SLOPE_PPM );
-
-#     ifdef MHD
-//    assuming that g_FC_B[] is accessed with the strides NIn/NIn+1 along the transverse/longitudinal directions
-      idx_B[0] = IDX321( i_cc, j_cc, k_cc, NIn_p1, NIn    );
-      idx_B[1] = IDX321( i_cc, j_cc, k_cc, NIn,    NIn_p1 );
-      idx_B[2] = IDX321( i_cc, j_cc, k_cc, NIn,    NIn    );
-#     endif
-
- //   cc/fc: cell/face-centered variables; _C_ncomp: central cell with all NCOMP_LR variables
-      real cc_C_ncomp[NCOMP_LR], fc[6][NCOMP_LR], dfc[NCOMP_LR], dfc6[NCOMP_LR];
-
-      for (int v=0; v<NCOMP_LR; v++)   cc_C_ncomp[v] = g_PriVar[v][idx_cc];
-
-
-//    2-a. evaluate the eigenvalues and eigenvectors along all three directions for the pure-hydro CTU integrator
-#     if ( !defined MHD  &&  FLU_SCHEME == CTU )
-      Hydro_GetEigenSystem( cc_C_ncomp, EigenVal, LEigenVec, REigenVec, EoS );
-#     endif
-
-
-//    loop over different spatial directions
-      for (int d=0; d<3; d++)
-      {
-//       2-b. evaluate the eigenvalues and eigenvectors along the target direction for the MHD CTU integrator
-#        if (  defined MHD  &&  ( FLU_SCHEME == CTU || defined CHAR_RECONSTRUCTION )  )
-         MHD_GetEigenSystem( cc_C_ncomp, EigenVal[d], LEigenVec, REigenVec, EoS, d );
-#        endif
-
-
-//       3. get the face-centered primitive variables
-         const int faceL      = 2*d;      // left and right face indices
-         const int faceR      = faceL+1;
-         const int idx_ccLL   = idx_cc - 2*didx_cc[d];
-         const int idx_ccL    = idx_cc - didx_cc[d];
-         const int idx_ccC    = idx_cc;
-         const int idx_ccR    = idx_cc + didx_cc[d];
-         const int idx_ccRR   = idx_cc + 2*didx_cc[d];
-
-         const real C_factor = 1.25;
-         const real round_err = 1.e-12;
-
-         for (int v=0; v<NCOMP_LR; v++)
-         {
-            real tmp, rho, cc_abs_max;
-
-            real fc_L, fc_R;            // face center value
-            real cc_LL, cc_L, cc_C, cc_R, cc_RR; // cell center value
-            real d_LL, d_L, d_R, d_RR;  // slope at face center
-            real dd_L, dd_C, dd_R;      // curverture at cell center
-
-//          3-1. get all the value needed
-            cc_LL = g_PriVar[v][idx_ccLL];
-            cc_L  = g_PriVar[v][idx_ccL ];
-            cc_C  = g_PriVar[v][idx_cc  ];
-            cc_R  = g_PriVar[v][idx_ccR ];
-            cc_RR = g_PriVar[v][idx_ccRR];
-
-            d_LL  = cc_L  - cc_LL;
-            d_L   = cc_C  - cc_L ;
-            d_R   = cc_R  - cc_C ;
-            d_RR  = cc_RR - cc_R ;
-
-            dd_L  = cc_LL - (real)2.*cc_L + cc_C ;
-            dd_C  = cc_L  - (real)2.*cc_C + cc_R ;
-            dd_R  = cc_C  - (real)2.*cc_R + cc_RR;
-
-            cc_abs_max = MAX( FABS(cc_LL),
-                              MAX( FABS(cc_L),
-                                   MAX( FABS(cc_C),
-                                        MAX( FABS(cc_R), FABS(cc_RR) )
-                                      )
-                                 )
-                            );
-
-//          3-2. interpolate the face value
-            fc_L = ( -cc_LL + (real)7.*cc_L + (real)7.*cc_C - cc_R  ) / (real)12.0;
-            fc_R = ( -cc_L  + (real)7.*cc_C + (real)7.*cc_R - cc_RR ) / (real)12.0;
-            // fc_L = ((real)6.*(cc_L + cc_C) + cc_C - cc_LL - cc_R  + cc_L ) / (real)12.;
-            // fc_R = ((real)6.*(cc_C + cc_R) + cc_R - cc_L  - cc_RR + cc_C ) / (real)12.;
-
-
-//          3-3. prepare half value
-            real dh_LL, dh_L, dh_R, dh_RR;
-            real ddh_L, ddh_C, ddh_R;
-
-            dh_LL = fc_L - cc_L;
-            dh_L  = cc_C - fc_L;
-            dh_R  = fc_R - cc_C;
-            dh_RR = cc_R - fc_R;
-
-            ddh_L = cc_L - (real)2.*fc_L + cc_C;
-            ddh_C = fc_L - (real)2.*cc_C + fc_R;
-            ddh_R = cc_C - (real)2.*fc_R + cc_R;
-
-//          3-4. limit slope of L&R
-            if ( dh_LL*dh_L < 0.0 ) {
-               if ( SIGN(dd_L) == SIGN(ddh_L) && SIGN(ddh_L) == SIGN(dd_C) ) {
-                  tmp = SIGN(dd_C) * MIN( C_factor*FABS(dd_L),
-                                          MIN( (real)3.*FABS(ddh_L), C_factor*FABS(dd_C) )
-                                        );
-               } else {
-                  tmp = 0.0;
-               } // if ( SIGN(dd_L) == SIGN(ddh_L) && SIGN(ddh_L) == SIGN(dd_C) ) ... else ...
-               fc_L = (real)0.5*(cc_L+cc_C) - tmp/(real)6.0;
-
-//             update the slope
-               dh_LL = fc_L - cc_L;
-               dh_L  = cc_C - fc_L;
-            } // if ( dh_LL*dh_L < 0.0 )
-
-            if ( dh_R*dh_RR < 0.0 ) {
-               if ( SIGN(dd_C) == SIGN(ddh_R) && SIGN(ddh_R) == SIGN(dd_R) ) {
-                  tmp = SIGN(dd_C) * MIN( C_factor*FABS(dd_C),
-                                          MIN( (real)3.*FABS(ddh_R), C_factor*FABS(dd_R) )
-                                        );
-               } else {
-                  tmp = 0.0;
-               } // if ( SIGN(dd_C) == SIGN(ddh_R) && SIGN(ddh_R) == SIGN(dd_R) ) ... else ...
-               fc_R = (real)0.5*(cc_C+cc_R) - tmp/(real)6.0;
-
-//             update the slope
-               dh_R  = fc_R - cc_C;
-               dh_RR = cc_R - fc_R;
-            } // if ( dh_R*dh_RR < 0.0 )
-
-//          3-5. reduce error to round-off error
-            if ( SIGN(dd_L) == SIGN(dd_C) && SIGN(dd_C) == SIGN(dd_R) && SIGN(dd_R) == SIGN(ddh_C) ) {
-               tmp = SIGN(dd_C) * MIN( C_factor*FABS(dd_L),
-                                       MIN( C_factor*FABS(dd_C),
-                                            MIN( C_factor*FABS(dd_L), (real)6.0*FABS(ddh_C))
-                                          )
-                                     );
-            } else {
-               tmp = 0.0;
-            } // if ( SIGN(dd_L) == SIGN(dd_C) && SIGN(dd_C) == SIGN(dd_R) && SIGN(dd_R) == SIGN(ddh_C) ) ... else ...
-
-            if ( (real)6.*FABS(ddh_C) > round_err*cc_abs_max ) {
-               rho = tmp / ddh_C / (real)6.;
-            } else {
-               rho = 0.0;
-            } // if ( FABS(ddh_C) > round_error*cc_abs_max ) ... else ...
-
-            if ( dh_L*dh_R < 0.0 || d_L*d_R < 0.0 ) {
-               if ( rho < 1.-round_err )   fc_L = cc_C - rho * dh_L;
-               if ( rho < 1.-round_err )   fc_R = cc_C + rho * dh_R;
-            } else {
-               if ( FABS(dh_L) >= (real)2.*FABS(dh_R) )   fc_L = cc_C - (real)2.*dh_R;
-               if ( FABS(dh_R) >= (real)2.*FABS(dh_L) )   fc_R = cc_C + (real)2.*dh_L;
-            } // if ( dh_L*dh_R < 0.0 && d_L*d_R < 0.0 )
-
-//          3-6. store the value
-            fc[faceL][v] = fc_L;
-            fc[faceR][v] = fc_R;
-
-         } // for (int v=0; v<NCOMP_LR; v++)
-
-
-//       4. advance the face-centered variables by half time-step for the CTU integrator
-#        if ( FLU_SCHEME == CTU )
-
-#        ifdef LR_EINT
-#           error : CTU does NOT support LR_EINT !!
-#        endif
-
-         real Coeff_L, Coeff_R;
-         real Correct_L[NCOMP_LR], Correct_R[NCOMP_LR];
-
-//       4-1. compute the PPM coefficient (for the passive scalars as well)
-         for (int v=0; v<NCOMP_LR; v++)
-         {
-            dfc [v] = fc[faceR][v] - fc[faceL][v];
-            dfc6[v] = (real)6.0*(  cc_C_ncomp[v] - (real)0.5*( fc[faceL][v] + fc[faceR][v] )  );
-         }
-
-//       4-2. re-order variables for the y/z directions
-         Hydro_Rotate3D( dfc,  d, true, MAG_OFFSET );
-         Hydro_Rotate3D( dfc6, d, true, MAG_OFFSET );
-
-
-//       =====================================================================================
-//       a. for the HLL solvers (HLLE/HLLC/HLLD)
-//       =====================================================================================
-#        if (  ( RSOLVER == HLLE || RSOLVER == HLLC || RSOLVER == HLLD )  &&  defined HLL_NO_REF_STATE  )
-
-//       4-2-a1. evaluate the corrections to the left and right face-centered variables
-         for (int v=0; v<NWAVE; v++)
-         {
-            Correct_L[ idx_wave[v] ] = (real)0.0;
-            Correct_R[ idx_wave[v] ] = (real)0.0;
-         }
-
-         for (int Mode=0; Mode<NWAVE; Mode++)
-         {
-            Coeff_L = (real)0.0;
-            Coeff_R = (real)0.0;
-
-            if ( HLL_Include_All_Waves  ||  EigenVal[d][Mode] <= (real)0.0 )
-            {
-               const real Coeff_C = -dt_dh2*EigenVal[d][Mode];
-               const real Coeff_D = real(-4.0/3.0)*SQR(Coeff_C);
-
-               for (int v=0; v<NWAVE; v++)
-                  Coeff_L += LEigenVec[Mode][v]*(  Coeff_C*( dfc[ idx_wave[v] ] + dfc6[ idx_wave[v] ] ) +
-                                                   Coeff_D*( dfc6[ idx_wave[v] ]                      )  );
-
-               for (int v=0; v<NWAVE; v++)
-                  Correct_L[ idx_wave[v] ] += Coeff_L*REigenVec[Mode][v];
-            }
-
-            if ( HLL_Include_All_Waves  ||  EigenVal[d][Mode] >= (real)0.0 )
-            {
-               const real Coeff_A = -dt_dh2*EigenVal[d][Mode];
-               const real Coeff_B = real(-4.0/3.0)*SQR(Coeff_A);
-
-               for (int v=0; v<NWAVE; v++)
-                  Coeff_R += LEigenVec[Mode][v]*(  Coeff_A*( dfc[ idx_wave[v] ] - dfc6[ idx_wave[v] ] ) +
-                                                   Coeff_B*( dfc6[ idx_wave[v] ]                      )  );
-
-               for (int v=0; v<NWAVE; v++)
-                  Correct_R[ idx_wave[v] ] += Coeff_R*REigenVec[Mode][v];
-            }
-         } // for (int Mode=0; Mode<NWAVE; Mode++)
-
-
-//       =====================================================================================
-//       b. for the Roe's and exact solvers
-//       =====================================================================================
-#        else // ( RSOLVER == ROE/EXACT || ifndef HLL_NO_REF_STATE )
-
-//       4-2-b1. evaluate the reference states
-         Coeff_L = -dt_dh2*FMIN( EigenVal[d][       0 ], (real)0.0 );
-         Coeff_R = -dt_dh2*FMAX( EigenVal[d][ NWAVE-1 ], (real)0.0 );
-
-         for (int v=0; v<NWAVE; v++)
-         {
-            Correct_L[ idx_wave[v] ] = Coeff_L*(  dfc[ idx_wave[v] ] + ( (real)1.0 - real(4.0/3.0)*Coeff_L )*dfc6[ idx_wave[v] ]  );
-            Correct_R[ idx_wave[v] ] = Coeff_R*(  dfc[ idx_wave[v] ] - ( (real)1.0 + real(4.0/3.0)*Coeff_R )*dfc6[ idx_wave[v] ]  );
-         }
-
-
-//       4-2-b2. evaluate the corrections to the left and right face-centered variables
-         for (int Mode=0; Mode<NWAVE; Mode++)
-         {
-            Coeff_L = (real)0.0;
-            Coeff_R = (real)0.0;
-
-            if ( EigenVal[d][Mode] <= (real)0.0 )
-            {
-               const real Coeff_C = dt_dh2*( EigenVal[d][0] - EigenVal[d][Mode] );
-//             write as (a-b)*(a+b) instead of a^2-b^2 to ensure that Coeff_D=0 when Coeff_C=0
-//             Coeff_D = real(4.0/3.0)*dt_dh2*dt_dh2* ( EigenVal[d][   0]*EigenVal[d][   0] -
-//                                                      EigenVal[d][Mode]*EigenVal[d][Mode]   );
-               const real Coeff_D = real(4.0/3.0)*dt_dh2*Coeff_C*( EigenVal[d][0] + EigenVal[d][Mode] );
-
-               for (int v=0; v<NWAVE; v++)
-                  Coeff_L += LEigenVec[Mode][v]*(  Coeff_C*( dfc[ idx_wave[v] ] + dfc6[ idx_wave[v] ] ) +
-                                                   Coeff_D*( dfc6[ idx_wave[v] ]                      )  );
-
-               for (int v=0; v<NWAVE; v++)
-                  Correct_L[ idx_wave[v] ] += Coeff_L*REigenVec[Mode][v];
-            }
-
-            if ( EigenVal[d][Mode] >= (real)0.0 )
-            {
-               const real Coeff_A = dt_dh2*( EigenVal[d][ NWAVE-1 ] - EigenVal[d][Mode] );
-//             write as (a-b)*(a+b) instead of a^2-b^2 to ensure that Coeff_B=0 when Coeff_A=0
-//             Coeff_B = real(4.0/3.0)*dt_dh2*dt_dh2* ( EigenVal[d][NWAVE-1]*EigenVal[d][NWAVE-1] -
-//                                                      EigenVal[d][Mode   ]*EigenVal[d][Mode   ]   );
-               const real Coeff_B = real(4.0/3.0)*dt_dh2*Coeff_A*( EigenVal[d][ NWAVE-1 ] + EigenVal[d][Mode] );
-
-               for (int v=0; v<NWAVE; v++)
-                  Coeff_R += LEigenVec[Mode][v]*(  Coeff_A*( dfc[ idx_wave[v] ] - dfc6[ idx_wave[v] ] ) +
-                                                   Coeff_B*( dfc6[ idx_wave[v] ]                      )  );
-
-               for (int v=0; v<NWAVE; v++)
-                  Correct_R[ idx_wave[v] ] += Coeff_R*REigenVec[Mode][v];
-            }
-         } // for (int Mode=0; Mode<NWAVE; Mode++)
-
-#        endif // if (  ( RSOLVER == HLLE || RSOLVER == HLLC || RSOLVER == HLLD )  &&  defined HLL_NO_REF_STATE  ) ... else ...
-
-
-//       4-3. evaluate the corrections to the left and right face-centered passive scalars
-//            --> passive scalars travel with fluid velocity (i.e., entropy mode)
-#        if ( NCOMP_PASSIVE > 0 )
-         Coeff_L = -dt_dh2*FMIN( EigenVal[d][1], (real)0.0 );
-         Coeff_R = -dt_dh2*FMAX( EigenVal[d][1], (real)0.0 );
-
-         for (int v=NCOMP_FLUID; v<NCOMP_TOTAL; v++)
-         {
-            Correct_L[v] = Coeff_L*(  dfc[v] + ( (real)1.0 - real(4.0/3.0)*Coeff_L )*dfc6[v]  );
-            Correct_R[v] = Coeff_R*(  dfc[v] - ( (real)1.0 + real(4.0/3.0)*Coeff_R )*dfc6[v]  );
-         }
-#        endif
-
-
-//       4-4. add the MHD source terms
-#        ifdef MHD
-         const int t1 = (d+1)%3;    // transverse direction 1
-         const int t2 = (d+2)%3;    // transverse direction 2
-         real B_nL, B_nR, B_t1L, B_t1R, B_t2L, B_t2R;
-         real dB_n, dB_t1, dB_t2, v_t1, v_t2, src_t1, src_t2;
-
-         B_nL   = g_FC_B[d ][ idx_B[d ] ];
-         B_t1L  = g_FC_B[t1][ idx_B[t1] ];
-         B_t2L  = g_FC_B[t2][ idx_B[t2] ];
-         B_nR   = g_FC_B[d ][ idx_B[d ] + didx_cc[d ] ];
-         B_t1R  = g_FC_B[t1][ idx_B[t1] + didx_cc[t1] ];
-         B_t2R  = g_FC_B[t2][ idx_B[t2] + didx_cc[t2] ];
-
-         dB_n   = B_nR  - B_nL;
-         dB_t1  = B_t1R - B_t1L;
-         dB_t2  = B_t2R - B_t2L;
-
-         v_t1   = cc_C_ncomp[ 1 + t1 ];
-         v_t2   = cc_C_ncomp[ 1 + t2 ];
-
-         src_t1 = dt_dh2*v_t1*MINMOD( dB_n, -dB_t1 );
-         src_t2 = dt_dh2*v_t2*MINMOD( dB_n, -dB_t2 );
-
-         Correct_L[ MAG_OFFSET + 1 ] += src_t1;
-         Correct_R[ MAG_OFFSET + 1 ] += src_t1;
-         Correct_L[ MAG_OFFSET + 2 ] += src_t2;
-         Correct_R[ MAG_OFFSET + 2 ] += src_t2;
-#        endif // #ifdef MHD
-
-
-//       4-5. evaluate the face-centered variables at the half time-step
-         Hydro_Rotate3D( Correct_L, d, false, MAG_OFFSET );
-         Hydro_Rotate3D( Correct_R, d, false, MAG_OFFSET );
-
-         for (int v=0; v<NCOMP_LR; v++)
-         {
-            fc[faceL][v] += Correct_L[v];
-            fc[faceR][v] += Correct_R[v];
-         }
-
-
-//       4-6. apply density and pressure floors
-         fc[faceL][0] = FMAX( fc[faceL][0], MinDens );
-         fc[faceR][0] = FMAX( fc[faceR][0], MinDens );
-
-         fc[faceL][4] = Hydro_CheckMinPres( fc[faceL][4], MinPres );
-         fc[faceR][4] = Hydro_CheckMinPres( fc[faceR][4], MinPres );
-
-#        if ( NCOMP_PASSIVE > 0 )
-         for (int v=NCOMP_FLUID; v<NCOMP_TOTAL; v++) {
-         fc[faceL][v] = FMAX( fc[faceL][v], TINY_NUMBER );
-         fc[faceR][v] = FMAX( fc[faceR][v], TINY_NUMBER ); }
-#        endif
-
-#        endif // #if ( FLU_SCHEME == CTU )
-
-
-//       5. reset the longitudinal B field to the input face-centered values
-//          --> actually no data reconstruction is required for that
-//###OPTIMIZARION: do not perform data reconstruction for the longitudinal B field
-#        ifdef MHD
-#        if ( FLU_SCHEME != CTU )
-         const real B_nL = g_FC_B[d][ idx_B[d]              ];
-         const real B_nR = g_FC_B[d][ idx_B[d] + didx_cc[d] ];
-#        endif
-         fc[faceL][ MAG_OFFSET + d ] = B_nL;
-         fc[faceR][ MAG_OFFSET + d ] = B_nR;
-#        endif // #ifdef MHD
-
-
-//       6. primitive variables --> conserved variables
-//          --> When LR_EINT is on, use the reconstructed internal energy instead of pressure in Hydro_Pri2Con()
-//              to skip expensive EoS conversion
-         real tmp[NCOMP_LR];  // input and output arrays must not overlap for Pri2Con()
-#        ifdef LR_EINT
-         real* const EintPtr = tmp + NCOMP_TOTAL_PLUS_MAG;
-#        else
-         real* const EintPtr = NULL;
-#        endif
-
-         for (int v=0; v<NCOMP_LR; v++)   tmp[v] = fc[faceL][v];
-         Hydro_Pri2Con( tmp, fc[faceL], FracPassive, NFrac, FracIdx, EoS->DensPres2Eint_FuncPtr,
-                        EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, EintPtr );
-
-         for (int v=0; v<NCOMP_LR; v++)   tmp[v] = fc[faceR][v];
-         Hydro_Pri2Con( tmp, fc[faceR], FracPassive, NFrac, FracIdx, EoS->DensPres2Eint_FuncPtr,
-                        EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, EintPtr );
-
-      } // for (int d=0; d<3; d++)
-
-
-#     if ( FLU_SCHEME == MHM )
-//    7. advance the face-centered variables by half time-step for the MHM integrator
-      Hydro_HancockPredict( fc, dt, dh, g_ConVar, idx_cc, i_cc, j_cc, k_cc, g_FC_B, g_EC_Ele, NGhost, N_HF_ELE,
-                            MinDens, MinPres, MinEint, EoS );
-#     endif // # if ( FLU_SCHEME == MHM )
-
-
-//    8. store the face-centered values to the output array
-//       --> use NCOMP_TOTAL_PLUS_MAG instead of LR_EINT since we don't need to store internal energy in g_FC_Var[]
-      for (int f=0; f<6; f++)
-      for (int v=0; v<NCOMP_TOTAL_PLUS_MAG; v++)
-         g_FC_Var[f][v][idx_fc] = fc[f][v];
-
-   } // CGPU_LOOP( idx_fc, CUBE(N_FC_VAR) )
-
-#  ifdef __CUDACC__
-   __syncthreads();
-#  endif
-
-#  if ( FLU_SCHEME == MHM  &&  defined MHD )
-// 9. Store the half-step primitive variables for MHM+MHD
-//    --> must be done after the CGPU_LOOP( idx_fc, CUBE(N_FC_VAR) ) loop since it will update g_PriVar[]
-   Hydro_ConFC2PriCC_MHM( g_PriVar, g_FC_Var, MinDens, MinPres, MinEint, FracPassive, NFrac, FracIdx,
-                          JeansMinPres, JeansMinPres_Coeff, EoS );
-
-#  endif // #if ( FLU_SCHEME == MHM  &&  defined MHD )
-
-} // FUNCTION : Hydro_DataReconstruction (PPM)
-#endif // #if ( LR_SCHEME == PPM )
-
-
-
-#if ( LR_SCHEME == PPM_OLD )
-//-------------------------------------------------------------------------------------------------------
-// Function    :  Hydro_DataReconstruction
-// Description :  Reconstruct the face-centered variables by the piecewise-parabolic method (PPM)
-//
-// Note        :  See the PLM routine
-//
-// Parameter   :  See the PLM routine
-//------------------------------------------------------------------------------------------------------
-GPU_DEVICE
-void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
-                               const real g_FC_B     [][ SQR(FLU_NXT)*FLU_NXT_P1 ],
-                                     real g_PriVar   [][ CUBE(FLU_NXT) ],
-                                     real g_FC_Var   [][NCOMP_TOTAL_PLUS_MAG][ CUBE(N_FC_VAR) ],
-                                     real g_Slope_PPM[][NCOMP_LR            ][ CUBE(N_SLOPE_PPM) ],
-                                     real g_EC_Ele   [][ CUBE(N_EC_ELE) ],
-                               const bool Con2Pri, const LR_Limiter_t LR_Limiter, const real MinMod_Coeff,
-                               const real dt, const real dh,
-                               const real MinDens, const real MinPres, const real MinEint,
-                               const bool FracPassive, const int NFrac, const int FracIdx[],
-                               const bool JeansMinPres, const real JeansMinPres_Coeff,
-                               const EoS_t *EoS )
-{
-
-//### NOTE: temporary solution to the bug in cuda 10.1 and 10.2 that incorrectly overwrites didx_cc[]
-#  if   ( FLU_SCHEME == MHM )
-   const int NIn    = FLU_NXT;
-#  elif ( FLU_SCHEME == MHM_RP )
-   const int NIn    = N_HF_VAR;
-#  elif ( FLU_SCHEME == CTU )
-   const int NIn    = FLU_NXT;
-#  else
-#  error : ERROR : unsupported FLU_SCHEME !!
-#  endif
-   const int NGhost = LR_GHOST_SIZE;
-
-
-// check
-#  ifdef GAMER_DEBUG
-   if ( NIn - 2*NGhost != N_FC_VAR )
-      printf( "ERROR : NIn - 2*NGhost != N_FC_VAR (NIn %d, NGhost %d, N_FC_VAR %d) !!\n",
-              NIn, NGhost, N_FC_VAR );
-
-#  if ( N_SLOPE_PPM != N_FC_VAR + 2 )
-#     error : ERROR : N_SLOPE_PPM != N_FC_VAR + 2 !!
-#  endif
-
-#  if ( defined LR_EINT  &&  FLU_SCHEME == CTU )
-#     error : CTU does NOT support LR_EINT !!
-#  endif
-#  endif // GAMER_DEBUG
-
-
-   const int  didx_cc   [3]  = { 1, NIn, SQR(NIn) };
-   const int  didx_slope[3]  = { 1, N_SLOPE_PPM, SQR(N_SLOPE_PPM) };
-
-#  if ( FLU_SCHEME == CTU )
-   const real dt_dh2         = (real)0.5*dt/dh;
-
-// index mapping between arrays with size NWAVE and NCOMP_TOTAL_PLUS_MAG/NCOMP_LR
-#  ifdef MHD
-   const int idx_wave[NWAVE] = { 0, 1, 2, 3, 4, MAG_OFFSET+1, MAG_OFFSET+2 };
-#  else
-   const int idx_wave[NWAVE] = { 0, 1, 2, 3, 4 };
-#  endif
-
-// include waves both from left and right directions during the data reconstruction, as suggested in ATHENA
-#  if (  ( RSOLVER == HLLE || RSOLVER == HLLC || RSOLVER == HLLD )  &&  defined HLL_NO_REF_STATE  )
-#  ifdef HLL_INCLUDE_ALL_WAVES
-   const bool HLL_Include_All_Waves = true;
-#  else
-   const bool HLL_Include_All_Waves = false;
-#  endif
-#  endif // if (  ( RSOLVER == HLLE || RSOLVER == HLLC || RSOLVER == HLLD )  &&  defined HLL_NO_REF_STATE  )
-#  endif // #if ( FLU_SCHEME == CTU )
-
-// eigenvalues and eigenvectors
-// --> constant components of the left and right eigenvector matrices must be initialized
-#  if ( FLU_SCHEME == CTU )
-   real EigenVal[3][NWAVE];
-#  ifdef MHD
-   real REigenVec[NWAVE][NWAVE] = { { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    {       0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    {       1.0,       0.0,       0.0,       0.0,       0.0,       0.0,       0.0 },
-                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    {       0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL } };
-   real LEigenVec[NWAVE][NWAVE] = { { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    { 0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    { 1.0,       0.0,       0.0,       0.0, NULL_REAL,       0.0,       0.0 },
-                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    { 0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL } };
-
-#  else
-   real LEigenVec[NWAVE][NWAVE] = { { 0.0, NULL_REAL, 0.0, 0.0, NULL_REAL },
-                                    { 1.0,       0.0, 0.0, 0.0, NULL_REAL },
-                                    { 0.0,       0.0, 1.0, 0.0,       0.0 },
-                                    { 0.0,       0.0, 0.0, 1.0,       0.0 },
-                                    { 0.0, NULL_REAL, 0.0, 0.0, NULL_REAL } };
-
-   real REigenVec[NWAVE][NWAVE] = { { 1.0, NULL_REAL, 0.0, 0.0, NULL_REAL },
-                                    { 1.0,       0.0, 0.0, 0.0,       0.0 },
-                                    { 0.0,       0.0, 1.0, 0.0,       0.0 },
-                                    { 0.0,       0.0, 0.0, 1.0,       0.0 },
-                                    { 1.0, NULL_REAL, 0.0, 0.0, NULL_REAL } };
-#  endif // #ifdef MHD ... else ...
-
-#  elif ( defined MHD  &&  defined CHAR_RECONSTRUCTION ) // #if ( FLU_SCHEME == CTU )
-   real EigenVal[3][NWAVE];
-   real REigenVec[NWAVE][NWAVE] = { { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    {       0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    {       1.0,       0.0,       0.0,       0.0,       0.0,       0.0,       0.0 },
-                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    {       0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL } };
-   real LEigenVec[NWAVE][NWAVE] = { { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    { 0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    { 1.0,       0.0,       0.0,       0.0, NULL_REAL,       0.0,       0.0 },
-                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL },
-                                    { 0.0,       0.0, NULL_REAL, NULL_REAL,       0.0, NULL_REAL, NULL_REAL },
-                                    { 0.0, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL, NULL_REAL } };
-
-#  else // #if ( FLU_SCHEME == CTU ) ... elif ...
-   real (*const REigenVec)[NWAVE] = NULL;
-   real (*const LEigenVec)[NWAVE] = NULL;
-#  endif // #if ( FLU_SCHEME ==  CTU ) ... elif ... else ...
-
-
-// 0. conserved --> primitive variables
-   if ( Con2Pri )
-   {
-      real ConVar_1Cell[NCOMP_TOTAL_PLUS_MAG], PriVar_1Cell[NCOMP_TOTAL_PLUS_MAG];
-#     ifdef LR_EINT
-      real Eint;
-      real* const EintPtr = &Eint;
-#     else
-      real* const EintPtr = NULL;
-#     endif
-
-      CGPU_LOOP( idx, CUBE(NIn) )
-      {
-         for (int v=0; v<NCOMP_TOTAL; v++)   ConVar_1Cell[v] = g_ConVar[v][idx];
-
-#        ifdef MHD
-//       assuming that g_FC_B[] is accessed with the strides NIn/NIn+1 along the transverse/longitudinal directions
-         const int size_ij = SQR( NIn );
-         const int i       = idx % NIn;
-         const int j       = idx % size_ij / NIn;
-         const int k       = idx / size_ij;
-
-         MHD_GetCellCenteredBField( ConVar_1Cell+NCOMP_TOTAL, g_FC_B[0], g_FC_B[1], g_FC_B[2], NIn, NIn, NIn, i, j, k );
-#        endif
-
-         Hydro_Con2Pri( ConVar_1Cell, PriVar_1Cell, MinPres, FracPassive, NFrac, FracIdx,
-                        JeansMinPres, JeansMinPres_Coeff, EoS->DensEint2Pres_FuncPtr, EoS->DensPres2Eint_FuncPtr,
-                        EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, EintPtr );
-
-         for (int v=0; v<NCOMP_TOTAL_PLUS_MAG; v++)   g_PriVar[v][idx] = PriVar_1Cell[v];
-
-#        ifdef LR_EINT
-         g_PriVar[NCOMP_TOTAL_PLUS_MAG][idx] = Hydro_CheckMinEint( Eint, MinEint ); // store Eint in the last variable
-#        endif
-      } // CGPU_LOOP( idx, CUBE(NIn) )
-
-#     ifdef __CUDACC__
-      __syncthreads();
-#     endif
-   } // if ( Con2Pri )
-
-
-// 1. evaluate the monotonic slope of all cells
-   const int N_SLOPE_PPM2 = SQR( N_SLOPE_PPM );
-   CGPU_LOOP( idx_slope, CUBE(N_SLOPE_PPM) )
-   {
-      const int i_cc   = NGhost - 1 + idx_slope%N_SLOPE_PPM;
-      const int j_cc   = NGhost - 1 + idx_slope%N_SLOPE_PPM2/N_SLOPE_PPM;
-      const int k_cc   = NGhost - 1 + idx_slope/N_SLOPE_PPM2;
-      const int idx_cc = IDX321( i_cc, j_cc, k_cc, NIn, NIn );
-
-//    cc_C/L/R: cell-centered variables of the Central/Left/Right cells
-      real cc_C[NCOMP_LR], cc_L[NCOMP_LR], cc_R[NCOMP_LR], Slope_Limiter[NCOMP_LR];
-
-      for (int v=0; v<NCOMP_LR; v++)   cc_C[v] = g_PriVar[v][idx_cc];
-
-//    loop over different spatial directions
-      for (int d=0; d<3; d++)
-      {
-         const int idx_ccL = idx_cc - didx_cc[d];
-         const int idx_ccR = idx_cc + didx_cc[d];
-
-#        if ( defined MHD  &&  defined CHAR_RECONSTRUCTION )
-         MHD_GetEigenSystem( cc_C, EigenVal[d], LEigenVec, REigenVec, EoS, d );
-#        endif
-
-         for (int v=0; v<NCOMP_LR; v++)
-         {
-            cc_L[v] = g_PriVar[v][idx_ccL];
-            cc_R[v] = g_PriVar[v][idx_ccR];
-         }
-
-         Hydro_LimitSlope( cc_L, cc_C, cc_R, LR_Limiter, MinMod_Coeff, d,
-                           LEigenVec, REigenVec, Slope_Limiter, EoS );
-
-//       store the results to g_Slope_PPM[]
-         for (int v=0; v<NCOMP_LR; v++)   g_Slope_PPM[d][v][idx_slope] = Slope_Limiter[v];
-
-      } // for (int d=0; d<3; d++)
-   } // CGPU_LOOP( idx_slope, CUBE(N_SLOPE_PPM) )
-
-#  ifdef __CUDACC__
-   __syncthreads();
-#  endif
-
-
-// compute electric field for MHM
-#  if ( FLU_SCHEME == MHM  &&  defined MHD )
-   MHD_ComputeElectric_Half( g_EC_Ele, g_ConVar, g_FC_B, N_HF_ELE, NIn, NGhost );
-#  endif
-
-
-// data reconstruction
-   const int N_FC_VAR2 = SQR( N_FC_VAR );
-#  ifdef MHD
-   const int NIn_p1    = NIn + 1;
-   int idx_B[NCOMP_MAG];
-#  endif
-
-   CGPU_LOOP( idx_fc, CUBE(N_FC_VAR) )
-   {
-      const int i_fc      = idx_fc%N_FC_VAR;
-      const int j_fc      = idx_fc%N_FC_VAR2/N_FC_VAR;
-      const int k_fc      = idx_fc/N_FC_VAR2;
-
-      const int i_cc      = i_fc + NGhost;
-      const int j_cc      = j_fc + NGhost;
-      const int k_cc      = k_fc + NGhost;
-      const int idx_cc    = IDX321( i_cc, j_cc, k_cc, NIn, NIn );
-
-      const int i_slope   = i_fc + 1;   // because N_SLOPE_PPM = N_FC_VAR + 2
-      const int j_slope   = j_fc + 1;
-      const int k_slope   = k_fc + 1;
-      const int idx_slope = IDX321( i_slope, j_slope, k_slope, N_SLOPE_PPM, N_SLOPE_PPM );
-
-#     ifdef MHD
-//    assuming that g_FC_B[] is accessed with the strides NIn/NIn+1 along the transverse/longitudinal directions
-      idx_B[0] = IDX321( i_cc, j_cc, k_cc, NIn_p1, NIn    );
-      idx_B[1] = IDX321( i_cc, j_cc, k_cc, NIn,    NIn_p1 );
-      idx_B[2] = IDX321( i_cc, j_cc, k_cc, NIn,    NIn    );
-#     endif
-
- //   cc/fc: cell/face-centered variables; _C_ncomp: central cell with all NCOMP_LR variables
-      real cc_C_ncomp[NCOMP_LR], fc[6][NCOMP_LR], dfc[NCOMP_LR], dfc6[NCOMP_LR];
-
-      for (int v=0; v<NCOMP_LR; v++)   cc_C_ncomp[v] = g_PriVar[v][idx_cc];
-
-
-//    2-a. evaluate the eigenvalues and eigenvectors along all three directions for the pure-hydro CTU integrator
-#     if ( !defined MHD  &&  FLU_SCHEME == CTU )
-      Hydro_GetEigenSystem( cc_C_ncomp, EigenVal, LEigenVec, REigenVec, EoS );
-#     endif
-
-
-//    loop over different spatial directions
-      for (int d=0; d<3; d++)
-      {
-//       2-b. evaluate the eigenvalues and eigenvectors along the target direction for the MHD CTU integrator
-#        if (  defined MHD  &&  ( FLU_SCHEME == CTU || defined CHAR_RECONSTRUCTION )  )
-         MHD_GetEigenSystem( cc_C_ncomp, EigenVal[d], LEigenVec, REigenVec, EoS, d );
-#        endif
-
-
-//       3. get the face-centered primitive variables
-         const int faceL      = 2*d;      // left and right face indices
-         const int faceR      = faceL+1;
-         const int idx_ccL    = idx_cc - didx_cc[d];
-         const int idx_ccR    = idx_cc + didx_cc[d];
          const int idx_slopeL = idx_slope - didx_slope[d];
          const int idx_slopeR = idx_slope + didx_slope[d];
 
+         const real C_factor = 1.25;
+         const real round_err = 1.e-12;
+
          for (int v=0; v<NCOMP_LR; v++)
          {
-//          cc/fc: cell/face-centered variables; _C/L/R: Central/Left/Right cells
-            real cc_C, cc_L, cc_R, dcc_L, dcc_R, dcc_C, fc_L, fc_R, Max, Min;
-
-//          3-1. parabolic interpolation
-            cc_L  = g_PriVar[v][idx_ccL];
-            cc_R  = g_PriVar[v][idx_ccR];
-            cc_C  = cc_C_ncomp[v];
-
-            dcc_L = g_Slope_PPM[d][v][idx_slopeL];
-            dcc_R = g_Slope_PPM[d][v][idx_slopeR];
-            dcc_C = g_Slope_PPM[d][v][idx_slope ];
-
-            fc_L  = (real)0.5*( cc_C + cc_L ) - (real)1.0/(real)6.0*( dcc_C - dcc_L );
-            fc_R  = (real)0.5*( cc_C + cc_R ) - (real)1.0/(real)6.0*( dcc_R - dcc_C );
-
-
-//          3-2. monotonicity constraint
-//          extra monotonicity check for the CENTRAL limiter since it's not TVD
-            if ( LR_Limiter == LR_LIMITER_CENTRAL )
+            if ( LR_Limiter == LR_LIMITER_ATHENA )
             {
-               if ( (cc_C-fc_L)*(fc_L-cc_L) < (real)0.0 )   fc_L = (real)0.5*( cc_C + cc_L );
-               if ( (cc_R-fc_R)*(fc_R-cc_C) < (real)0.0 )   fc_R = (real)0.5*( cc_C + cc_R );
-            }
+               real tmp, rho, cc_abs_max;
+//             fc/cc: face/cell-centered value; cc_*: ceell-centered value; d_*: face-centered slope; dd_*: cell-centered curvature
+               real fc_L, fc_R, cc_LL, cc_L, cc_C, cc_R, cc_RR, d_L, d_R, dd_L, dd_C, dd_R;
+//             dh_*: face-centered slope (half increment); ddh_*: cell-centered curvature (half increment)
+               real dh_LL, dh_L, dh_R, dh_RR, ddh_L, ddh_C, ddh_R;
 
-            dfc [v] = fc_R - fc_L;
-            dfc6[v] = (real)6.0*(  cc_C - (real)0.5*( fc_L + fc_R )  );
+//             3-1. get all the value needed
+               cc_LL = g_PriVar[v][idx_ccLL];
+               cc_L  = g_PriVar[v][idx_ccL ];
+               cc_C  = g_PriVar[v][idx_cc  ];
+               cc_R  = g_PriVar[v][idx_ccR ];
+               cc_RR = g_PriVar[v][idx_ccRR];
 
-            if (  ( fc_R - cc_C )*( cc_C - fc_L ) <= (real)0.0  )
+               d_L   = cc_C - cc_L;
+               d_R   = cc_R - cc_C;
+
+               dd_L  = cc_LL - (real)2.*cc_L + cc_C ;
+               dd_C  = cc_L  - (real)2.*cc_C + cc_R ;
+               dd_R  = cc_C  - (real)2.*cc_R + cc_RR;
+
+               cc_abs_max = MAX(FABS(cc_LL), MAX(FABS(cc_L), MAX(FABS(cc_C), MAX(FABS(cc_R), FABS(cc_RR)))));
+
+//             3-2. interpolate the face value
+               fc_L = ( -cc_LL + (real)7.*cc_L + (real)7.*cc_C - cc_R  ) / (real)12.0;
+               fc_R = ( -cc_L  + (real)7.*cc_C + (real)7.*cc_R - cc_RR ) / (real)12.0;
+
+//             3-3. prepare half increment value
+               dh_LL = fc_L - cc_L;
+               dh_L  = cc_C - fc_L;
+               dh_R  = fc_R - cc_C;
+               dh_RR = cc_R - fc_R;
+
+               ddh_L = cc_L - (real)2.*fc_L + cc_C;
+               ddh_C = fc_L - (real)2.*cc_C + fc_R;
+               ddh_R = cc_C - (real)2.*fc_R + cc_R;
+
+//             3-4. limit slope of L&R
+               if ( dh_LL*dh_L < 0.0 ) {
+                  if ( SIGN(dd_L) == SIGN(ddh_L)  &&  SIGN(ddh_L) == SIGN(dd_C) ) {
+                     tmp = SIGN(dd_C) * MIN(C_factor*FABS(dd_L), MIN( (real)3.*FABS(ddh_L), C_factor*FABS(dd_C)));
+                  } else {
+                     tmp = 0.0;
+                  } // if ( SIGN(dd_L) == SIGN(ddh_L)  &&  SIGN(ddh_L) == SIGN(dd_C) ) ... else ...
+                  fc_L  = (real)0.5*(cc_L+cc_C) - tmp/(real)6.0;
+                  dh_LL = fc_L - cc_L;
+                  dh_L  = cc_C - fc_L;
+               } // if ( dh_LL*dh_L < 0.0 )
+
+               if ( dh_R*dh_RR < 0.0 ) {
+                  if ( SIGN(dd_C) == SIGN(ddh_R)  &&  SIGN(ddh_R) == SIGN(dd_R) ) {
+                     tmp = SIGN(dd_C) * MIN(C_factor*FABS(dd_C), MIN( (real)3.*FABS(ddh_R), C_factor*FABS(dd_R)));
+                  } else {
+                     tmp = 0.0;
+                  } // if ( SIGN(dd_C) == SIGN(ddh_R)  &&  SIGN(ddh_R) == SIGN(dd_R) ) ... else ...
+                  fc_R  = (real)0.5*(cc_C+cc_R) - tmp/(real)6.0;
+                  dh_R  = fc_R - cc_C;
+                  dh_RR = cc_R - fc_R;
+               } // if ( dh_R*dh_RR < 0.0 )
+
+//             preparation for the CTU (not in athena++)
+               dfc [v] = fc_R - fc_L;
+               dfc6[v] = (real)6.0*( cc_C - (real)0.5*(fc_L + fc_R) );
+
+//             3-5. reduce error to round-off error
+               if ( SIGN(dd_L) == SIGN(dd_C)  &&  SIGN(dd_C) == SIGN(dd_R)  &&  SIGN(dd_R) == SIGN(ddh_C) ) {
+                  tmp = SIGN(dd_C) * MIN( C_factor*FABS(dd_L), MIN( C_factor*FABS(dd_C), MIN( C_factor*FABS(dd_L), (real)6.0*FABS(ddh_C))));
+               } else {
+                  tmp = 0.0;
+               } // if ( SIGN(dd_L) == SIGN(dd_C)  &&  SIGN(dd_C) == SIGN(dd_R)  &&  SIGN(dd_R) == SIGN(ddh_C) ) ... else ...
+
+               if ( (real)6.*FABS(ddh_C) > round_err*cc_abs_max ) {
+                  rho = tmp / ddh_C / (real)6.;
+               } else {
+                  rho = 0.0;
+               } // if ( FABS(ddh_C) > round_error*cc_abs_max ) ... else ...
+
+               if ( dh_L*dh_R < 0.0 || d_L*d_R < 0.0 ) {
+                  if ( rho < 1.-round_err ) fc_L = cc_C - rho * dh_L;
+                  if ( rho < 1.-round_err ) fc_R = cc_C + rho * dh_R;
+               } else {
+                  if ( FABS(dh_L) >= (real)2.*FABS(dh_R) ) fc_L = cc_C - (real)2.*dh_R;
+                  if ( FABS(dh_R) >= (real)2.*FABS(dh_L) ) fc_R = cc_C + (real)2.*dh_L;
+               } // if ( dh_L*dh_R < 0.0 && d_L*d_R < 0.0 )
+
+            } else // if ( LR_Limiter == LR_LIMITER_ATHENA )
             {
-               fc_L = cc_C;
-               fc_R = cc_C;
-            }
-            else if ( dfc[v]*dfc6[v] > +dfc[v]*dfc[v] )
-               fc_L = (real)3.0*cc_C - (real)2.0*fc_R;
-            else if ( dfc[v]*dfc6[v] < -dfc[v]*dfc[v] )
-               fc_R = (real)3.0*cc_C - (real)2.0*fc_L;
+//             cc/fc: cell/face-centered variables; _C/L/R: Central/Left/Right cells
+               real cc_C, cc_L, cc_R, dcc_L, dcc_R, dcc_C, fc_L, fc_R, Max, Min;
+
+//             3-1. parabolic interpolation
+               cc_L  = g_PriVar[v][idx_ccL];
+               cc_R  = g_PriVar[v][idx_ccR];
+               cc_C  = cc_C_ncomp[v];
+
+               dcc_L = g_Slope_PPM[d][v][idx_slopeL];
+               dcc_R = g_Slope_PPM[d][v][idx_slopeR];
+               dcc_C = g_Slope_PPM[d][v][idx_slope ];
+
+               fc_L  = (real)0.5*( cc_C + cc_L ) - (real)1.0/(real)6.0*( dcc_C - dcc_L );
+               fc_R  = (real)0.5*( cc_C + cc_R ) - (real)1.0/(real)6.0*( dcc_R - dcc_C );
 
 
-//          3-3. ensure the face-centered variables lie between neighboring cell-centered values
-            Min  = ( cc_C < cc_L ) ? cc_C : cc_L;
-            Max  = ( cc_C > cc_L ) ? cc_C : cc_L;
-            fc_L = ( fc_L > Min  ) ? fc_L : Min;
-            fc_L = ( fc_L < Max  ) ? fc_L : Max;
+//             3-2. monotonicity constraint
+//             extra monotonicity check for the CENTRAL limiter since it's not TVD
+               if ( LR_Limiter == LR_LIMITER_CENTRAL )
+               {
+                  if ( (cc_C-fc_L)*(fc_L-cc_L) < (real)0.0 )   fc_L = (real)0.5*( cc_C + cc_L );
+                  if ( (cc_R-fc_R)*(fc_R-cc_C) < (real)0.0 )   fc_R = (real)0.5*( cc_C + cc_R );
+               }
 
-            Min  = ( cc_C < cc_R ) ? cc_C : cc_R;
-            Max  = ( cc_C > cc_R ) ? cc_C : cc_R;
-            fc_R = ( fc_R > Min  ) ? fc_R : Min;
-            fc_R = ( fc_R < Max  ) ? fc_R : Max;
+               dfc [v] = fc_R - fc_L;
+               dfc6[v] = (real)6.0*(  cc_C - (real)0.5*( fc_L + fc_R )  );
+
+               if (  ( fc_R - cc_C )*( cc_C - fc_L ) <= (real)0.0  )
+               {
+                  fc_L = cc_C;
+                  fc_R = cc_C;
+               }
+               else if ( dfc[v]*dfc6[v] > +dfc[v]*dfc[v] )
+                  fc_L = (real)3.0*cc_C - (real)2.0*fc_R;
+               else if ( dfc[v]*dfc6[v] < -dfc[v]*dfc[v] )
+                  fc_R = (real)3.0*cc_C - (real)2.0*fc_L;
+
+//             3-3. ensure the face-centered variables lie between neighboring cell-centered values
+               Min  = ( cc_C < cc_L ) ? cc_C : cc_L;
+               Max  = ( cc_C > cc_L ) ? cc_C : cc_L;
+               fc_L = ( fc_L > Min  ) ? fc_L : Min;
+               fc_L = ( fc_L < Max  ) ? fc_L : Max;
+
+               Min  = ( cc_C < cc_R ) ? cc_C : cc_R;
+               Max  = ( cc_C > cc_R ) ? cc_C : cc_R;
+               fc_R = ( fc_R > Min  ) ? fc_R : Min;
+               fc_R = ( fc_R < Max  ) ? fc_R : Max;
+            } // if ( LR_Limiter == LR_LIMITER_ATHENA ) ... else ...
 
             fc[faceL][v] = fc_L;
             fc[faceR][v] = fc_R;
@@ -2623,8 +1368,8 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
 
 #  endif // #if ( FLU_SCHEME == MHM  &&  defined MHD )
 
-} // FUNCTION : Hydro_DataReconstruction (PPM_OLD)
-#endif // #if ( LR_SCHEME == PPM_OLD )
+} // FUNCTION : Hydro_DataReconstruction (PPM)
+#endif // #if ( LR_SCHEME == PPM )
 
 
 
@@ -3239,8 +1984,9 @@ void Hydro_LimitSlope( const real L[], const real C[], const real R[], const LR_
                Slope_Limiter[v]  = FMIN(  FABS( Slope_A[v] ), Slope_Limiter[v]  );
                Slope_Limiter[v] *= SIGN( Slope_C[v] );
                break;
-            
+
             case LR_LIMITER_ATHENA:   // ATHENA++ limiter
+               Slope_Limiter[v] = Slope_C[v];
                break;
 
             default :

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
@@ -900,11 +900,12 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
 
          } // for (int d=0; d<3; d++)
       } // CGPU_LOOP( idx_slope, CUBE(N_SLOPE_PPM) )
+
+#     ifdef __CUDACC__
+      __syncthreads();
+#     endif
    } // if ( LR_Limiter != LR_LIMITER_ATHENA )
 
-#  ifdef __CUDACC__
-   __syncthreads();
-#  endif
 
 
 // compute electric field for MHM

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
@@ -908,7 +908,6 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
    int idx_B[NCOMP_MAG];
 #  endif
 
-   // printf("PPM (con, pri, con)\n");
    CGPU_LOOP( idx_fc, CUBE(N_FC_VAR) )
    {
       const int i_fc      = idx_fc%N_FC_VAR;
@@ -1000,11 +999,6 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
                                  )
                             );
 
-           // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf(" CC: %+.16e %+.16e %+.16e %+.16e %+.16e\n", cc_LL, cc_L, cc_C, cc_R, cc_RR);
-           // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf(" dC: %+.16e %+.16e %+.16e %+.16e\n", d_LL, d_L, d_R, d_RR);
-           // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("ddC: %+.16e %+.16e %+.16e\n", dd_L, dd_C, dd_R);
-           // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("cc_abs_max: %+.16e\n", cc_abs_max);
-
 //          3-2. interpolate the face value
             fc_L = ( -cc_LL + (real)7.*cc_L + (real)7.*cc_C - cc_R  ) / (real)12.0;
             fc_R = ( -cc_L  + (real)7.*cc_C + (real)7.*cc_R - cc_RR ) / (real)12.0;
@@ -1017,8 +1011,6 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
             // real dd_ip1 = (cc_RR - cc_R) / (real)2. + qb / (real)2.;
             // fc_L = cc_L/(real)2. + cc_C/(real)2. + dd_im1/(real)6. - dd    /(real)6.;
             // fc_R = cc_C/(real)2. + cc_R/(real)2. + dd    /(real)6. - dd_ip1/(real)6.;
-
-           // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("1 => %02d: %+.16e %+.16e\n", i_cc, fc_L, fc_R);
 
 //          3-3. prepare half value
             real dh_LL, dh_L, dh_R, dh_RR;
@@ -1033,9 +1025,6 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
             ddh_C = fc_L - (real)2.*cc_C + fc_R;
             ddh_R = cc_C - (real)2.*fc_R + cc_R;
 
-            // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf(" dh: %+.16e %+.16e %+.16e %+.16e\n", dh_LL, dh_L, dh_R, dh_RR);
-            // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("ddh: %+.16e %+.16e %+.16e\n", ddh_L, ddh_C, ddh_R);
-
 //          3-4. limit slope of L&R
             if ( dh_LL*dh_L < 0.0 ) {
                if ( SIGN(dd_L) == SIGN(ddh_L) && SIGN(ddh_L) == SIGN(dd_C) ) {
@@ -1045,8 +1034,6 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
                } else {
                   tmp = 0.0;
                } // if ( SIGN(dd_L) == SIGN(ddh_L) && SIGN(ddh_L) == SIGN(dd_C) ) ... else ...
-               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("extrma at i-1/2, %+.16e => %+.16e ", fc_L, (real)0.5*(cc_L+cc_C) - tmp/(real)6.0);
-               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("tmp = %+.16e\n", tmp);
                fc_L = (real)0.5*(cc_L+cc_C) - tmp/(real)6.0;
             } // if ( dh_LL*dh_L < 0.0 )
 
@@ -1058,12 +1045,8 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
                } else {
                   tmp = 0.0;
                } // if ( SIGN(dd_C) == SIGN(ddh_R) && SIGN(ddh_R) == SIGN(dd_R) ) ... else ...
-               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("extrma at i+1/2, %+.16e => %+.16e ", fc_R, (real)0.5*(cc_R+cc_C) - tmp/(real)6.0);
-               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("tmp = %+.16e\n", tmp);
                fc_R = (real)0.5*(cc_C+cc_R) - tmp/(real)6.0;
             } // if ( dh_R*dh_RR < 0.0 )
-
-           // if (debug)  if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("2 => %02d: %+.16e %+.16e\n", i_cc, fc_L, fc_R);
 
 //          3.4.1 test update the half value
             dh_LL = fc_L - cc_L;
@@ -1073,7 +1056,6 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
 
 //          3-5. reduce error to round-off error
             if ( SIGN(dd_L) == SIGN(dd_C) && SIGN(dd_C) == SIGN(dd_R) && SIGN(dd_R) == SIGN(ddh_C) ) {
-               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("same dd at i => ");
                tmp = SIGN(dd_C) * MIN( C_factor*FABS(dd_L),
                                        MIN( C_factor*FABS(dd_C),
                                             MIN( C_factor*FABS(dd_L), (real)6.0*FABS(ddh_C))
@@ -1082,44 +1064,32 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
             } else {
                tmp = 0.0;
             } // if ( SIGN(dd_L) == SIGN(dd_C) && SIGN(dd_C) == SIGN(dd_R) && SIGN(dd_R) == SIGN(ddh_C) ) ... else ...
-            // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("tmp = %+.16e\n", tmp);
 
             if ( (real)6.*FABS(ddh_C) > round_err*cc_abs_max ) {
-               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("big dd => ");
                rho = tmp / ddh_C / (real)6.;
             } else {
                rho = 0.0;
             } // if ( FABS(ddh_C) > round_error*cc_abs_max ) ... else ...
-            // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("rho = %+.16e\n", rho);
 
             if ( dh_L*dh_R < 0.0 || d_L*d_R < 0.0 ) {
-               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("Extrema at i: ");
                if ( rho < 1.-round_err )   {
                   fc_L = cc_C - rho * dh_L;
-                  // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("fix left ");
                }
                if ( rho < 1.-round_err )   {
                   fc_R = cc_C + rho * dh_R;
-                  // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("fix right ");
                }
-               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("\n");
             } else {
-               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("No extrema at i: ");
                if ( FABS(dh_L) >= (real)2.*FABS(dh_R) )   {
                   fc_L = cc_C - (real)2.*dh_R;
-                  // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("fix left ");
                }
                if ( FABS(dh_R) >= (real)2.*FABS(dh_L) )   {
                   fc_R = cc_C + (real)2.*dh_L;
-                  // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("fix right ");
                }
-               // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("\n");
             } // if ( dh_L*dh_R < 0.0 && d_L*d_R < 0.0 )
 
 //          3-6. store the value
             fc[faceL][v] = fc_L;
             fc[faceR][v] = fc_R;
-            // if (debug) if (v==0 && d==0 && j_cc==8 && k_cc==8) printf("Final: %+.16e %+.16e\n", fc_L, fc_R);
 
          } // for (int v=0; v<NCOMP_LR; v++)
 
@@ -1367,17 +1337,6 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
       for (int f=0; f<6; f++)
       for (int v=0; v<NCOMP_TOTAL_PLUS_MAG; v++)
          g_FC_Var[f][v][idx_fc] = fc[f][v];
-
-      // if ( j_cc == 8 && k_cc == 8 )
-      // {
-      //    printf( "i=%02d, j=%02d, k=%02d", i_cc, j_cc, k_cc);
-      //    printf( "| %+.16e %+.16e %+.16e | ", fc[0][0], g_PriVar[0][idx_cc], fc[1][0] );
-      //    printf( "| %+.16e %+.16e %+.16e | ", fc[0][1], g_PriVar[1][idx_cc], fc[1][1] );
-      //    printf( "| %+.16e %+.16e %+.16e | ", fc[0][2], g_PriVar[2][idx_cc], fc[1][2] );
-      //    printf( "| %+.16e %+.16e %+.16e | ", fc[0][3], g_PriVar[3][idx_cc], fc[1][3] );
-      //    printf( "| %+.16e %+.16e %+.16e | ", fc[0][4], g_PriVar[4][idx_cc], fc[1][4] );
-      //    printf("\n");
-      // }
 
    } // CGPU_LOOP( idx_fc, CUBE(N_FC_VAR) )
 

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
@@ -967,11 +967,13 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
 
          for (int v=0; v<NCOMP_LR; v++)
          {
+//          fc: face-centered value
+            real fc_L, fc_R;
             if ( LR_Limiter == LR_LIMITER_ATHENA )
             {
                real tmp, rho, cc_abs_max;
-//             fc/cc: face/cell-centered value; cc_*: ceell-centered value; d_*: face-centered slope; dd_*: cell-centered curvature
-               real fc_L, fc_R, cc_LL, cc_L, cc_C, cc_R, cc_RR, d_L, d_R, dd_L, dd_C, dd_R;
+//             cc: cell-centered value; cc_*: cell-centered value; d_*: face-centered slope; dd_*: cell-centered curvature
+               real cc_LL, cc_L, cc_C, cc_R, cc_RR, d_L, d_R, dd_L, dd_C, dd_R;
 //             dh_*: face-centered slope (half increment); ddh_*: cell-centered curvature (half increment)
                real dh_LL, dh_L, dh_R, dh_RR, ddh_L, ddh_C, ddh_R;
 
@@ -1055,8 +1057,8 @@ void Hydro_DataReconstruction( const real g_ConVar   [][ CUBE(FLU_NXT) ],
 
             } else // if ( LR_Limiter == LR_LIMITER_ATHENA )
             {
-//             cc/fc: cell/face-centered variables; _C/L/R: Central/Left/Right cells
-               real cc_C, cc_L, cc_R, dcc_L, dcc_R, dcc_C, fc_L, fc_R, Max, Min;
+//             cc: cell-centered variables; _C/L/R: Central/Left/Right cells
+               real cc_C, cc_L, cc_R, dcc_L, dcc_R, dcc_C, Max, Min;
 
 //             3-1. parabolic interpolation
                cc_L  = g_PriVar[v][idx_ccL];

--- a/src/TestProblem/Hydro/AcousticWave/Init_TestProb_Hydro_AcousticWave.cpp
+++ b/src/TestProblem/Hydro/AcousticWave/Init_TestProb_Hydro_AcousticWave.cpp
@@ -218,10 +218,8 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
    WaveW = 2.0*M_PI/(Acoustic_WaveLength/Acoustic_Cs);
    Phase = WaveK*r - Acoustic_Sign*WaveW*Time + Acoustic_Phase0;
 
-   // Dens  = 1.0 + Acoustic_RhoAmp*cos(Phase);
-   Dens  = 1.0 + Acoustic_RhoAmp*sin(Phase);
-   // Mom   = Dens*( v1*cos(Phase) + Acoustic_v0 );
-   Mom   = 1.0*( v1*sin(Phase) + Acoustic_v0 );
+   Dens  = 1.0 + Acoustic_RhoAmp*cos(Phase);
+   Mom   = Dens*( v1*cos(Phase) + Acoustic_v0 );
 
    switch ( Acoustic_Dir ) {
       case 0:  MomX = Mom;            MomY = 0.0;   MomZ = 0.0;   break;
@@ -230,12 +228,10 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
       case 3:  MomX = Mom/sqrt(3.0);  MomY = MomX;  MomZ = MomX;  break;
    }
 
-   // Pres  = P0 + P1*cos(Phase);
-   // Eint  = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-   //                                   EoS_AuxArray_Int, h_EoS_Table );   // assuming EoS requires no passive scalars
-   // Etot  = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );     // do NOT include magnetic energy here
-   const real h0 = P0/(GAMMA-1.0) + 0.5 * 1.0 * Acoustic_v0 * Acoustic_v0 + P0;
-   Etot = P0 / (GAMMA-1.0) + 0.5 * 1.0 * Acoustic_v0 * Acoustic_v0 + Acoustic_RhoAmp * sin(Phase) * h0;
+   Pres  = P0 + P1*cos(Phase);
+   Eint  = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
+                                     EoS_AuxArray_Int, h_EoS_Table );   // assuming EoS requires no passive scalars
+   Etot  = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );     // do NOT include magnetic energy here
 
 // set the output array
    fluid[DENS] = Dens;

--- a/src/TestProblem/Hydro/AcousticWave/Init_TestProb_Hydro_AcousticWave.cpp
+++ b/src/TestProblem/Hydro/AcousticWave/Init_TestProb_Hydro_AcousticWave.cpp
@@ -218,8 +218,9 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
    WaveW = 2.0*M_PI/(Acoustic_WaveLength/Acoustic_Cs);
    Phase = WaveK*r - Acoustic_Sign*WaveW*Time + Acoustic_Phase0;
 
-   Dens  = 1.0 + Acoustic_RhoAmp*cos(Phase);
-   Mom   = Dens*( v1*cos(Phase) + Acoustic_v0 );
+   Dens  = 1.0 + Acoustic_RhoAmp*sin(Phase);
+   // Mom   = Dens*( v1*sin(Phase) + Acoustic_v0 );
+   Mom   = 1.0*( v1*sin(Phase) + Acoustic_v0 );
 
    switch ( Acoustic_Dir ) {
       case 0:  MomX = Mom;            MomY = 0.0;   MomZ = 0.0;   break;
@@ -228,10 +229,12 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
       case 3:  MomX = Mom/sqrt(3.0);  MomY = MomX;  MomZ = MomX;  break;
    }
 
-   Pres  = P0 + P1*cos(Phase);
-   Eint  = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-                                     EoS_AuxArray_Int, h_EoS_Table );   // assuming EoS requires no passive scalars
-   Etot  = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );     // do NOT include magnetic energy here
+   // Pres  = P0 + P1*sin(Phase);
+   // Eint  = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
+   //                                   EoS_AuxArray_Int, h_EoS_Table );   // assuming EoS requires no passive scalars
+   // Etot  = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );     // do NOT include magnetic energy here
+   const real h0 = P0/(GAMMA-1.0) + 0.5 * 1.0 * Acoustic_v0 * Acoustic_v0 + P0;
+   Etot = P0 / (GAMMA-1.0) + 0.5 * 1.0 * Acoustic_v0 * Acoustic_v0 + Acoustic_RhoAmp * sin(Phase) * h0;
 
 // set the output array
    fluid[DENS] = Dens;


### PR DESCRIPTION
As #247 indicates, the current error convergence rate is not second-order accurate. This PR improves the PPM data reconstruction method.

## Results
[Athena PPM algorithm (PDF)](https://drive.google.com/file/d/1KX9lK7q2ChyosQoun5iC3x2mcg1LQPy4/view?usp=drive_link) / [Athena PPM algorithm (PowerPoint)](https://docs.google.com/presentation/d/1P--Us4ipXRB3t0OMtYI_P92CZAvnsmk5/edit?usp=drive_link&ouid=101271316745208642650&rtpof=true&sd=true)
[Athena PPM results (Google slides)](https://docs.google.com/presentation/d/1QM8l-jbmZXitEOPdpV2A6gYoDQkbWoKAts2znw2DAYg/edit?usp=sharing)

## Default
1. The CFL factor (`DT__FLUID`) is recommended to be larger than `0.4`.

## Performance
1. The performance of the new PPM is about 1.3 times slower than the original PPM (`VL_GMOD`).

## Issue
1. `MHM` with `MHD` using `LR_LIMITER_ATHENA` causes small-scale oscillation for high-resolution linear wave test.

## References
1. [Athena++ source code](https://github.com/PrincetonUniversity/athena)
1. [Athena](https://iopscience.iop.org/article/10.1086/588755)
1. [Athena++](https://iopscience.iop.org/article/10.3847/1538-4365/ab929b)
1. [The Piecewise Parabolic Method (PPM) for gas-dynamical simulations](https://www.sciencedirect.com/science/article/pii/0021999184901438)
1. [A limiter for PPM that preserves accuracy at smooth extrema](https://www.sciencedirect.com/science/article/pii/S0021999108001435?ref=pdf_download&fr=RR-2&rr=7ffb3769ce5ea3a5)
1. [A high-order finite-volume method for conservation laws on locally refined grids](https://projecteuclid.org/journals/communications-in-applied-mathematics-and-computational-science/volume-6/issue-1/A-high-order-finite-volume-method-for-conservation-laws-on/10.2140/camcos.2011.6.1.full)