### PR TITLE
Reset OMP_NTHREAD properly

### DIFF
--- a/src/Init/Init_ResetParameter.cpp
+++ b/src/Init/Init_ResetParameter.cpp
@@ -29,7 +29,41 @@ void Init_ResetParameter()
 #  ifdef OPENMP
    if ( OMP_NTHREAD <= 0 )
    {
-      OMP_NTHREAD = omp_get_max_threads();
+      int  NCPU_Node, NNode_PBS, NNode_SLURM;
+      FILE *fp;
+
+//    determine if the PBS/SLURM software is used
+      fp = popen("echo ${PBS_NUM_NODES:-0}", "r");
+      fscanf(fp, "%d", &NNode_PBS);
+
+      fp = popen("echo ${SLURM_JOB_NUM_NODES:-0}", "r");
+      fscanf(fp, "%d", &NNode_SLURM);
+
+
+//    set up the number of OpenMP thread
+      if ( NNode_PBS ) // PBS system
+      {
+         fp = popen("echo $PBS_NUM_PPN", "r");
+         fscanf(fp, "%d", &NCPU_Node);
+
+         OMP_NTHREAD = NCPU_Node * NNode_PBS / MPI_NRank;
+      }
+
+      else if ( NNode_SLURM ) // SLURM system
+      {
+         fp = popen("echo $SLURM_CPUS_ON_NODE", "r");
+         fscanf(fp, "%d", &NCPU_Node);
+
+         OMP_NTHREAD = NCPU_Node * NNode_SLURM / MPI_NRank;
+      }
+
+      else
+      {
+         OMP_NTHREAD = omp_get_max_threads();
+      }
+
+
+      pclose(fp);
 
       PRINT_RESET_PARA( OMP_NTHREAD, FORMAT_INT, "" );
    }


### PR DESCRIPTION
When using PBS/SLURM system, reset `OMP_NTHREAD` to `number_of_CPU_cores_per_node / number_of_MPI_ranks_per_node` if not set.

Related issue: #263