### PR TITLE
Switch from -O3 to -O2 in *.config for the intel compiler

### DIFF
--- a/configs/bluewaters.config
+++ b/configs/bluewaters.config
@@ -7,7 +7,7 @@ CXX_MPI mpicxx
 
 # flags
 CXXFLAG -g
-CXXFLAG -O3
+CXXFLAG -O2
 CXXFLAG -fp-model precise
 #CXXFLAG -std=c++11
 #CXXFLAG -gxx-name=YOUR_G++

--- a/configs/eureka_intel.config
+++ b/configs/eureka_intel.config
@@ -14,7 +14,7 @@ CXX_MPI mpicxx
 
 # flags
 CXXFLAG -g
-CXXFLAG -O3
+CXXFLAG -O2
 CXXFLAG -fp-model precise
 #CXXFLAG -std=c++11
 #CXXFLAG -gxx-name=YOUR_G++

--- a/configs/ncts.config
+++ b/configs/ncts.config
@@ -11,7 +11,7 @@ CXX_MPI mpicxx
 
 # intel flags
 CXXFLAG -g
-CXXFLAG -O3
+CXXFLAG -O2
 CXXFLAG -fp-model precise
 CXXFLAG -w1
 CXXFLAG -Wno-unknown-pragmas -diag-disable 3180

--- a/configs/spock_intel.config
+++ b/configs/spock_intel.config
@@ -14,7 +14,7 @@ CXX_MPI mpicxx
 
 # flags
 CXXFLAG -g
-CXXFLAG -O3
+CXXFLAG -O2
 CXXFLAG -fp-model precise
 #CXXFLAG -std=c++11
 #CXXFLAG -gxx-name=YOUR_G++


### PR DESCRIPTION
The commit https://github.com/gamer-project/gamer/commit/9f750a5d9b8568e4cb3a760a9b86d3f892d00b3d seems to trigger a bug in the intel compiler. The issue can be reproduced with the test `CR_Diffusion` when enabling `OPT__OUTPUT_PART  7`, leading to the following error messages.
```
Output_DumpData_Part (DumpID = 0)           ...
[eureka01:70782:0:70782] Caught signal 11 (Segmentation fault: Sent by the kernel at address (nil))

/projectW/fish/gamer_develop/gamer/src/Main/Prepare_PatchData.cpp: [ L__Z17Prepare_PatchDataidPfS_iiPKilliiiibS1_iffffb_559__par_region0_2_0() ]
      ...
      993                                                          idx_i = IDX321( ijk_s[0],        j, k, size_i[0], size_i[1] );
      994                for (int i=ijk_s[0]; i<ijk_e[0]; i++)  {
      995
==>   996                   Data1PG_FC_Ptr[idx_o] = amr->patch[MagSg][lv][PID]->magnetic[TVarFCIdx][idx_i];
      997
      998                   if ( MagIntTime ) // temporal interpolation
      999                   Data1PG_FC_Ptr[idx_o] =   MagWeighting     *Data1PG_FC_Ptr[idx_o]

==== backtrace (tid:  70782) ====
 0 0x0000000000410429 L__Z17Prepare_PatchDataidPfS_iiPKilliiiibS1_iffffb_559__par_region0_2_0()  /projectW/fish/gamer_develop/gamer/src/Main/Prepare_PatchDat
a.cpp:996
 1 0x000000000013fbb3 __kmp_invoke_microtask()  ???:0
 2 0x00000000000bb903 __kmp_invoke_task_func()  /nfs/site/proj/openmp/promo/20211013/tmp/lin_32e-rtl_int_5_nor_dyn.rel.c0.s0.t1..h1.w1-fxilab153/../../src/kmp_runtime.cpp:7813
 3 0x00000000000bd3de __kmp_fork_call()  /nfs/site/proj/openmp/promo/20211013/tmp/lin_32e-rtl_int_5_nor_dyn.rel.c0.s0.t1..h1.w1-fxilab153/../../src/kmp_runtime.cpp:2494
 4 0x000000000007dcb5 __kmpc_fork_call()  /nfs/site/proj/openmp/promo/20211013/tmp/lin_32e-rtl_int_5_nor_dyn.rel.c0.s0.t1..h1.w1-fxilab153/../../src/kmp_csupport.cpp:358
 5 0x000000000040aa48 Prepare_PatchData()  /projectW/fish/gamer_develop/gamer/src/Main/Prepare_PatchData.cpp:559
 6 0x000000000048bfe3 _INTERNALb996796c::GetDerivedField()  /projectW/fish/gamer_develop/gamer/src/Output/Output_DumpData_Part.cpp:470
 7 0x000000000048cea9 Output_DumpData_Part()  /projectW/fish/gamer_develop/gamer/src/Output/Output_DumpData_Part.cpp:203
 8 0x000000000048ad80 Output_DumpData()  /projectW/fish/gamer_develop/gamer/src/Output/Output_DumpData.cpp:276
 9 0x0000000000405fc5 main()  /projectW/fish/gamer_develop/gamer/src/Main/Main.cpp:565
10 0x0000000000022555 __libc_start_main()  ???:0
11 0x0000000000405e29 _start()  ???:0
=================================
```

The above commit does nothing but enables some sanity checks in `Prepare_PatchData()` regardless of `GAMER_DEBUG`. Switching from `-O3` to `-O2` solves the issue with no apparent explanation, suggesting that it's probably a bug in the compiler instead of GAMER itself.

Accordingly, this PR changes the default optimization level from `-O3` to `-O2` in all configuration files using the intel compiler. I have confirmed that it has a negligible impact on the performance of both the `eureka` and `spock` GPU clusters.