### PR TITLE
Generalize Aux_ComputeProfile()

### DIFF
--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -37,7 +37,7 @@ int  Aux_CountRow( const char *FileName );
 void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double r_max_input, const double dr_min,
                          const bool LogBin, const double LogBinRatio, const bool RemoveEmpty, const long TVarBitIdx[],
                          const int NProf, const int MinLv, const int MaxLv, const PatchType_t PatchType,
-                         const double PrepTime );
+                         const double PrepTimeIn );
 void Aux_FindExtrema( Extrema_t *Extrema, const ExtremaMode_t Mode, const int MinLv, const int MaxLv,
                       const PatchType_t PatchType );
 #ifndef SERIAL

--- a/src/Auxiliary/Aux_ComputeProfile.cpp
+++ b/src/Auxiliary/Aux_ComputeProfile.cpp
@@ -5,6 +5,7 @@ extern void SetTempIntPara( const int lv, const int Sg0, const double PrepTime, 
 
 
 
+
 //-------------------------------------------------------------------------------------------------------
 // Function    :  Aux_ComputeProfile
 // Description :  Compute the average radial profile of target field(s)
@@ -17,12 +18,14 @@ extern void SetTempIntPara( const int lv, const int Sg0, const double PrepTime, 
 //                       Prof->NBin    : Total number of bins
 //                   --> See the "Profile_t" structure defined in "include/Profile.h" for details
 //                   --> These arrays will be free'd when deleting "Prof"
-//                2. Maximum radius adopted when actually computing the profile may be larger than the input "r_max"
+//                2. The exact maximum radius adopted may be slightly larger than the input "r_max"
 //                   --> Because "r_max" in general does not coincide with the right edge of the maximum bin
 //                3. Support hybrid OpenMP/MPI parallelization
 //                   --> All ranks will share the same profile data after invoking this function
-//                4. Use cell volume as the weighting of each cell
-//                   --> Will support other weighting functions in the future
+//                4. Weighting of each cell:
+//                      Cell mass  : gas velocity, gravitational potential
+//                      Cell volume: other fields
+//                   --> Will support more weighting fields in the future
 //                5. Support computing multiple fields
 //                   --> The order of fields to be returned follows TVarBitIdx[]
 //
@@ -41,9 +44,11 @@ extern void SetTempIntPara( const int lv, const int Sg0, const double PrepTime, 
 //                                        Data[empty_bin]=Weight[empty_bin]=NCell[empty_bin]=0
 //                TVarBitIdx  : Bitwise indices of target variables for computing the profiles
 //                              --> Supported indices (defined in Macro.h):
-//                                     HYDRO : _DENS, _MOMX, _MOMY, _MOMZ, _ENGY, _VELR, _PRES, _EINT
-//                                             [, _DUAL, _POTE]
+//                                     HYDRO : _DENS, _MOMX, _MOMY, _MOMZ, _ENGY, _VELX, _VELY, _VELZ, _VELR,
+//                                             _PRES, _TEMP, _ENTR, _EINT
+//                                             [, _DUAL, _CRAY, _POTE, __MAGX_CC, _MAGY_CC, _MAGZ_CC, _MAGE_CC]
 //                                     ELBDM : _DENS, _REAL, _IMAG [, _POTE]
+//                              --> All fields supported by Prepare_PatchData() are also supported here
 //                              --> For a passive scalar with an integer field index FieldIdx returned by AddField(),
 //                                  one can convert it to a bitwise field index by BIDX(FieldIdx)
 //                NProf       : Number of Profile_t objects in Prof
@@ -52,8 +57,8 @@ extern void SetTempIntPara( const int lv, const int Sg0, const double PrepTime, 
 //                              --> Supported types: PATCH_LEAF, PATCH_NONLEAF, PATCH_BOTH, PATCH_LEAF_PLUS_MAXNONLEAF
 //                              --> PATCH_LEAF_PLUS_MAXNONLEAF includes leaf patches on all target levels
 //                                  (i.e., MinLv ~ MaxLv) and non-leaf patches only on MaxLv
-//                PrepTime    : Target physical time to prepare data
-//                              --> If PrepTime<0, turn off temporal interpolation and always use the most recent data
+//                PrepTimeIn  : Target physical time to prepare data
+//                              --> If PrepTimeIn<0, turn off temporal interpolation and always use the most recent data
 //
 // Example     :  const double      Center[3]      = { amr->BoxCenter[0], amr->BoxCenter[1], amr->BoxCenter[2] };
 //                const double      MaxRadius      = 0.5*amr->BoxSize[0];
@@ -94,7 +99,7 @@ extern void SetTempIntPara( const int lv, const int Sg0, const double PrepTime, 
 void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double r_max_input, const double dr_min,
                          const bool LogBin, const double LogBinRatio, const bool RemoveEmpty, const long TVarBitIdx[],
                          const int NProf, const int MinLv, const int MaxLv, const PatchType_t PatchType,
-                         const double PrepTime )
+                         const double PrepTimeIn )
 {
 
 // check
@@ -120,29 +125,25 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
    if ( PatchType != PATCH_LEAF  &&  PatchType != PATCH_NONLEAF  &&
         PatchType != PATCH_BOTH  &&  PatchType != PATCH_LEAF_PLUS_MAXNONLEAF )
       Aux_Error( ERROR_INFO, "incorrect PatchType (%d) !!\n", PatchType );
-#  endif
+
+#  endif // #ifdef GAMER_DEBUG
 
 
-// precompute the integer indices of intrinsic fluid fields for better performance
-   const int IdxUndef = -1;
-   int TFluIntIdx[NProf];
-
-   for (int p=0; p<NProf; p++)
-   {
-      TFluIntIdx[p] = IdxUndef;
-
-      for (int v=0; v<NCOMP_TOTAL; v++)
-         if ( TVarBitIdx[p] & (1L<<v) )   TFluIntIdx[p] = v;
-   }
-
-
-// check whether _POTE is in TVarBitIdx since the potential array may have not been computed during initialization
+// list all supported fields
+// --> all fields supported by Prepare_PatchData() should be supported here
+   long SupportedFields = ( _TOTAL | _DERIVED );
 #  ifdef GRAVITY
-   bool InclPot = false;
-
-   for (int p=0; p<NProf; p++)
-      if ( TVarBitIdx[p] & _POTE )   InclPot = true;
+   SupportedFields |= _POTE;
 #  endif
+#  ifdef PARTICLE
+   SupportedFields |= _PAR_DENS;
+   SupportedFields |= _TOTAL_DENS;
+#  endif
+
+   for (int p=0; p<NProf; p++) {
+      if ( TVarBitIdx[p] & ~SupportedFields )
+         Aux_Error( ERROR_INFO, "unsupported field (TVarBitIdx[%d] = %ld) !!\n", p, TVarBitIdx[p] );
+   }
 
 
 // initialize the profile objects
@@ -198,13 +199,44 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
    Aux_AllocateArray3D( OMP_NCell,  NProf, NT, Prof[0]->NBin );
 
 
-// collect profile data in this rank
-   const double r_max2      = SQR( Prof[0]->MaxRadius );
-   const double HalfBox[3]  = { 0.5*amr->BoxSize[0], 0.5*amr->BoxSize[1], 0.5*amr->BoxSize[2] };
-   const bool   Periodic[3] = { OPT__BC_FLU[0] == BC_FLU_PERIODIC,
-                                OPT__BC_FLU[2] == BC_FLU_PERIODIC,
-                                OPT__BC_FLU[4] == BC_FLU_PERIODIC };
+// set global constants
+   const double r_max2         = SQR( Prof[0]->MaxRadius );
+   const double HalfBox[3]     = { 0.5*amr->BoxSize[0], 0.5*amr->BoxSize[1], 0.5*amr->BoxSize[2] };
+   const bool   Periodic[3]    = { OPT__BC_FLU[0] == BC_FLU_PERIODIC,
+                                   OPT__BC_FLU[2] == BC_FLU_PERIODIC,
+                                   OPT__BC_FLU[4] == BC_FLU_PERIODIC };
+   const int    CellSkip       = -1;
+   const int    WeightByVolume = 1;
+   const int    WeightByMass   = 2;
 
+
+// temporarily overwrite OPT__INT_TIME
+// --> necessary because SetTempIntPara() called by Prepare_PatchData() relies on OPT__INT_TIME
+// --> must restore it before exiting this routine
+   const bool IntTimeBackup = OPT__INT_TIME;
+   OPT__INT_TIME = ( PrepTimeIn >= 0.0 ) ? true : false;
+
+
+// set undefined fields to _NONE for simplicity
+#  ifndef _VELX
+#  define _VELX _NONE
+#  endif
+#  ifndef _VELY
+#  define _VELY _NONE
+#  endif
+#  ifndef _VELZ
+#  define _VELZ _NONE
+#  endif
+#  ifndef _VELR
+#  define _VELR _NONE
+#  endif
+#  ifndef _POTE
+#  define _POTE _NONE
+#  endif
+
+
+// different OpenMP threads and MPI processes first compute profiles independently
+// --> their data will be combined later
 #  pragma omp parallel
    {
 #     ifdef OPENMP
@@ -213,7 +245,7 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
       const int TID = 0;
 #     endif
 
-//    initialize arrays
+//    initialize profile arrays
       for (int p=0; p<NProf; p++)
       for (int b=0; b<Prof[0]->NBin; b++)
       {
@@ -222,11 +254,11 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
          OMP_NCell [p][TID][b] = 0;
       }
 
-//    allocate passive scalar arrays
-#     if ( MODEL == HYDRO )
-      real *Passive      = new real [NCOMP_PASSIVE];
-      real *Passive_IntT = new real [NCOMP_PASSIVE];
-#     endif
+
+//    allocate other per-thread arrays
+      real (*Patch_Data)[PS1][PS1][PS1] = new real [8][PS1][PS1][PS1];  // field data of each cell
+      int  (*Patch_Bin )[PS1][PS1][PS1] = new int  [8][PS1][PS1][PS1];  // radial bin of each cell
+
 
 //    loop over all target levels
       for (int lv=MinLv; lv<=MaxLv; lv++)
@@ -235,333 +267,232 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
          const double dv = CUBE( dh );
 
 
-//       determine temporal interpolation parameters
-         bool FluIntTime = false;
-         int  FluSg      = amr->FluSg[lv];
-         int  FluSg_IntT;
+//       determine the temporal interpolation parameters
+//       --> mainly for computing cell mass for weighting; Prepare_PatchData() needs PrepTime
+         const int    FluSg0 = amr->FluSg[lv];
+         const double PrepTime = ( PrepTimeIn >= 0.0 ) ? PrepTimeIn : amr->FluSgTime[lv][FluSg0];
+
+         bool FluIntTime;
+         int  FluSg, FluSg_IntT;
          real FluWeighting, FluWeighting_IntT;
 
-#        ifdef MHD
-         bool MagIntTime = false;
-         int  MagSg      = amr->MagSg[lv];
-         int  MagSg_IntT;
-         real MagWeighting, MagWeighting_IntT;
-#        endif
-
-#        ifdef GRAVITY
-         bool PotIntTime = false;
-         int  PotSg      = amr->PotSg[lv];
-         int  PotSg_IntT;
-         real PotWeighting, PotWeighting_IntT;
-#        endif
-
-         if ( PrepTime >= 0.0 )
-         {
-//          fluid
-            const int FluSg0 = amr->FluSg[lv];
-            SetTempIntPara( lv, FluSg0, PrepTime, amr->FluSgTime[lv][FluSg0], amr->FluSgTime[lv][1-FluSg0],
-                            FluIntTime, FluSg, FluSg_IntT, FluWeighting, FluWeighting_IntT );
-
-//          magnetic field
-#           ifdef MHD
-            const int MagSg0 = amr->MagSg[lv];
-            SetTempIntPara( lv, MagSg0, PrepTime, amr->MagSgTime[lv][MagSg0], amr->MagSgTime[lv][1-MagSg0],
-                            MagIntTime, MagSg, MagSg_IntT, MagWeighting, MagWeighting_IntT );
-#           endif
-
-//          potential
-#           ifdef GRAVITY
-            if ( InclPot ) {
-            const int PotSg0 = amr->PotSg[lv];
-            SetTempIntPara( lv, PotSg0, PrepTime, amr->PotSgTime[lv][PotSg0], amr->PotSgTime[lv][1-PotSg0],
-                            PotIntTime, PotSg, PotSg_IntT, PotWeighting, PotWeighting_IntT );
-            }
-#           endif
-         }
+         SetTempIntPara( lv, FluSg0, PrepTime, amr->FluSgTime[lv][FluSg0], amr->FluSgTime[lv][1-FluSg0],
+                         FluIntTime, FluSg, FluSg_IntT, FluWeighting, FluWeighting_IntT );
 
 
 //       use the "static" schedule for reproducibility
 #        pragma omp for schedule( static )
-         for (int PID=0; PID<amr->NPatchComma[lv][1]; PID++)
+         for (int PID0=0; PID0<amr->NPatchComma[lv][1]; PID0+=8)
          {
 //          skip untargeted patches
-            if ( amr->patch[0][lv][PID]->son != -1 )
+            bool SkipPatch[8], SkipPatchGroup=true;
+
+            for (int LocalID=0; LocalID<8; LocalID++)
             {
-               if ( PatchType == PATCH_LEAF )                                    continue;
-               if ( PatchType == PATCH_LEAF_PLUS_MAXNONLEAF  &&  lv != MaxLv )   continue;
-            }
+               const int PID = PID0 + LocalID;
+               SkipPatch[LocalID] = false;
 
-            else
-            {
-               if ( PatchType == PATCH_NONLEAF )                                 continue;
-            }
-
-
-            const real (*FluidPtr)[PS1][PS1][PS1] = amr->patch[ FluSg ][lv][PID]->fluid;
-#           ifdef GRAVITY
-            const real (*PotPtr  )[PS1][PS1]      = amr->patch[ PotSg ][lv][PID]->pot;
-#           endif
-
-//          pointer for temporal interpolation
-            const real (*FluidPtr_IntT)[PS1][PS1][PS1] = ( FluIntTime ) ? amr->patch[ FluSg_IntT ][lv][PID]->fluid : NULL;
-#           ifdef GRAVITY
-            const real (*PotPtr_IntT  )[PS1][PS1]      = ( PotIntTime ) ? amr->patch[ PotSg_IntT ][lv][PID]->pot   : NULL;
-#           endif
-
-
-            const double x0 = amr->patch[0][lv][PID]->EdgeL[0] + 0.5*dh - Center[0];
-            const double y0 = amr->patch[0][lv][PID]->EdgeL[1] + 0.5*dh - Center[1];
-            const double z0 = amr->patch[0][lv][PID]->EdgeL[2] + 0.5*dh - Center[2];
-
-            for (int k=0; k<PS1; k++)  {  double dz = z0 + k*dh;
-                                          if ( Periodic[2] ) {
-                                             if      ( dz > +HalfBox[2] )  {  dz -= amr->BoxSize[2];  }
-                                             else if ( dz < -HalfBox[2] )  {  dz += amr->BoxSize[2];  }
-                                          }
-            for (int j=0; j<PS1; j++)  {  double dy = y0 + j*dh;
-                                          if ( Periodic[1] ) {
-                                             if      ( dy > +HalfBox[1] )  {  dy -= amr->BoxSize[1];  }
-                                             else if ( dy < -HalfBox[1] )  {  dy += amr->BoxSize[1];  }
-                                          }
-            for (int i=0; i<PS1; i++)  {  double dx = x0 + i*dh;
-                                          if ( Periodic[0] ) {
-                                             if      ( dx > +HalfBox[0] )  {  dx -= amr->BoxSize[0];  }
-                                             else if ( dx < -HalfBox[0] )  {  dx += amr->BoxSize[0];  }
-                                          }
-
-               const double r2 = SQR(dx) + SQR(dy) + SQR(dz);
-
-               if ( r2 < r_max2 )
+               if ( amr->patch[0][lv][PID]->son != -1 )
                {
-                  const double r   = sqrt( r2 );
-                  const int    bin = ( LogBin ) ? (  (r<dr_min) ? 0 : int( log(r/dr_min)/log(LogBinRatio) ) + 1  )
-                                                : int( r/dr_min );
-//                prevent from round-off errors
-                  if ( bin >= Prof[0]->NBin )   continue;
+                  if ( PatchType == PATCH_LEAF )                                    SkipPatch[LocalID] = true;
+                  if ( PatchType == PATCH_LEAF_PLUS_MAXNONLEAF  &&  lv != MaxLv )   SkipPatch[LocalID] = true;
+               }
 
-//                check
-#                 ifdef GAMER_DEBUG
-                  if ( bin < 0 )    Aux_Error( ERROR_INFO, "bin (%d) < 0 !!\n", bin );
-#                 endif
+               else
+               {
+                  if ( PatchType == PATCH_NONLEAF )                                 SkipPatch[LocalID] = true;
+               }
 
-//                prepare passive scalars (for better sustainability, always do it even when unnecessary)
-#                 if ( MODEL == HYDRO )
-                  for (int v_out=0; v_out<NCOMP_PASSIVE; v_out++)
+               if ( ! SkipPatch[LocalID] )   SkipPatchGroup = false;
+            } // for (int LocalID=0; LocalID<8; LocalID++)
+
+            if ( SkipPatchGroup )   continue;
+
+
+//          store the radial bin associated with each cell
+//          --> do it before looping over all target fields to avoid redundant calculations
+            for (int LocalID=0; LocalID<8; LocalID++)
+            {
+               if ( SkipPatch[LocalID] )  continue;
+
+               const int    PID = PID0 + LocalID;
+               const double x0  = amr->patch[0][lv][PID]->EdgeL[0] + 0.5*dh - Center[0];
+               const double y0  = amr->patch[0][lv][PID]->EdgeL[1] + 0.5*dh - Center[1];
+               const double z0  = amr->patch[0][lv][PID]->EdgeL[2] + 0.5*dh - Center[2];
+
+               for (int k=0; k<PS1; k++)  {  double dz = z0 + k*dh;
+                                             if ( Periodic[2] ) {
+                                                if      ( dz > +HalfBox[2] )  {  dz -= amr->BoxSize[2];  }
+                                                else if ( dz < -HalfBox[2] )  {  dz += amr->BoxSize[2];  }
+                                             }
+               for (int j=0; j<PS1; j++)  {  double dy = y0 + j*dh;
+                                             if ( Periodic[1] ) {
+                                                if      ( dy > +HalfBox[1] )  {  dy -= amr->BoxSize[1];  }
+                                                else if ( dy < -HalfBox[1] )  {  dy += amr->BoxSize[1];  }
+                                             }
+               for (int i=0; i<PS1; i++)  {  double dx = x0 + i*dh;
+                                             if ( Periodic[0] ) {
+                                                if      ( dx > +HalfBox[0] )  {  dx -= amr->BoxSize[0];  }
+                                                else if ( dx < -HalfBox[0] )  {  dx += amr->BoxSize[0];  }
+                                             }
+
+                  const double r2 = SQR(dx) + SQR(dy) + SQR(dz);
+
+                  if ( r2 < r_max2 )
                   {
-                     const int v_in = v_out + NCOMP_FLUID;
+                     const double r   = sqrt( r2 );
+                     const int    bin = ( LogBin ) ? (  (r<dr_min) ? 0 : int( log(r/dr_min)/log(LogBinRatio) ) + 1  )
+                                                   : int( r/dr_min );
+//                   prevent from round-off errors
+                     if ( bin >= Prof[0]->NBin )   Patch_Bin[LocalID][k][j][i] = CellSkip;
+                     else                          Patch_Bin[LocalID][k][j][i] = bin;
 
-                     Passive     [v_out] = FluidPtr     [v_in][k][j][i];
-                     if ( FluIntTime )
-                     Passive_IntT[v_out] = FluidPtr_IntT[v_in][k][j][i];
+//                   check
+#                    ifdef GAMER_DEBUG
+                     if ( bin < 0 )    Aux_Error( ERROR_INFO, "bin (%d) < 0 !!\n", bin );
+#                    endif
                   }
-#                 endif
 
-                  for (int p=0; p<NProf; p++)
+                  else
+                     Patch_Bin[LocalID][k][j][i] = CellSkip;
+               }}} // i,j,k
+            } // for (int LocalID=0; LocalID<8; LocalID++)
+
+
+//          compute one field at a time
+            for (int p=0; p<NProf; p++)
+            {
+//             collect the data of the target field
+//             _VELR is currently not supported by Prepare_PatchData()
+               if ( TVarBitIdx[p] == _VELR )
+               {
+                  for (int LocalID=0; LocalID<8; LocalID++)
                   {
-//                   intrinsic fluid fields
-                     if ( TFluIntIdx[p] != IdxUndef )
-                     {
-                        const real Weight = dv;
+                     if ( SkipPatch[LocalID] )  continue;
 
-                        OMP_Data  [p][TID][bin] += ( FluIntTime )
-                                                 ? ( FluWeighting     *FluidPtr     [ TFluIntIdx[p] ][k][j][i]
-                                                   + FluWeighting_IntT*FluidPtr_IntT[ TFluIntIdx[p] ][k][j][i] )*Weight
-                                                 :                     FluidPtr     [ TFluIntIdx[p] ][k][j][i]  *Weight;
-                        OMP_Weight[p][TID][bin] += Weight;
-                        OMP_NCell [p][TID][bin] ++;
+                     const int PID = PID0 + LocalID;
+                     const real (*FluidPtr     )[PS1][PS1][PS1] =                  amr->patch[ FluSg      ][lv][PID]->fluid;
+                     const real (*FluidPtr_IntT)[PS1][PS1][PS1] = ( FluIntTime ) ? amr->patch[ FluSg_IntT ][lv][PID]->fluid : NULL;
+
+                     const double x0 = amr->patch[0][lv][PID]->EdgeL[0] + 0.5*dh - Center[0];
+                     const double y0 = amr->patch[0][lv][PID]->EdgeL[1] + 0.5*dh - Center[1];
+                     const double z0 = amr->patch[0][lv][PID]->EdgeL[2] + 0.5*dh - Center[2];
+
+                     for (int k=0; k<PS1; k++)  {  double dz = z0 + k*dh;
+                                                   if ( Periodic[2] ) {
+                                                      if      ( dz > +HalfBox[2] )  {  dz -= amr->BoxSize[2];  }
+                                                      else if ( dz < -HalfBox[2] )  {  dz += amr->BoxSize[2];  }
+                                                   }
+                     for (int j=0; j<PS1; j++)  {  double dy = y0 + j*dh;
+                                                   if ( Periodic[1] ) {
+                                                      if      ( dy > +HalfBox[1] )  {  dy -= amr->BoxSize[1];  }
+                                                      else if ( dy < -HalfBox[1] )  {  dy += amr->BoxSize[1];  }
+                                                   }
+                     for (int i=0; i<PS1; i++)  {  double dx = x0 + i*dh;
+                                                   if ( Periodic[0] ) {
+                                                      if      ( dx > +HalfBox[0] )  {  dx -= amr->BoxSize[0];  }
+                                                      else if ( dx < -HalfBox[0] )  {  dx += amr->BoxSize[0];  }
+                                                   }
+
+                        if ( Patch_Bin[LocalID][k][j][i] == CellSkip )  continue;
+
+                        const double r        = sqrt( SQR(dx) + SQR(dy) + SQR(dz) );
+                        const real _Dens      =                  (real)1.0 / FluidPtr     [DENS][k][j][i];
+                        const real _Dens_IntT = ( FluIntTime ) ? (real)1.0 / FluidPtr_IntT[DENS][k][j][i] : NULL_REAL;
+                        const real VelR       = ( FluIntTime )
+                                              ? ( FluWeighting     *( FluidPtr     [MOMX][k][j][i]*dx +
+                                                                      FluidPtr     [MOMY][k][j][i]*dy +
+                                                                      FluidPtr     [MOMZ][k][j][i]*dz )*_Dens
+                                                + FluWeighting_IntT*( FluidPtr_IntT[MOMX][k][j][i]*dx +
+                                                                      FluidPtr_IntT[MOMY][k][j][i]*dy +
+                                                                      FluidPtr_IntT[MOMZ][k][j][i]*dz )*_Dens_IntT ) / r
+                                              :                     ( FluidPtr     [MOMX][k][j][i]*dx +
+                                                                      FluidPtr     [MOMY][k][j][i]*dy +
+                                                                      FluidPtr     [MOMZ][k][j][i]*dz )*_Dens / r;
+                        Patch_Data[LocalID][k][j][i] = VelR;
+                     }}} // i,j,k
+                  } // for (int LocalID=0; LocalID<8; LocalID++)
+               } // if ( TVarBitIdx[p] == _VELR )
+
+               else
+               {
+                  const int  NGhost             = 0;
+                  const int  NPG                = 1;
+                  const bool IntPhase_No        = false;
+                  const real MinDens_No         = -1.0;
+                  const real MinPres_No         = -1.0;
+                  const real MinTemp_No         = -1.0;
+                  const real MinEntr_No         = -1.0;
+                  const bool DE_Consistency_Yes = true;
+
+                  Prepare_PatchData( lv, PrepTime, Patch_Data[0][0][0], NULL, NGhost, NPG, &PID0,
+                                     TVarBitIdx[p], _NONE, INT_NONE, INT_NONE, UNIT_PATCH, NSIDE_00, IntPhase_No,
+                                     OPT__BC_FLU, BC_POT_NONE, MinDens_No, MinPres_No, MinTemp_No, MinEntr_No,
+                                     DE_Consistency_Yes );
+               } // if ( TVarBitIdx[p] == _VELR ) ... else ...
+
+
+//             set the weight field
+//###REVISE: allow users to choose the weight field
+               int WeightField=-1;
+
+               if ( TVarBitIdx[p] == _VELX  ||
+                    TVarBitIdx[p] == _VELY  ||
+                    TVarBitIdx[p] == _VELZ  ||
+                    TVarBitIdx[p] == _VELR  ||
+                    TVarBitIdx[p] == _POTE   )     WeightField = WeightByMass;
+
+               else                                WeightField = WeightByVolume;
+
+
+//             compute the radial profile
+               for (int LocalID=0; LocalID<8; LocalID++)
+               {
+                  if ( SkipPatch[LocalID] )  continue;
+
+                  const int PID = PID0 + LocalID;
+                  const real (*DensPtr     )[PS1][PS1] =                  amr->patch[ FluSg      ][lv][PID]->fluid[DENS];
+                  const real (*DensPtr_IntT)[PS1][PS1] = ( FluIntTime ) ? amr->patch[ FluSg_IntT ][lv][PID]->fluid[DENS] : NULL;
+
+                  for (int k=0; k<PS1; k++)
+                  for (int j=0; j<PS1; j++)
+                  for (int i=0; i<PS1; i++)
+                  {
+                     if ( Patch_Bin[LocalID][k][j][i] == CellSkip )  continue;
+
+//                   compute the weight
+                     real Weight;
+                     switch ( WeightField )
+                     {
+                        case WeightByMass   :   Weight = ( FluIntTime )
+                                                       ? ( FluWeighting     *DensPtr     [k][j][i]
+                                                         + FluWeighting_IntT*DensPtr_IntT[k][j][i] )*dv
+                                                       :                     DensPtr     [k][j][i]  *dv;
+                           break;
+
+                        case WeightByVolume :   Weight = dv;
+                           break;
+
+                        default:
+                           Aux_Error( ERROR_INFO, "unsupported weight field (%d) !!\n", WeightField );
+                           exit( 1 );
                      }
 
-//                   other fields
-                     else
-                     {
-                        switch ( TVarBitIdx[p] )
-                        {
-//                         gravitational potential
-#                          ifdef GRAVITY
-                           case _POTE:
-                           {
-                              const real Weight = ( FluIntTime )    // weighted by cell mass
-                                                ? ( FluWeighting     *FluidPtr     [DENS][k][j][i]
-                                                  + FluWeighting_IntT*FluidPtr_IntT[DENS][k][j][i] )*dv
-                                                :                     FluidPtr     [DENS][k][j][i]  *dv;
 
-                              OMP_Data  [p][TID][bin] += ( PotIntTime )
-                                                       ? ( PotWeighting     *PotPtr     [k][j][i]
-                                                         + PotWeighting_IntT*PotPtr_IntT[k][j][i] )*Weight
-                                                       :                     PotPtr     [k][j][i]  *Weight;
-                              OMP_Weight[p][TID][bin] += Weight;
-                              OMP_NCell [p][TID][bin] ++;
-                           }
-                           break;
-#                          endif
+//                   update the profile
+                     const int bin = Patch_Bin[LocalID][k][j][i];
 
-//                         derived fields
-#                          if ( MODEL == HYDRO )
-                           case _VELR:
-                           {
-                              const real Weight = ( FluIntTime )    // weighted by cell mass
-                                                ? ( FluWeighting     *FluidPtr     [DENS][k][j][i]
-                                                  + FluWeighting_IntT*FluidPtr_IntT[DENS][k][j][i] )*dv
-                                                :                     FluidPtr     [DENS][k][j][i]  *dv;
-
-                              const real MomR   = ( FluIntTime )
-                                                ? ( FluWeighting     *( FluidPtr     [MOMX][k][j][i]*dx +
-                                                                        FluidPtr     [MOMY][k][j][i]*dy +
-                                                                        FluidPtr     [MOMZ][k][j][i]*dz )
-                                                  + FluWeighting_IntT*( FluidPtr_IntT[MOMX][k][j][i]*dx +
-                                                                        FluidPtr_IntT[MOMY][k][j][i]*dy +
-                                                                        FluidPtr_IntT[MOMZ][k][j][i]*dz ) ) / r
-                                                :                     ( FluidPtr     [MOMX][k][j][i]*dx +
-                                                                        FluidPtr     [MOMY][k][j][i]*dy +
-                                                                        FluidPtr     [MOMZ][k][j][i]*dz )   / r;
-
-                              OMP_Data  [p][TID][bin] += MomR*dv;    // vr*(rho*dv)
-                              OMP_Weight[p][TID][bin] += Weight;
-                              OMP_NCell [p][TID][bin] ++;
-                           }
-                           break;
-
-                           case _PRES:
-                           {
-                              const bool CheckMinPres_No = false;
-                              const real Weight          = dv;
-#                             ifdef MHD
-                              const real Emag            = MHD_GetCellCenteredBEnergyInPatch( lv, PID, i, j, k, MagSg      );
-                              const real Emag_IntT       = ( MagIntTime )
-                                                         ? MHD_GetCellCenteredBEnergyInPatch( lv, PID, i, j, k, MagSg_IntT )
-                                                         : NULL_REAL;
-#                             else
-                              const real Emag            = NULL_REAL;
-                              const real Emag_IntT       = NULL_REAL;
-#                             endif
-                              const real Pres = ( FluIntTime )
-                                              ?   FluWeighting     *Hydro_Con2Pres( FluidPtr     [DENS][k][j][i],
-                                                                                    FluidPtr     [MOMX][k][j][i],
-                                                                                    FluidPtr     [MOMY][k][j][i],
-                                                                                    FluidPtr     [MOMZ][k][j][i],
-                                                                                    FluidPtr     [ENGY][k][j][i],
-                                                                                    Passive,
-                                                                                    CheckMinPres_No, NULL_REAL, Emag,
-                                                                                    EoS_DensEint2Pres_CPUPtr,
-                                                                                    EoS_GuessHTilde_CPUPtr, EoS_HTilde2Temp_CPUPtr,
-                                                                                    EoS_AuxArray_Flt,
-                                                                                    EoS_AuxArray_Int, h_EoS_Table, NULL )
-                                                + FluWeighting_IntT*Hydro_Con2Pres( FluidPtr_IntT[DENS][k][j][i],
-                                                                                    FluidPtr_IntT[MOMX][k][j][i],
-                                                                                    FluidPtr_IntT[MOMY][k][j][i],
-                                                                                    FluidPtr_IntT[MOMZ][k][j][i],
-                                                                                    FluidPtr_IntT[ENGY][k][j][i],
-                                                                                    Passive_IntT,
-                                                                                    CheckMinPres_No, NULL_REAL, Emag_IntT,
-                                                                                    EoS_DensEint2Pres_CPUPtr,
-                                                                                    EoS_GuessHTilde_CPUPtr, EoS_HTilde2Temp_CPUPtr,
-                                                                                    EoS_AuxArray_Flt,
-                                                                                    EoS_AuxArray_Int, h_EoS_Table, NULL )
-                                              :                     Hydro_Con2Pres( FluidPtr     [DENS][k][j][i],
-                                                                                    FluidPtr     [MOMX][k][j][i],
-                                                                                    FluidPtr     [MOMY][k][j][i],
-                                                                                    FluidPtr     [MOMZ][k][j][i],
-                                                                                    FluidPtr     [ENGY][k][j][i],
-                                                                                    Passive,
-                                                                                    CheckMinPres_No, NULL_REAL, Emag,
-                                                                                    EoS_DensEint2Pres_CPUPtr,
-                                                                                    EoS_GuessHTilde_CPUPtr, EoS_HTilde2Temp_CPUPtr,
-                                                                                    EoS_AuxArray_Flt,
-                                                                                    EoS_AuxArray_Int, h_EoS_Table, NULL );
-
-                              OMP_Data  [p][TID][bin] += Pres*Weight;
-                              OMP_Weight[p][TID][bin] += Weight;
-                              OMP_NCell [p][TID][bin] ++;
-                           }
-                           break;
-
-                           case _EINT:
-                           {
-                              const real Weight = dv;
-                              const real Dens   = FluidPtr[DENS][k][j][i];
-
-//                            use the dual-energy variable to calculate the internal energy directly, if applicable
-#                             ifdef DUAL_ENERGY
-
-#                             if   ( DUAL_ENERGY == DE_ENPY )
-                              const bool CheckMinPres_No = false;
-                              const real Enpy = FluidPtr[DUAL][k][j][i];
-                              const real Pres = Hydro_DensDual2Pres( Dens, Enpy, EoS_AuxArray_Flt[1],
-                                                                     CheckMinPres_No, NULL_REAL );
-                              const real Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, Passive, EoS_AuxArray_Flt,
-                                                                          EoS_AuxArray_Int, h_EoS_Table );
-#                             elif ( DUAL_ENERGY == DE_EINT )
-#                             error : DE_EINT is NOT supported yet !!
-#                             endif
-
-#                             else // #ifdef DUAL_ENERGY
-
-                              const bool CheckMinEint_No = false;
-                              const real MomX            = FluidPtr[MOMX][k][j][i];
-                              const real MomY            = FluidPtr[MOMY][k][j][i];
-                              const real MomZ            = FluidPtr[MOMZ][k][j][i];
-                              const real Etot            = FluidPtr[ENGY][k][j][i];
-#                             ifdef MHD
-                              const real Emag            = MHD_GetCellCenteredBEnergyInPatch( lv, PID, i, j, k, MagSg      );
-                              const real Emag_IntT       = ( MagIntTime )
-                                                         ? MHD_GetCellCenteredBEnergyInPatch( lv, PID, i, j, k, MagSg_IntT )
-                                                         : NULL_REAL;
-#                             else
-                              const real Emag            = NULL_REAL;
-                              const real Emag_IntT       = NULL_REAL;
-#                             endif
-                              const real Eint = ( FluIntTime )
-                                              ?   FluWeighting     *Hydro_Con2Eint( FluidPtr     [DENS][k][j][i],
-                                                                                    FluidPtr     [MOMX][k][j][i],
-                                                                                    FluidPtr     [MOMY][k][j][i],
-                                                                                    FluidPtr     [MOMZ][k][j][i],
-                                                                                    FluidPtr     [ENGY][k][j][i],
-                                                                                    CheckMinEint_No, NULL_REAL, Emag,
-                                                                                    EoS_GuessHTilde_CPUPtr, EoS_HTilde2Temp_CPUPtr,
-                                                                                    EoS_AuxArray_Flt,
-                                                                                    EoS_AuxArray_Int, h_EoS_Table )
-                                                + FluWeighting_IntT*Hydro_Con2Eint( FluidPtr_IntT[DENS][k][j][i],
-                                                                                    FluidPtr_IntT[MOMX][k][j][i],
-                                                                                    FluidPtr_IntT[MOMY][k][j][i],
-                                                                                    FluidPtr_IntT[MOMZ][k][j][i],
-                                                                                    FluidPtr_IntT[ENGY][k][j][i],
-                                                                                    CheckMinEint_No, NULL_REAL, Emag_IntT,
-                                                                                    EoS_GuessHTilde_CPUPtr, EoS_HTilde2Temp_CPUPtr,
-                                                                                    EoS_AuxArray_Flt,
-                                                                                    EoS_AuxArray_Int, h_EoS_Table )
-                                              :                     Hydro_Con2Eint( FluidPtr     [DENS][k][j][i],
-                                                                                    FluidPtr     [MOMX][k][j][i],
-                                                                                    FluidPtr     [MOMY][k][j][i],
-                                                                                    FluidPtr     [MOMZ][k][j][i],
-                                                                                    FluidPtr     [ENGY][k][j][i],
-                                                                                    CheckMinEint_No, NULL_REAL, Emag,
-                                                                                    EoS_GuessHTilde_CPUPtr, EoS_HTilde2Temp_CPUPtr,
-                                                                                    EoS_AuxArray_Flt,
-                                                                                    EoS_AuxArray_Int, h_EoS_Table );
-#                             endif // #ifdef DUAL_ENERGY ... else
-
-                              OMP_Data  [p][TID][bin] += Eint*Weight;
-                              OMP_Weight[p][TID][bin] += Weight;
-                              OMP_NCell [p][TID][bin] ++;
-                           }
-                           break;
-#                          endif // HYDRO
-
-                           default:
-                              Aux_Error( ERROR_INFO, "unsupported field (%ld) !!\n", TVarBitIdx[p] );
-                              exit( 1 );
-                        } // switch ( TVarBitIdx[p] )
-                     } // if ( TFluIntIdx[p] != IdxUndef ) ... else ...
-                  } // for (int p=0; p<NProf; p++)
-               } // if ( r2 < r_max2 )
-            }}} // i,j,k
-         } // for (int PID=0; PID<amr->NPatchComma[lv][1]; PID++)
+                     OMP_Data  [p][TID][bin] += Patch_Data[LocalID][k][j][i]*Weight;
+                     OMP_Weight[p][TID][bin] += Weight;
+                     OMP_NCell [p][TID][bin] ++;
+                  } // i,j,k
+               } // for (int LocalID=0; LocalID<8; LocalID++)
+            } // for (int p=0; p<NProf; p++)
+         } // for (int PID0=0; PID0<amr->NPatchComma[lv][1]; PID0+=8)
       } // for (int lv=MinLv; lv<=MaxLv; lv++)
 
-#     if ( MODEL == HYDRO )
-      delete [] Passive;         Passive      = NULL;
-      delete [] Passive_IntT;    Passive_IntT = NULL;
-#     endif
+      delete [] Patch_Data;
+      delete [] Patch_Bin;
 
    } // OpenMP parallel region
 
@@ -675,5 +606,9 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
                                          : Prof[p]->Radius[LastBin] + 0.5*dr_min;
       }
    } // if ( RemoveEmpty )
+
+
+// restore the original temporal interpolation setup
+   OPT__INT_TIME = IntTimeBackup;
 
 } // FUNCTION : Aux_ComputeProfile

--- a/src/Main/InterpolateGhostZone.cpp
+++ b/src/Main/InterpolateGhostZone.cpp
@@ -879,7 +879,7 @@ void InterpolateGhostZone( const int lv, const int PID, real IntData_CC[], real 
                CData_CC_Ptr[Idx] = Hydro_Con2Pres( FluidForEoS[DENS], FluidForEoS[MOMX], FluidForEoS[MOMY],
                                                    FluidForEoS[MOMZ], FluidForEoS[ENGY], FluidForEoS+NCOMP_FLUID,
                                                    (MinPres>=(real)0.0), MinPres, Emag,
-                                                   EoS_DensEint2Pres_CPUPtr,  EoS_GuessHTilde_CPUPtr, EoS_HTilde2Temp_CPUPtr,
+                                                   EoS_DensEint2Pres_CPUPtr, EoS_GuessHTilde_CPUPtr, EoS_HTilde2Temp_CPUPtr,
                                                    EoS_AuxArray_Flt, EoS_AuxArray_Int,
                                                    h_EoS_Table, NULL );
 

--- a/src/Main/Prepare_PatchData.cpp
+++ b/src/Main/Prepare_PatchData.cpp
@@ -2810,7 +2810,7 @@ extern bool Particle_Collected;
 // Description :  Initialize rho_ext[] used by Prepare_PatchData() for preparing particle density on grids
 //
 // Note        :  1. This function is currently called by Gra_AdvanceDt(), Output_DumpData_Total(),
-//                   Output_DumpData_Total_HDF5(), and Output_BasePowerSpectrum()
+//                   Output_DumpData_Total_HDF5(), Output_BasePowerSpectrum(), and Aux_ComputeProfile()
 //                2. Apply to both real and buffer patches
 //                3. For patches without any particle, this routine ensures either rho_ext == NULL or
 //                   rho_ext[0][0][0] == RHO_EXT_NEED_INIT
@@ -2977,7 +2977,7 @@ void Prepare_PatchData_InitParticleDensityArray( const int lv, const double Prep
 // Function    :  Prepare_PatchData_FreeParticleDensityArray
 // Description :  Free rho_ext[] allocated by Prepare_PatchData() temporarily for storing the partice mass density
 //
-// Note        :  1. Currently this function is called by Gra_AdvanceDt(), Output_DumpData_Total(),
+// Note        :  1. This function is currently called by Gra_AdvanceDt(), Output_DumpData_Total(),
 //                   Output_DumpData_Total_HDF5(), Output_BasePowerSpectrum(), and Aux_ComputeProfile()
 //                2. Apply to buffer patches as well
 //                3. Do not free memory if OPT__REUSE_MEMORY is on

--- a/src/Main/Prepare_PatchData.cpp
+++ b/src/Main/Prepare_PatchData.cpp
@@ -3008,7 +3008,8 @@ void SetTargetSibling( int NTSib[], int *TSib[] )
 } // FUNCTION : SetTargetSibling
 
 
-#  ifdef MASSIVE_PARTICLES
+
+#ifdef MASSIVE_PARTICLES
 //-------------------------------------------------------------------------------------------------------
 // Function    :  Prepare_PatchData_InitParticleDensityArray
 // Description :  Initialize rho_ext[] by setting rho_ext[0][0][0] = RHO_EXT_NEED_INIT
@@ -3042,7 +3043,8 @@ void Prepare_PatchData_InitParticleDensityArray( const int lv )
 // Function    :  Prepare_PatchData_FreeParticleDensityArray
 // Description :  Free rho_ext[] allocated by Prepare_PatchData() temporarily for storing the partice mass density
 //
-// Note        :  1. Currently this function is called by Gra_AdvanceDt(), Main(), and Output_DumpData_Total()
+// Note        :  1. Currently this function is called by Gra_AdvanceDt(), Output_DumpData_Total(),
+//                   Output_DumpData_Total_HDF5(), Output_BasePowerSpectrum(), and Aux_ComputeProfile()
 //                2. Apply to buffer patches as well
 //                3. Do not free memory if OPT__REUSE_MEMORY is on
 //

--- a/src/Main/Prepare_PatchData.cpp
+++ b/src/Main/Prepare_PatchData.cpp
@@ -454,7 +454,7 @@ void Prepare_PatchData( const int lv, const double PrepTime, real *OutputCC, rea
 // nothing to do if no target variable is found
    if ( NVarCC_Tot == 0  &&  NVarFC_Tot == 0  &&  MPI_Rank == 0 )
    {
-      Aux_Message( stderr, "WARNING : no target variable is found !!\n" );
+      Aux_Message( stderr, "WARNING : no target variable is found in %s() !!\n", __FUNCTION__ );
       return;
    }
 

--- a/src/Main/Prepare_PatchData.cpp
+++ b/src/Main/Prepare_PatchData.cpp
@@ -174,8 +174,7 @@ void Prepare_PatchData( const int lv, const double PrepTime, real *OutputCC, rea
 
 
 // check
-#  ifdef GAMER_DEBUG
-
+// --> do it even when disabling GAMER_DEBUG since this routine is critical and the check is inexpensive
    long AllVarCC = ( _TOTAL | _DERIVED );
 #  ifdef GRAVITY
    AllVarCC |= _POTE;
@@ -324,8 +323,6 @@ void Prepare_PatchData( const int lv, const double PrepTime, real *OutputCC, rea
    if (  ( TVarCC & _ENTR )  &&  EoS_DensEint2Entr_CPUPtr == NULL )
       Aux_Error( ERROR_INFO, "EoS_DensEint2Entr_CPUPtr == NULL !!\n" );
 #  endif
-
-#  endif // #ifdef GAMER_DEBUG
 
 
    const double dh               = amr->dh[lv];

--- a/src/Main/Prepare_PatchData.cpp
+++ b/src/Main/Prepare_PatchData.cpp
@@ -480,13 +480,6 @@ void Prepare_PatchData( const int lv, const double PrepTime, real *OutputCC, rea
       const int Sg0 = amr->FluSg[lv];
       SetTempIntPara( lv, Sg0, PrepTime, amr->FluSgTime[lv][Sg0], amr->FluSgTime[lv][1-Sg0],
                       FluIntTime, FluSg, FluSg_IntT, FluWeighting, FluWeighting_IntT );
-
-//    check: although temporal interpolation is allowed, currently PrepTime is expected to be equal to either
-//           amr->FluSgTime[lv][0] or amr->FluSgTime[lv][1]
-      if ( FluIntTime  &&  MPI_Rank == 0 )
-         Aux_Message( stderr, "WARNING : cannot determine FluSg "
-                              "(lv %d, PrepTime %20.14e, SgTime[0] %20.14e, SgTime[1] %20.14e) !!\n",
-                      lv, PrepTime, amr->FluSgTime[lv][0], amr->FluSgTime[lv][1] );
    }
 
 // magnetic field
@@ -501,13 +494,6 @@ void Prepare_PatchData( const int lv, const double PrepTime, real *OutputCC, rea
       const int Sg0 = amr->MagSg[lv];
       SetTempIntPara( lv, Sg0, PrepTime, amr->MagSgTime[lv][Sg0], amr->MagSgTime[lv][1-Sg0],
                       MagIntTime, MagSg, MagSg_IntT, MagWeighting, MagWeighting_IntT );
-
-//    check: although temporal interpolation is allowed, currently PrepTime is expected to be equal to either
-//           amr->MagSgTime[lv][0] or amr->MagSgTime[lv][1]
-      if ( MagIntTime  &&  MPI_Rank == 0 )
-         Aux_Message( stderr, "WARNING : cannot determine MagSg "
-                              "(lv %d, PrepTime %20.14e, SgTime[0] %20.14e, SgTime[1] %20.14e) !!\n",
-                      lv, PrepTime, amr->MagSgTime[lv][0], amr->MagSgTime[lv][1] );
    }
 #  endif // #ifdef MHD
 
@@ -522,18 +508,6 @@ void Prepare_PatchData( const int lv, const double PrepTime, real *OutputCC, rea
       const int Sg0 = amr->PotSg[lv];
       SetTempIntPara( lv, Sg0, PrepTime, amr->PotSgTime[lv][Sg0], amr->PotSgTime[lv][1-Sg0],
                       PotIntTime, PotSg, PotSg_IntT, PotWeighting, PotWeighting_IntT );
-
-//    check: although temporal interpolation is allowed, currently PrepTime is expected to be equal to either
-//           amr->PotSgTime[lv][0] or amr->PotSgTime[lv][1]
-//           --> the only exception is when calling Par_UpdateParticle() to prepare the coarse-grid potential
-//               for correcting the velocity of particles just crossing from fine to coarse grids
-#     ifdef PARTICLE
-      if ( amr->Par->ImproveAcc )
-#     endif
-      if ( PotIntTime  &&  MPI_Rank == 0 )
-         Aux_Message( stderr, "WARNING : cannot determine PotSg "
-                              "(lv %d, PrepTime %20.14e, SgTime[0] %20.14e, SgTime[1] %20.14e) !!\n",
-                      lv, PrepTime, amr->PotSgTime[lv][0], amr->PotSgTime[lv][1] );
    }
 #  endif // #ifdef GRAVITY
 


### PR DESCRIPTION
This PR generalizes the radial profile routine `Aux_ComputeProfile()`:
- Support more fields by calling `Prepare_PatchData()`, such as particle density and cell-centered magnetic fields
- Support temporal interpolation even when disabling `OPT__INT_TIME`
- When enabling temporal interpolation, the radial velocity profile (`_VELR`) will be slightly different from the previous results due to a different weighting approach
