### PR TITLE
Fix warning message

### DIFF
--- a/include/Global.h
+++ b/include/Global.h
@@ -51,7 +51,7 @@ extern int        PassiveNorm_NVar, PassiveNorm_VarIdx[NCOMP_PASSIVE];
 extern int        PassiveIntFrac_NVar, PassiveIntFrac_VarIdx[NCOMP_PASSIVE];
 
 extern int        StrLen_Flt;
-extern char       BlankPlusFormat_Flt[MAX_STRING];
+extern char       BlankPlusFormat_Flt[MAX_STRING+1];
 
 extern double     BOX_SIZE, DT__MAX, DT__FLUID, DT__FLUID_INIT, END_T, OUTPUT_DT, OUTPUT_WALLTIME, DT__SYNC_PARENT_LV, DT__SYNC_CHILDREN_LV;
 extern long int   END_STEP;

--- a/src/Init/Init_ResetParameter.cpp
+++ b/src/Init/Init_ResetParameter.cpp
@@ -275,9 +275,9 @@ void Init_ResetParameter()
 //     For example, the format %20.16e will give a length of 20. However, if only checking the string after %,
 //     the format %+-20.16e (align to the left and also add a + sign for a positive value) will give a zero string length
 //     since +- is not an integer. This is why checking OPT__OUTPUT_DATA_FORMAT+2 is necessary.
-   if ( strlen(OPT__OUTPUT_TEXT_FORMAT_FLT) > MAX_STRING-2 )
-      Aux_Error( ERROR_INFO, "Length of OPT__OUTPUT_TEXT_FORMAT_FLT (%d) should be smaller than MAX_STRING-2 (%d) !!\n",
-                 strlen(OPT__OUTPUT_TEXT_FORMAT_FLT), MAX_STRING-2 );
+   if ( strlen(OPT__OUTPUT_TEXT_FORMAT_FLT) > MAX_STRING-1 )
+      Aux_Error( ERROR_INFO, "Length of OPT__OUTPUT_TEXT_FORMAT_FLT (%d) should be smaller than MAX_STRING-1 (%d) !!\n",
+                 strlen(OPT__OUTPUT_TEXT_FORMAT_FLT), MAX_STRING-1 );
 
    StrLen_Flt = MAX( abs(atoi(OPT__OUTPUT_TEXT_FORMAT_FLT+1)), abs(atoi(OPT__OUTPUT_TEXT_FORMAT_FLT+2)) );
    sprintf( BlankPlusFormat_Flt, " %s", OPT__OUTPUT_TEXT_FORMAT_FLT );

--- a/src/Main/Main.cpp
+++ b/src/Main/Main.cpp
@@ -39,7 +39,7 @@ long                 FixUpVar_Flux, FixUpVar_Restrict;
 int                  PassiveNorm_NVar, PassiveNorm_VarIdx[NCOMP_PASSIVE];
 int                  PassiveIntFrac_NVar, PassiveIntFrac_VarIdx[NCOMP_PASSIVE];
 int                  StrLen_Flt;
-char                 BlankPlusFormat_Flt[MAX_STRING];
+char                 BlankPlusFormat_Flt[MAX_STRING+1];
 
 int                  MPI_Rank, MPI_Rank_X[3], MPI_SibRank[26], NX0[3], NPatchTotal[NLEVEL];
 int                 *BaseP = NULL;


### PR DESCRIPTION
Solve the following warning message caused by #317 :
```
Init/Init_ResetParameter.cpp: In function ‘void Init_ResetParameter()’:
Init/Init_ResetParameter.cpp:283:38: warning: ‘sprintf’ may write a terminating nul past the end of the destination [-Wformat-overflow=]
  283 |    sprintf( BlankPlusFormat_Flt, " %s", OPT__OUTPUT_TEXT_FORMAT_FLT );
      |                                      ^
Init/Init_ResetParameter.cpp:283:11: note: ‘sprintf’ output between 2 and 513 bytes into a destination of size 512
  283 |    sprintf( BlankPlusFormat_Flt, " %s", OPT__OUTPUT_TEXT_FORMAT_FLT );
      |    ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```