### PR TITLE
[Bugfix] Fix compilation errors related to PARTICLE condition

### DIFF
--- a/src/Auxiliary/Aux_ComputeProfile.cpp
+++ b/src/Auxiliary/Aux_ComputeProfile.cpp
@@ -144,7 +144,7 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
 #  ifdef GRAVITY
    SupportedFields |= _POTE;
 #  endif
-#  ifdef PARTICLE
+#  ifdef MASSIVE_PARTICLES
    SupportedFields |= _PAR_DENS;
    SupportedFields |= _TOTAL_DENS;
 #  endif
@@ -156,7 +156,7 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
 
 
 // record whether particle density is requested
-#  ifdef PARTICLE
+#  ifdef MASSIVE_PARTICLES
    bool NeedPar = false;
    for (int p=0; p<NProf; p++) {
       if ( TVarBitIdx[p] == _PAR_DENS  ||  TVarBitIdx[p] == _TOTAL_DENS ) {
@@ -274,7 +274,7 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
 
 
 //    initialize the particle density array (rho_ext) and collect particles to the target level
-#     ifdef PARTICLE
+#     ifdef MASSIVE_PARTICLES
       const bool TimingSendPar_No = false;
       const bool JustCountNPar_No = false;
 #     ifdef LOAD_BALANCE
@@ -295,7 +295,7 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
 
          Prepare_PatchData_InitParticleDensityArray( lv, PrepTime );
       } // if ( NeedPar )
-#     endif // #ifdef PARTICLE
+#     endif // #ifdef MASSIVE_PARTICLES
 
 
 //    different OpenMP threads and MPI processes first compute profiles independently
@@ -546,7 +546,7 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
 
 //    free particle resources
 //    --> these two routines should NOT be put inside an OpenMP parallel region
-#     ifdef PARTICLE
+#     ifdef MASSIVE_PARTICLES
       if ( NeedPar )
       {
          Par_CollectParticle2OneLevel_FreeMemory( lv, SibBufPatch, FaSibBufPatch );

--- a/src/Auxiliary/Aux_FindExtrema.cpp
+++ b/src/Auxiliary/Aux_FindExtrema.cpp
@@ -169,7 +169,7 @@ void Aux_FindExtrema( Extrema_t *Extrema, const ExtremaMode_t Mode, const int Mi
    const real   MinTemp_No        = -1.0;
    const real   MinEntr_No        = -1.0;
    const bool   DE_Consistency_No = false;
-#  ifdef PARTICLE
+#  ifdef MASSIVE_PARTICLES
    const bool   TimingSendPar_No  = false;
    const bool   JustCountNPar_No  = false;
 #  ifdef LOAD_BALANCE
@@ -181,7 +181,7 @@ void Aux_FindExtrema( Extrema_t *Extrema, const ExtremaMode_t Mode, const int Mi
    const bool   SibBufPatch       = NULL_BOOL;
    const bool   FaSibBufPatch     = NULL_BOOL;
 #  endif
-#  endif // #ifdef PARTICLE
+#  endif // #ifdef MASSIVE_PARTICLES
 
 
 // initialize the extrema
@@ -205,7 +205,7 @@ void Aux_FindExtrema( Extrema_t *Extrema, const ExtremaMode_t Mode, const int Mi
       for (int t=0; t<NTotal; t++)  PID0_List[t] = 8*t;
 
 //    initialize the particle density array (rho_ext) and collect particles to the target level
-#     ifdef PARTICLE
+#     ifdef MASSIVE_PARTICLES
       if ( Extrema->Field & _PAR_DENS  ||  Extrema->Field & _TOTAL_DENS )
       {
          Par_CollectParticle2OneLevel( lv, _PAR_MASS|_PAR_POSX|_PAR_POSY|_PAR_POSZ|_PAR_TYPE, PredictPos, Time[lv],
@@ -324,7 +324,7 @@ void Aux_FindExtrema( Extrema_t *Extrema, const ExtremaMode_t Mode, const int Mi
       } // for (int Disp=0; Disp<NTotal; Disp+=NPG_Max)
 
 //    free memory for collecting particles from other ranks and levels, and free density arrays with ghost zones (rho_ext)
-#     ifdef PARTICLE
+#     ifdef MASSIVE_PARTICLES
       if ( Extrema->Field & _PAR_DENS  ||  Extrema->Field & _TOTAL_DENS )
       {
          Par_CollectParticle2OneLevel_FreeMemory( lv, SibBufPatch, FaSibBufPatch );

--- a/src/Auxiliary/Aux_FindWeightedAverageCenter.cpp
+++ b/src/Auxiliary/Aux_FindWeightedAverageCenter.cpp
@@ -115,7 +115,7 @@ void Aux_FindWeightedAverageCenter( double WeightedAverageCenter[], const double
    const real   MinTemp_No        = -1.0;
    const real   MinEntr_No        = -1.0;
    const bool   DE_Consistency_No = false;
-#  ifdef PARTICLE
+#  ifdef MASSIVE_PARTICLES
    const bool   TimingSendPar_No  = false;
    const bool   JustCountNPar_No  = false;
 #  ifdef LOAD_BALANCE
@@ -127,7 +127,7 @@ void Aux_FindWeightedAverageCenter( double WeightedAverageCenter[], const double
    const bool   SibBufPatch       = NULL_BOOL;
    const bool   FaSibBufPatch     = NULL_BOOL;
 #  endif
-#  endif // #ifdef PARTICLE
+#  endif // #ifdef MASSIVE_PARTICLES
 
 // initialize the referenced center in the first iteration as the input Center_ref
    const double MaxR2             = SQR( MaxR );
@@ -183,7 +183,7 @@ void Aux_FindWeightedAverageCenter( double WeightedAverageCenter[], const double
          for (int t=0; t<NTotal; t++)  PID0_List[t] = 8*t;
 
 //       initialize the particle density array (rho_ext) and collect particles to the target level
-#        ifdef PARTICLE
+#        ifdef MASSIVE_PARTICLES
          if ( WeightingDensityField & _PAR_DENS  ||  WeightingDensityField & _TOTAL_DENS )
          {
             Par_CollectParticle2OneLevel( lv, _PAR_MASS|_PAR_POSX|_PAR_POSY|_PAR_POSZ|_PAR_TYPE, PredictPos, Time[lv],
@@ -283,7 +283,7 @@ void Aux_FindWeightedAverageCenter( double WeightedAverageCenter[], const double
          } // for (int Disp=0; Disp<NTotal; Disp+=NPG_Max)
 
 //       free memory for collecting particles from other ranks and levels, and free density arrays with ghost zones (rho_ext)
-#        ifdef PARTICLE
+#        ifdef MASSIVE_PARTICLES
          if ( WeightingDensityField & _PAR_DENS  ||  WeightingDensityField & _TOTAL_DENS )
          {
             Par_CollectParticle2OneLevel_FreeMemory( lv, SibBufPatch, FaSibBufPatch );

--- a/src/Auxiliary/Aux_TakeNote.cpp
+++ b/src/Auxiliary/Aux_TakeNote.cpp
@@ -1434,7 +1434,9 @@ void Aux_TakeNote()
       fprintf( Note, "OPT__OUTPUT_TEXT_FORMAT_FLT     %s\n",      OPT__OUTPUT_TEXT_FORMAT_FLT );
 #     ifdef PARTICLE
       fprintf( Note, "OPT__OUTPUT_PAR_MODE           % d\n",      OPT__OUTPUT_PAR_MODE        );
+#     ifdef TRACER
       fprintf( Note, "OPT__OUTPUT_PAR_MESH           % d\n",      OPT__OUTPUT_PAR_MESH        );
+#     endif
 #     endif
       fprintf( Note, "OPT__OUTPUT_BASEPS             % d\n",      OPT__OUTPUT_BASEPS          );
       fprintf( Note, "OPT__OUTPUT_BASE               % d\n",      OPT__OUTPUT_BASE            );

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -462,7 +462,7 @@ void Init_Load_Parameter()
 #  ifdef TRACER
    ReadPara->Add( "OPT__OUTPUT_PAR_MESH",       &OPT__OUTPUT_PAR_MESH,            true,            Useless_bool,  Useless_bool   );
 #  else
-   ReadPara->Add( "OPT__OUTPUT_PAR_MESH",       &OPT__OUTPUT_PAR_MESH,            false,           false,         false          );
+   ReadPara->Add( "OPT__OUTPUT_PAR_MESH",       &OPT__OUTPUT_PAR_MESH,            false,           Useless_bool,  Useless_bool   );
 #  endif
 #  endif
    ReadPara->Add( "OPT__OUTPUT_BASEPS",         &OPT__OUTPUT_BASEPS,              false,           Useless_bool,  Useless_bool   );

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -459,11 +459,11 @@ void Init_Load_Parameter()
    ReadPara->Add( "OPT__OUTPUT_TEXT_FORMAT_FLT", OPT__OUTPUT_TEXT_FORMAT_FLT,     "%24.16e",       Useless_str,   Useless_str    );
 #  ifdef PARTICLE
    ReadPara->Add( "OPT__OUTPUT_PAR_MODE",       &OPT__OUTPUT_PAR_MODE,            0,               0,             2              );
-#  endif
 #  ifdef TRACER
    ReadPara->Add( "OPT__OUTPUT_PAR_MESH",       &OPT__OUTPUT_PAR_MESH,            true,            Useless_bool,  Useless_bool   );
 #  else
    ReadPara->Add( "OPT__OUTPUT_PAR_MESH",       &OPT__OUTPUT_PAR_MESH,            false,           false,         false          );
+#  endif
 #  endif
    ReadPara->Add( "OPT__OUTPUT_BASEPS",         &OPT__OUTPUT_BASEPS,              false,           Useless_bool,  Useless_bool   );
    ReadPara->Add( "OPT__OUTPUT_BASE",           &OPT__OUTPUT_BASE,                false,           Useless_bool,  Useless_bool   );

--- a/src/Init/Init_ResetParameter.cpp
+++ b/src/Init/Init_ResetParameter.cpp
@@ -424,6 +424,15 @@ void Init_ResetParameter()
       PRINT_RESET_PARA( amr->Par->GhostSizeTracer, FORMAT_INT, "for the adopted PAR_TR_INTERP scheme" );
    }
 
+#  ifndef TRACER
+   if ( OPT__OUTPUT_PAR_MESH )
+   {
+      OPT__OUTPUT_PAR_MESH = false;
+
+      PRINT_RESET_PARA( OPT__OUTPUT_PAR_MESH, FORMAT_INT, "since TRACER is disabled" );
+   }
+#  endif
+
 #  endif // #ifdef PARTICLE
 
 


### PR DESCRIPTION
- Fix the compilation problem (linker) when disabling `GRAVITY` but enabling `PARTICLE`
- Fix the compilation error (`OPT__OUTPUT_PAR_MESH`) when disabling `PARTICLE`
- Fix the potential runtime error when enabling `PARTICLE` and disabling `TRACER`