### PR TITLE
[Bugfix] Fix #425

### DIFF
--- a/doc/wiki/Adding-Parameters.md
+++ b/doc/wiki/Adding-Parameters.md
@@ -4,7 +4,10 @@ Mandatory steps are marked by &#x1F4CC;.
 
 1. &#x1F4CC; Add new global variables to both `src/GAMER/Main.cpp` and `include/Global.h`
 
-2.  &#x1F4CC; Edit `src/Init/Init_Load_Parameter.cpp` to load new parameters
+> [!IMPORTANT]
+> The length of the string variable must be `MAX_STRING`.
+
+2. &#x1F4CC; Edit `src/Init/Init_Load_Parameter.cpp` to load new parameters
 
 3. Add notes in `src/Auxiliary/Aux_TakeNote.cpp` [optional but recommended]
 

--- a/include/Global.h
+++ b/include/Global.h
@@ -86,7 +86,7 @@ extern int        OPT__UM_IC_FLOAT8;
 extern double     COM_CEN_X, COM_CEN_Y, COM_CEN_Z, COM_MAX_R, COM_MIN_RHO, COM_TOLERR_R;
 extern int        COM_MAX_ITER;
 extern double     ANGMOM_ORIGIN_X, ANGMOM_ORIGIN_Y, ANGMOM_ORIGIN_Z;
-extern char       OUTPUT_DIR[MAX_STRING-100];
+extern char       OUTPUT_DIR[MAX_STRING];
 extern double     FLAG_ANGULAR_CEN_X, FLAG_ANGULAR_CEN_Y, FLAG_ANGULAR_CEN_Z;
 extern double     FLAG_RADIAL_CEN_X, FLAG_RADIAL_CEN_Y, FLAG_RADIAL_CEN_Z;
 

--- a/src/Auxiliary/Aux_Check_Conservation.cpp
+++ b/src/Auxiliary/Aux_Check_Conservation.cpp
@@ -33,7 +33,7 @@ void Aux_Check_Conservation( const char *comment )
 {
 
    static bool FirstTime = true;
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Record__Conservation", OUTPUT_DIR );
 
 

--- a/src/Auxiliary/Aux_Check_Parameter.cpp
+++ b/src/Auxiliary/Aux_Check_Parameter.cpp
@@ -337,9 +337,9 @@ void Aux_Check_Parameter()
 #  endif // #if ( MODEL == HYDRO )
 
 
-   if ( strlen(OUTPUT_DIR) > MAX_STRING-100-1 )
-      Aux_Error( ERROR_INFO, "Length of OUTPUT_DIR (%d) should be smaller than MAX_STRING-100-1 (%d) !!\n",
-                 strlen(OUTPUT_DIR), MAX_STRING-100-1 );
+   if ( strlen(OUTPUT_DIR) > MAX_STRING-1 )
+      Aux_Error( ERROR_INFO, "Length of OUTPUT_DIR (%d) should be smaller than MAX_STRING-1 (%d) !!\n",
+                 strlen(OUTPUT_DIR), MAX_STRING-1 );
 
    if (  ! Aux_CheckFolderExist( OUTPUT_DIR )  )
       Aux_Error( ERROR_INFO, "\"%s\" folder set by OUTPUT_DIR does not exist !!\n", OUTPUT_DIR );

--- a/src/Auxiliary/Aux_GetMemInfo.cpp
+++ b/src/Auxiliary/Aux_GetMemInfo.cpp
@@ -27,7 +27,7 @@ void Aux_GetMemInfo()
    const int NInfo = 4; // number of memory information to be recorded (VmSize/Peak, VmRSS/HWM)
 
    static bool FirstTime=true;
-   char   FileName_Record[MAX_STRING], FileName_Status[MAX_STRING], Useless[NInfo][MAX_STRING], *line=NULL;
+   char   FileName_Record[2*MAX_STRING], FileName_Status[MAX_STRING], Useless[NInfo][MAX_STRING], *line=NULL;
    char   VmSize[MAX_STRING], VmPeak[MAX_STRING], VmRSS[MAX_STRING], VmHWM[MAX_STRING];
    bool   GetVmSize=false, GetVmPeak=false, GetVmRSS=false, GetVmHWM=false;
    double Vm_double[NInfo], Vm_max[NInfo], Vm_sum[NInfo];

--- a/src/Auxiliary/Aux_Record_Center.cpp
+++ b/src/Auxiliary/Aux_Record_Center.cpp
@@ -21,7 +21,7 @@ void Aux_Record_Center()
 {
 
    static bool FirstTime = true;
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Record__Center", OUTPUT_DIR );
 
 

--- a/src/Auxiliary/Aux_Record_CorrUnphy.cpp
+++ b/src/Auxiliary/Aux_Record_CorrUnphy.cpp
@@ -16,7 +16,7 @@ void Aux_Record_CorrUnphy()
 {
 
    static bool FirstTime = true;
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Record__NCorrUnphy", OUTPUT_DIR );
 
    long NCorrAllRank[NLEVEL];

--- a/src/Auxiliary/Aux_Record_PatchCount.cpp
+++ b/src/Auxiliary/Aux_Record_PatchCount.cpp
@@ -12,7 +12,7 @@
 void Aux_Record_PatchCount()
 {
 
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Record__PatchCount", OUTPUT_DIR );
 
    static bool FirstTime = true;

--- a/src/Auxiliary/Aux_Record_Performance.cpp
+++ b/src/Auxiliary/Aux_Record_Performance.cpp
@@ -21,7 +21,7 @@ void Aux_Record_Performance( const double ElapsedTime )
 {
 
    static bool FirstTime = true;
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Record__Performance", OUTPUT_DIR );
 
 

--- a/src/Auxiliary/Aux_Record_User.cpp
+++ b/src/Auxiliary/Aux_Record_User.cpp
@@ -24,7 +24,7 @@ void Aux_Record_User_Template()
 {
 
    static bool FirstTime = true;
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Record__User", OUTPUT_DIR );
 
    if ( FirstTime )

--- a/src/Auxiliary/Aux_TakeNote.cpp
+++ b/src/Auxiliary/Aux_TakeNote.cpp
@@ -23,7 +23,7 @@ void Aux_TakeNote()
 
 
    FILE *Note;
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Record__Note", OUTPUT_DIR );
 
 
@@ -38,7 +38,7 @@ void Aux_TakeNote()
       fprintf( Note, "***********************************************************************************\n" );
       fclose( Note );
 
-      char Command[MAX_STRING];
+      char Command[2*MAX_STRING];
       sprintf( Command, "cat ./Input__Note >> %s/Record__Note", OUTPUT_DIR );
       system( Command );
 

--- a/src/Auxiliary/Aux_Timing.cpp
+++ b/src/Auxiliary/Aux_Timing.cpp
@@ -227,7 +227,7 @@ void Aux_Record_Timing()
 {
 
    FILE *File = NULL;
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Record__Timing", OUTPUT_DIR );
 
    const char Comment_LB[][4] = { "Max", "Min", "Ave" };
@@ -988,7 +988,7 @@ void Aux_AccumulatedTiming( const double TotalT, double InitT, double OtherT )
 
    const char Comment_LB[][4] = { "Max", "Min", "Ave" };
    const int  NNewTimer       = 2;
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Record__Timing", OUTPUT_DIR );
 
    double dt_P, Flu_P, Gra_P, Src_P, Che_P, SF_P, FB_P, FixUp_P, Flag_P, Refine_P, Sum_P, MPI_Grid_P;

--- a/src/Fluid/Flu_Close.cpp
+++ b/src/Fluid/Flu_Close.cpp
@@ -971,7 +971,7 @@ void CorrectUnphysical( const int lv, const int NPG, const int *PID0_List,
                   const bool CheckMinPres_No = false;
                   real In[NCOMP_TOTAL], tmp[NCOMP_TOTAL];
 
-                  char FileName[MAX_STRING];
+                  char FileName[2*MAX_STRING];
                   sprintf( FileName, "%s/FailedPatchGroup_r%03d_lv%02d_PID0-%05d", OUTPUT_DIR, MPI_Rank, lv, PID0_List[TID] );
 
 //                use "a" instead of "w" since there may be more than one failed cell in a given patch group

--- a/src/GPU_API/CUAPI_DiagnoseDevice.cu
+++ b/src/GPU_API/CUAPI_DiagnoseDevice.cu
@@ -59,7 +59,7 @@ void CUAPI_DiagnoseDevice()
 
 
 // record the device properties
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Record__Note", OUTPUT_DIR );
 
    if ( MPI_Rank == 0 )

--- a/src/LoadBalance/LB_EstimateLoadImbalance.cpp
+++ b/src/LoadBalance/LB_EstimateLoadImbalance.cpp
@@ -99,7 +99,7 @@ double LB_EstimateLoadImbalance()
       if ( OPT__RECORD_LOAD_BALANCE )
       {
          static bool FirstTime = true;
-         char FileName[MAX_STRING];
+         char FileName[2*MAX_STRING];
          sprintf( FileName, "%s/Record__LoadBalance", OUTPUT_DIR );
 
          if ( FirstTime )

--- a/src/LoadBalance/LB_GetBufferData.cpp
+++ b/src/LoadBalance/LB_GetBufferData.cpp
@@ -1639,7 +1639,7 @@ void LB_GetBufferData( const int lv, const int FluSg, const int MagSg, const int
 #  ifdef TIMING
    if ( OPT__TIMING_MPI )
    {
-      char FileName[MAX_STRING];
+      char FileName[2*MAX_STRING];
       sprintf( FileName, "%s/Record__TimingMPI_Rank%05d", OUTPUT_DIR, MPI_Rank );
 
       char ModeName[100];

--- a/src/Main/Main.cpp
+++ b/src/Main/Main.cpp
@@ -78,7 +78,7 @@ int                  OPT__UM_IC_FLOAT8;
 double               COM_CEN_X, COM_CEN_Y, COM_CEN_Z, COM_MAX_R, COM_MIN_RHO, COM_TOLERR_R;
 int                  COM_MAX_ITER;
 double               ANGMOM_ORIGIN_X, ANGMOM_ORIGIN_Y, ANGMOM_ORIGIN_Z;
-char                 OUTPUT_DIR[MAX_STRING-100];
+char                 OUTPUT_DIR[MAX_STRING];
 double               FLAG_ANGULAR_CEN_X, FLAG_ANGULAR_CEN_Y, FLAG_ANGULAR_CEN_Z;
 double               FLAG_RADIAL_CEN_X, FLAG_RADIAL_CEN_Y, FLAG_RADIAL_CEN_Z;
 
@@ -856,7 +856,7 @@ int main( int argc, char *argv[] )
 
    if ( MPI_Rank == 0  &&  OPT__RECORD_NOTE )
    {
-      char FileName[MAX_STRING];
+      char FileName[2*MAX_STRING];
       sprintf( FileName, "%s/Record__Note", OUTPUT_DIR );
 
       FILE *Note = fopen( FileName, "a" );

--- a/src/Miscellaneous/Mis_GetTimeStep.cpp
+++ b/src/Miscellaneous/Mis_GetTimeStep.cpp
@@ -30,7 +30,7 @@ double Mis_GetTimeStep( const int lv, const double dTime_SyncFaLv, const double 
 
    static bool FirstTime  = true;
    const int   NdTimeMax  = 20;
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Record__TimeStep", OUTPUT_DIR );
 
    char  (*dTime_Name)[MAX_STRING] = new char   [NdTimeMax][MAX_STRING];

--- a/src/Model_ELBDM/ELBDM_Aux_Record_Hybrid.cpp
+++ b/src/Model_ELBDM/ELBDM_Aux_Record_Hybrid.cpp
@@ -19,7 +19,7 @@ void ELBDM_Aux_Record_Hybrid()
 
 
    static bool FirstTime = true;
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Record__Hybrid", OUTPUT_DIR );
    FILE *File = NULL;
 

--- a/src/Model_Hydro/MHD_Aux_Check_DivergenceB.cpp
+++ b/src/Model_Hydro/MHD_Aux_Check_DivergenceB.cpp
@@ -129,7 +129,7 @@ void MHD_Aux_Check_DivergenceB( const bool Verbose, const char *comment )
    if ( MPI_Rank == 0 )
    {
       static bool FirstTime = true;
-      char FileName[MAX_STRING];
+      char FileName[2*MAX_STRING];
       sprintf( FileName, "%s/Record__DivB", OUTPUT_DIR );
 
 //    output header

--- a/src/Output/Output_BoundaryFlagList.cpp
+++ b/src/Output/Output_BoundaryFlagList.cpp
@@ -20,7 +20,7 @@ void Output_BoundaryFlagList( const int option, const int lv, const char *commen
       Aux_Error( ERROR_INFO, "incorrect parameter %s = %d !!\n", "option", option );
 
 
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    if ( option )  sprintf( FileName, "%s/BoundaryFlagList_%d_%d", OUTPUT_DIR, MPI_Rank, lv );
    else           sprintf( FileName, "%s/BufferFlagList_%d_%d",   OUTPUT_DIR, MPI_Rank, lv );
 

--- a/src/Output/Output_DumpData.cpp
+++ b/src/Output/Output_DumpData.cpp
@@ -103,9 +103,9 @@ void Output_DumpData( const int Stage )
 
 
 // set the file names for all output functions
-   char FileName_Total[MAX_STRING], FileName_Part[MAX_STRING], FileName_Temp[MAX_STRING], FileName_PS[MAX_STRING];
+   char FileName_Total[2*MAX_STRING], FileName_Part[2*MAX_STRING], FileName_Temp[2*MAX_STRING], FileName_PS[2*MAX_STRING];
 #  ifdef PARTICLE
-   char FileName_Particle[MAX_STRING];
+   char FileName_Particle[2*MAX_STRING];
 #  endif
 
    if ( OPT__OUTPUT_TOTAL )
@@ -318,7 +318,7 @@ void Output_DumpData( const int Stage )
 void Write_DumpRecord()
 {
 
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Record__Dump", OUTPUT_DIR );
 
 

--- a/src/Output/Output_ExchangeDataPatchList.cpp
+++ b/src/Output/Output_ExchangeDataPatchList.cpp
@@ -20,7 +20,7 @@ void Output_ExchangeDataPatchList( const int option, const int lv, const char *c
       Aux_Error( ERROR_INFO, "incorrect parameter %s = %d !!\n", "option", option );
 
 
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    if ( option )  sprintf( FileName, "%s/SendDataPatchList_%d_%d", OUTPUT_DIR, MPI_Rank, lv );
    else           sprintf( FileName, "%s/RecvDataPatchList_%d_%d", OUTPUT_DIR, MPI_Rank, lv );
 

--- a/src/Output/Output_ExchangeFluxPatchList.cpp
+++ b/src/Output/Output_ExchangeFluxPatchList.cpp
@@ -22,7 +22,7 @@ void Output_ExchangeFluxPatchList( const int option, const int lv, const char *c
       Aux_Error( ERROR_INFO, "incorrect parameter %s = %d !!\n", "lv", lv );
 
 
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    switch ( option )
    {
       case 0:  sprintf( FileName, "%s/SendFluxPatchList_%d_%d", OUTPUT_DIR, MPI_Rank, lv );

--- a/src/Output/Output_ExchangePatchMap.cpp
+++ b/src/Output/Output_ExchangePatchMap.cpp
@@ -58,7 +58,7 @@ void Output_ExchangePatchMap( const int lv, const int xyz, const char *comment )
    }
 
 
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/ExchangePatchMap_%d_%d_%2s", OUTPUT_DIR, MPI_Rank, lv, Dim[1] );
    if ( comment != NULL )
    {

--- a/src/Output/Output_FlagMap.cpp
+++ b/src/Output/Output_FlagMap.cpp
@@ -54,7 +54,7 @@ void Output_FlagMap( const int lv, const int xyz, const char *comment )
    }
 
 
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/FlagMap_%d_%d_%2s", OUTPUT_DIR, MPI_Rank, lv, Dim[1] );
    if ( comment != NULL )
    {

--- a/src/Output/Output_Flux.cpp
+++ b/src/Output/Output_Flux.cpp
@@ -34,7 +34,7 @@ void Output_Flux( const int lv, const int PID, const int Sib, const char *commen
 
    patch_t *Relation  = amr->patch[0][lv][PID];
 
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Flux_r%d_lv%d_p%d%c%c", OUTPUT_DIR, MPI_Rank, lv, PID, 45-2*(Sib%2), 120+Sib/2 );
    if ( comment != NULL )
    {

--- a/src/Output/Output_L1Error.cpp
+++ b/src/Output/Output_L1Error.cpp
@@ -75,7 +75,7 @@ void Output_L1Error( void (*AnalFunc_Flu)( real fluid[], const double x, const d
 
 
 // output filename
-   char FileName[NERR][MAX_STRING];
+   char FileName[NERR][2*MAX_STRING];
 
 #  if   ( MODEL == HYDRO )
    sprintf( FileName[            0], "%s/%s_Dens_%06d", OUTPUT_DIR, Prefix, DumpID );
@@ -276,7 +276,7 @@ void Output_L1Error( void (*AnalFunc_Flu)( real fluid[], const double x, const d
 
       for (int v=0; v<NERR; v++)    L1_Err_Sum[v] /= Norm;
 
-      char FileName_L1[MAX_STRING];
+      char FileName_L1[2*MAX_STRING];
       sprintf( FileName_L1, "%s/Record__L1Err", OUTPUT_DIR );
       FILE *File_L1 = fopen( FileName_L1, "a" );
 

--- a/src/Output/Output_Patch.cpp
+++ b/src/Output/Output_Patch.cpp
@@ -59,7 +59,7 @@ void Output_Patch( const int lv, const int PID, const int FluSg, const int MagSg
    real    (*pot)[PS1][PS1]           = amr->patch[PotSg][lv][PID]->pot;
 #  endif
 
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Patch_r%d_lv%d_p%d", OUTPUT_DIR, MPI_Rank, lv, PID );
    if ( comment != NULL )
    {

--- a/src/Output/Output_PatchCorner.cpp
+++ b/src/Output/Output_PatchCorner.cpp
@@ -18,7 +18,7 @@
 void Output_PatchCorner( const int lv, const char *comment )
 {
 
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/PatchCorner_%05d_%02d", OUTPUT_DIR, MPI_Rank, lv );
    if ( comment != NULL )
    {

--- a/src/Output/Output_PatchMap.cpp
+++ b/src/Output/Output_PatchMap.cpp
@@ -49,7 +49,7 @@ void Output_PatchMap( const int lv, const int PID, const int TSg, const int Comp
    patch_t *Relation = amr->patch[ 0][lv][PID];
    patch_t *Data     = amr->patch[TSg][lv][PID];
 
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/PatchMap_r%d_lv%d_p%d_v%d", OUTPUT_DIR, MPI_Rank, lv, PID, Comp );
    if ( comment != NULL )
    {

--- a/src/Output/Output_PreparedPatch_Fluid.cpp
+++ b/src/Output/Output_PreparedPatch_Fluid.cpp
@@ -50,7 +50,7 @@ void Output_PreparedPatch_Fluid( const int TLv, const int TPID,
 //    begin to output the prepared data
       patch_t *Relation = amr->patch[0][TLv][TPID];
 
-      char FileName[MAX_STRING];
+      char FileName[2*MAX_STRING];
       sprintf( FileName, "%s/PrePatch_Fluid_r%d_lv%d_p%d", OUTPUT_DIR, MPI_Rank, TLv, TPID );
       if ( comment != NULL )
       {

--- a/src/Particle/LoadBalance/Par_LB_SendParticleData.cpp
+++ b/src/Particle/LoadBalance/Par_LB_SendParticleData.cpp
@@ -253,7 +253,7 @@ void Par_LB_SendParticleData( const int NParAttFlt, const int NParAttInt, int *S
          dtime = Timer->GetValue() - time0;
 
 //       output to the same log file as LB_GetBufferData
-         char FileName[MAX_STRING];
+         char FileName[2*MAX_STRING];
          sprintf( FileName, "%s/Record__TimingMPI_Rank%05d", OUTPUT_DIR, MPI_Rank );
 
          FILE *File = fopen( FileName, "a" );

--- a/src/Particle/Par_Aux_Record_ParticleCount.cpp
+++ b/src/Particle/Par_Aux_Record_ParticleCount.cpp
@@ -16,7 +16,7 @@ void Par_Aux_Record_ParticleCount()
 {
 
    static bool FirstTime = true;
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Record__ParticleCount", OUTPUT_DIR );
 
    if ( MPI_Rank == 0  &&  FirstTime )

--- a/src/TestProblem/Hydro/Bondi/Record_Bondi.cpp
+++ b/src/TestProblem/Hydro/Bondi/Record_Bondi.cpp
@@ -37,7 +37,7 @@ extern int    Bondi_SinkNCell;
 void Record_Bondi()
 {
 
-   char FileName[MAX_STRING];
+   char FileName[2*MAX_STRING];
    sprintf( FileName, "%s/Record__BondiAccretionRate", OUTPUT_DIR );
 
    static bool   FirstTime = true;

--- a/src/TestProblem/Hydro/Gravity/Init_TestProb_Hydro_Gravity.cpp
+++ b/src/TestProblem/Hydro/Gravity/Init_TestProb_Hydro_Gravity.cpp
@@ -370,7 +370,7 @@ void Aux_Record_Gravity()
    if ( MPI_Rank == 0 )
    {
 //    header
-      char FileName[MAX_STRING];
+      char FileName[2*MAX_STRING];
       sprintf( FileName, "%s/Record__PoissonPerformance", OUTPUT_DIR );
 
       if ( !Aux_CheckFileExist(FileName) )


### PR DESCRIPTION
Solve #425.
Thank you, @salmanhiro and @technic960183, for identifying this issue. Thank you, @vivi235711 for your help.

## Reproduce the issue with the error message
1. Compile `gamer` with [AddressSanitizer (ASan) flags](https://github.com/gamer-project/gamer/wiki/Troubleshooting#check-static-arrays-with-addresssanitizer-asan)
2. Run `gamer`
<details>
<summary><i>Error message</i></summary>

<pre>
==58858==ERROR: AddressSanitizer: global-buffer-overflow on address 0x00010259625c at pc 0x00010b4ef33d bp 0x0003089dd110 sp 0x0003089dc8c0
WRITE of size 512 at 0x00010259625c thread T0
    #0 0x00010b4ef33c in strncpy+0x4cc (libclang_rt.asan_osx_dynamic.dylib:x86_64+0x4e33c)
    #1 0x0001021b7ca7 in ReadPara_t::Read(char const*) ReadPara.h:290
    #2 0x0001021affcf in Init_Load_Parameter() Init_Load_Parameter.cpp:626
    #3 0x0001021a8708 in Init_GAMER(int*, char***) Init_GAMER.cpp:38
    #4 0x0001020802e8 in main Main.cpp:614
    #5 0x00020283e2cc  (<unknown module>)

0x00010259625c is located 0 bytes after global variable 'OUTPUT_DIR' defined in 'Main/Main.cpp' (0x0001025960c0) of size 412
SUMMARY: AddressSanitizer: global-buffer-overflow ReadPara.h:290 in ReadPara_t::Read(char const*)
Shadow bytes around the buggy address:
  0x000102595f80: 00 f9 f9 f9 00 f9 f9 f9 00 f9 f9 f9 00 f9 f9 f9
  0x000102596000: 00 f9 f9 f9 00 f9 f9 f9 04 f9 f9 f9 00 f9 f9 f9
  0x000102596080: 00 f9 f9 f9 00 f9 f9 f9 00 00 00 00 00 00 00 00
  0x000102596100: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x000102596180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x000102596200: 00 00 00 00 00 00 00 00 00 00 00[04]f9 f9 f9 f9
  0x000102596280: f9 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9 00 f9 f9 f9
  0x000102596300: 00 f9 f9 f9 00 f9 f9 f9 00 f9 f9 f9 00 f9 f9 f9
  0x000102596380: 04 f9 f9 f9 04 f9 f9 f9 04 f9 f9 f9 04 f9 f9 f9
  0x000102596400: 04 f9 f9 f9 04 f9 f9 f9 00 00 00 f9 f9 f9 f9 f9
  0x000102596480: 04 f9 f9 f9 04 f9 f9 f9 04 f9 f9 f9 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==58858==ABORTING
zsh: abort      ./gamer
</pre>
</details>

## How to fix
1. Declare the length of `OUTPUT_DIR` as `MAX_STRING`
2. If the code uses `sprintf()` with `OUTPUT_DIR`, I append the destination string length to `2*MAX_STRING`.