### PR TITLE
Update fomalhaut.config

### DIFF
--- a/configs/fomalhaut.config
+++ b/configs/fomalhaut.config
@@ -1,8 +1,8 @@
 # NTHU-fomalhaut (openmpi-gnu)
 CUDA_PATH       /cluster/software/cuda-10.0
 #CUDA_PATH       /cluster/software/cuda/11.6/gcc--8.3.0
-FFTW2_PATH      /cluster/software/fftw/2.1.5/gcc--8.3.0/openmpi--3.1.4
-#FFTW3_PATH      /cluster/software/fftw/3.3.8/gcc--8.3.0/openmpi--3.1.4
+#FFTW2_PATH      /cluster/software/fftw/2.1.5/gcc--8.3.0/openmpi--3.1.4
+FFTW3_PATH      /cluster/software/fftw/3.3.8/gcc--8.3.0/openmpi--3.1.4
 MPI_PATH        /cluster/software/openmpi/3.1.4/gcc--8.3.0
 HDF5_PATH       /cluster/software/hdf5-parallel/1.8.21/gcc--8.3.0/openmpi--3.1.4
 GRACKLE_PATH

--- a/configs/fomalhaut.config
+++ b/configs/fomalhaut.config
@@ -1,8 +1,8 @@
 # NTHU-fomalhaut (openmpi-gnu)
 CUDA_PATH       /cluster/software/cuda-10.0
-# CUDA_PATH       /cluster/software/cuda/11.6/gcc--8.3.0
+#CUDA_PATH       /cluster/software/cuda/11.6/gcc--8.3.0
 FFTW2_PATH      /cluster/software/fftw/2.1.5/gcc--8.3.0/openmpi--3.1.4
-# FFTW3_PATH      /cluster/software/fftw/3.3.8/gcc--8.3.0/openmpi--3.1.4
+#FFTW3_PATH      /cluster/software/fftw/3.3.8/gcc--8.3.0/openmpi--3.1.4
 MPI_PATH        /cluster/software/openmpi/3.1.4/gcc--8.3.0
 HDF5_PATH       /cluster/software/hdf5-parallel/1.8.21/gcc--8.3.0/openmpi--3.1.4
 GRACKLE_PATH
@@ -39,6 +39,6 @@ NVCCFLAG_COM -O3
 NVCCFLAG_FLU -Xptxas -dlcm=ca -prec-div=false -ftz=true
 NVCCFLAG_POT -Xptxas -dlcm=ca
 
-# GPU
+# gpu
 GPU_COMPUTE_CAPABILITY 750    # GeForce RTX 2080 Ti (CUDA 10, g01 and g02)
-# GPU_COMPUTE_CAPABILITY 860    # RTX A4000 and GeForce RTX 3080 (CUDA 11, g03 and g04)
+#GPU_COMPUTE_CAPABILITY 860    # RTX A4000 and GeForce RTX 3080 (CUDA 11, g03 and g04)

--- a/configs/fomalhaut.config
+++ b/configs/fomalhaut.config
@@ -1,8 +1,13 @@
 # NTHU-fomalhaut (openmpi-gnu)
-CUDA_PATH       /cluster/software/cuda/10.1.105/gcc--8.3.0 # For CUDA 10
-FFTW2_PATH      /home/hyschive/software/fftw/2.1.5-openmpi-gnu
-MPI_PATH        /storage/app/gnu/openmpi-3.1.3-gcc8
-HDF5_PATH       /cluster/software/hdf5/1.10.5/gcc--8.3.0/serial
+CUDA_PATH       /cluster/software/cuda-10.0
+#CUDA_PATH       /cluster/software/cuda/11.6/gcc--8.3.0
+FFTW2_PATH      /cluster/software/fftw/2.1.5/gcc--8.3.0/openmpi--3.1.4
+FFTW3_PATH      /cluster/software/fftw/3.3.8/gcc--8.3.0/openmpi--3.1.4
+MPI_PATH        /cluster/software/openmpi/3.1.4/gcc--8.3.0
+HDF5_PATH       /cluster/software/hdf5-parallel/1.8.21/gcc--8.3.0/openmpi--3.1.4
+GRACKLE_PATH
+GSL_PATH
+LIBYT_PATH
 
 # compilers
 CXX     g++
@@ -34,6 +39,6 @@ NVCCFLAG_COM -O3
 NVCCFLAG_FLU -Xptxas -dlcm=ca -prec-div=false -ftz=true
 NVCCFLAG_POT -Xptxas -dlcm=ca
 
-#gpu
-# GPU_COMPUTE_CAPABILITY 860    # GeForce RTX 3080 and RTX A4000 (use CUDA 11)
-GPU_COMPUTE_CAPABILITY 750    # GeForce RTX 2080 Ti (default with CUDA 10)
+# GPU
+GPU_COMPUTE_CAPABILITY 750    # GeForce RTX 2080 Ti (CUDA 10, g01 and g02)
+#GPU_COMPUTE_CAPABILITY 860    # RTX A4000 and GeForce RTX 3080 (CUDA 11, g03 and g04)

--- a/configs/fomalhaut.config
+++ b/configs/fomalhaut.config
@@ -1,8 +1,8 @@
 # NTHU-fomalhaut (openmpi-gnu)
 CUDA_PATH       /cluster/software/cuda-10.0
-#CUDA_PATH       /cluster/software/cuda/11.6/gcc--8.3.0
+# CUDA_PATH       /cluster/software/cuda/11.6/gcc--8.3.0
 FFTW2_PATH      /cluster/software/fftw/2.1.5/gcc--8.3.0/openmpi--3.1.4
-FFTW3_PATH      /cluster/software/fftw/3.3.8/gcc--8.3.0/openmpi--3.1.4
+# FFTW3_PATH      /cluster/software/fftw/3.3.8/gcc--8.3.0/openmpi--3.1.4
 MPI_PATH        /cluster/software/openmpi/3.1.4/gcc--8.3.0
 HDF5_PATH       /cluster/software/hdf5-parallel/1.8.21/gcc--8.3.0/openmpi--3.1.4
 GRACKLE_PATH
@@ -41,4 +41,4 @@ NVCCFLAG_POT -Xptxas -dlcm=ca
 
 # GPU
 GPU_COMPUTE_CAPABILITY 750    # GeForce RTX 2080 Ti (CUDA 10, g01 and g02)
-#GPU_COMPUTE_CAPABILITY 860    # RTX A4000 and GeForce RTX 3080 (CUDA 11, g03 and g04)
+# GPU_COMPUTE_CAPABILITY 860    # RTX A4000 and GeForce RTX 3080 (CUDA 11, g03 and g04)

--- a/configs/fomalhaut.config
+++ b/configs/fomalhaut.config
@@ -1,8 +1,8 @@
 # NTHU-fomalhaut (openmpi-gnu)
-CUDA_PATH       /usr/local/cuda-10.0
+CUDA_PATH       /cluster/software/cuda/10.1.105/gcc--8.3.0 # For CUDA 10
 FFTW2_PATH      /home/hyschive/software/fftw/2.1.5-openmpi-gnu
 MPI_PATH        /storage/app/gnu/openmpi-3.1.3-gcc8
-HDF5_PATH       /storage/app/gnu/hdf5-1.8.21-gcc8
+HDF5_PATH       /cluster/software/hdf5/1.10.5/gcc--8.3.0/serial
 
 # compilers
 CXX     g++
@@ -35,5 +35,5 @@ NVCCFLAG_FLU -Xptxas -dlcm=ca -prec-div=false -ftz=true
 NVCCFLAG_POT -Xptxas -dlcm=ca
 
 #gpu
-GPU_COMPUTE_CAPABILITY 860    # GeForce RTX 3080 and RTX A4000
-#GPU_COMPUTE_CAPABILITY 750    # GeForce RTX 2080 Ti
+# GPU_COMPUTE_CAPABILITY 860    # GeForce RTX 3080 and RTX A4000 (use CUDA 11)
+GPU_COMPUTE_CAPABILITY 750    # GeForce RTX 2080 Ti (default with CUDA 10)

--- a/example/queue/submit_fomalhaut.job
+++ b/example/queue/submit_fomalhaut.job
@@ -13,7 +13,7 @@
 #Load module
 module purge
 module load gcc/8.3.0 cuda/10.0 openmpi/3.1.4 fftw/3.3.8 hdf5-parallel/1.8.21 # # GeForce RTX 2080 Ti (CUDA 10, g01 and g02)
-#module load gcc/8.3.0 cuda/11.0 openmpi/3.1.4 fftw/2.1.5 hdf5-parallel/1.8.21 # RTX A4000 and GeForce RTX 3080 (CUDA 11, g03 and g04)
+#module load gcc/8.3.0 cuda/11.0 openmpi/3.1.4 fftw/3.3.8 hdf5-parallel/1.8.21 # RTX A4000 and GeForce RTX 3080 (CUDA 11, g03 and g04)
 
 
 mpirun -np 2 -map-by ppr:1:socket:pe=18 --report-bindings ./gamer 1>>log 2>&1

--- a/example/queue/submit_fomalhaut.job
+++ b/example/queue/submit_fomalhaut.job
@@ -13,7 +13,7 @@
 #Load module
 module purge
 module load gcc/8.3.0 cuda/10.0 openmpi/3.1.4 fftw/3.3.8 hdf5-parallel/1.8.21 # # GeForce RTX 2080 Ti (CUDA 10, g01 and g02)
-#module load gcc/8.3.0 cuda/11.0 openmpi/3.1.4 fftw/3.3.8 hdf5-parallel/1.8.21 # RTX A4000 and GeForce RTX 3080 (CUDA 11, g03 and g04)
+#module load gcc/8.3.0 cuda/11.6 openmpi/3.1.4 fftw/3.3.8 hdf5-parallel/1.8.21 # RTX A4000 and GeForce RTX 3080 (CUDA 11, g03 and g04)
 
 
 mpirun -np 2 -map-by ppr:1:socket:pe=18 --report-bindings ./gamer 1>>log 2>&1

--- a/example/queue/submit_fomalhaut.job
+++ b/example/queue/submit_fomalhaut.job
@@ -12,6 +12,8 @@
 
 #Load module
 module purge
-module load gcc/8.3.0 cuda/10.0 openmpi/3.1.4 fftw/2.1.5 hdf5-parallel/1.8.21
+module load gcc/8.3.0 cuda/10.0 openmpi/3.1.4 fftw/2.1.5 hdf5-parallel/1.8.21 # # GeForce RTX 2080 Ti (CUDA 10, g01 and g02)
+# module load gcc/8.3.0 cuda/11.0 openmpi/3.1.4 fftw/2.1.5 hdf5-parallel/1.8.21 # RTX A4000 and GeForce RTX 3080 (CUDA 11, g03 and g04)
+
 
 mpirun -np 2 -map-by ppr:1:socket:pe=18 --report-bindings ./gamer 1>>log 2>&1

--- a/example/queue/submit_fomalhaut.job
+++ b/example/queue/submit_fomalhaut.job
@@ -12,8 +12,8 @@
 
 #Load module
 module purge
-module load gcc/8.3.0 cuda/10.0 openmpi/3.1.4 fftw/2.1.5 hdf5-parallel/1.8.21 # # GeForce RTX 2080 Ti (CUDA 10, g01 and g02)
-# module load gcc/8.3.0 cuda/11.0 openmpi/3.1.4 fftw/2.1.5 hdf5-parallel/1.8.21 # RTX A4000 and GeForce RTX 3080 (CUDA 11, g03 and g04)
+module load gcc/8.3.0 cuda/10.0 openmpi/3.1.4 fftw/3.3.8 hdf5-parallel/1.8.21 # # GeForce RTX 2080 Ti (CUDA 10, g01 and g02)
+#module load gcc/8.3.0 cuda/11.0 openmpi/3.1.4 fftw/2.1.5 hdf5-parallel/1.8.21 # RTX A4000 and GeForce RTX 3080 (CUDA 11, g03 and g04)
 
 
 mpirun -np 2 -map-by ppr:1:socket:pe=18 --report-bindings ./gamer 1>>log 2>&1

--- a/example/queue/submit_fomalhaut.job
+++ b/example/queue/submit_fomalhaut.job
@@ -12,7 +12,7 @@
 
 #Load module
 module purge
-module load gcc/8.3.0 cuda/10.0 openmpi/3.1.4 fftw/3.3.8 hdf5-parallel/1.8.21 # # GeForce RTX 2080 Ti (CUDA 10, g01 and g02)
+module load gcc/8.3.0 cuda/10.0 openmpi/3.1.4 fftw/3.3.8 hdf5-parallel/1.8.21 # GeForce RTX 2080 Ti (CUDA 10, g01 and g02)
 #module load gcc/8.3.0 cuda/11.6 openmpi/3.1.4 fftw/3.3.8 hdf5-parallel/1.8.21 # RTX A4000 and GeForce RTX 3080 (CUDA 11, g03 and g04)
 
 


### PR DESCRIPTION
# ✋ Pull request
Solves #433 
Update `fomalhaut.configs` file and add `cuda-11` compatibility on SLURM script.

## 📓 Description:
Key Changes: 
- Updating `fomalhaut.configs` paths according to newer cluster settings.
- Add option to use `cuda-11` on both `fomalhaut.configs` and example SLURM script.

## 🧪 Testing 

| **Hardware** | GeForce RTX 2080 Ti (CUDA 10, g01 and g02) | RTX A4000 and GeForce RTX 3080 (CUDA 11, g03 and g04)|
| -------------- | -------------- | -------------- |
| **Software** | CUDA 10.0 | CUDA 11.6 |
| **GPU Compatibility**  | `750`    | `860`     |
| **FFTW 2.1.5**  | ✅    | ✅     |
| **FFTW3 3.3.8**  | ✅     | ✅   |
| **OpenMPI 3.1.4** | ✅    | ✅   |
| **HDF5 1.8.21**    | ✅   | ✅   |

*Note: FFTW3 is commented out in the original configuration, so it may not be actively used.*


Tests Conducted: Manual
- ✅  Make and quickstarts on `cuda-10` architecture (works) 
[Record__Note_Blastwave_CUDA10.txt](https://github.com/user-attachments/files/18941952/Record__Note_Blastwave_CUDA10.txt)
[Record__Note_Shocktube_CUDA10.txt](https://github.com/user-attachments/files/18941953/Record__Note_Shocktube_CUDA10.txt)
[Record__Note_Slurm_CUDA10.txt](https://github.com/user-attachments/files/18941954/Record__Note_Slurm_CUDA10.txt)
- ✅   Make and quickstarts on `cuda-11` architecture (works)
[Record__Note_Shocktube_CUDA11.txt](https://github.com/user-attachments/files/18955186/Record__Note_Shocktube_CUDA11.txt)
[Record__Note_Blastwave_CUDA11.txt](https://github.com/user-attachments/files/18955200/Record__Note_Blastwave_CUDA11.txt)




