### PR TITLE
Add scale factor to Jeans coefficient

### DIFF
--- a/src/Main/InvokeSolver.cpp
+++ b/src/Main/InvokeSolver.cpp
@@ -547,7 +547,7 @@ void Solver( const Solver_t TSolver, const int lv, const double TimeNew, const d
 #  if ( MODEL == HYDRO  &&  defined GRAVITY )
 #  ifdef COMOVING
    const real JeansMinPres_Coeff = ( JEANS_MIN_PRES ) ?
-                                   Time[lv]*NEWTON_G*SQR(JEANS_MIN_PRES_NCELL*amr->dh[JEANS_MIN_PRES_LEVEL])/(GAMMA*M_PI) : NULL_REAL;
+                                   TimeOld*NEWTON_G*SQR(JEANS_MIN_PRES_NCELL*amr->dh[JEANS_MIN_PRES_LEVEL])/(GAMMA*M_PI) : NULL_REAL;
 #  else
    const real JeansMinPres_Coeff = ( JEANS_MIN_PRES ) ?
                                    NEWTON_G*SQR(JEANS_MIN_PRES_NCELL*amr->dh[JEANS_MIN_PRES_LEVEL])/(GAMMA*M_PI) : NULL_REAL;

--- a/src/Main/InvokeSolver.cpp
+++ b/src/Main/InvokeSolver.cpp
@@ -545,8 +545,13 @@ void Solver( const Solver_t TSolver, const int lv, const double TimeNew, const d
 #  endif
 
 #  if ( MODEL == HYDRO  &&  defined GRAVITY )
+#  ifdef COMOVING
+   const real JeansMinPres_Coeff = ( JEANS_MIN_PRES ) ?
+                                   Time[lv]*NEWTON_G*SQR(JEANS_MIN_PRES_NCELL*amr->dh[JEANS_MIN_PRES_LEVEL])/(GAMMA*M_PI) : NULL_REAL;
+#  else
    const real JeansMinPres_Coeff = ( JEANS_MIN_PRES ) ?
                                    NEWTON_G*SQR(JEANS_MIN_PRES_NCELL*amr->dh[JEANS_MIN_PRES_LEVEL])/(GAMMA*M_PI) : NULL_REAL;
+#  endif
 #  else
    const real JEANS_MIN_PRES     = false;
    const real JeansMinPres_Coeff = NULL_REAL;

--- a/src/Refine/Flag_Check.cpp
+++ b/src/Refine/Flag_Check.cpp
@@ -42,6 +42,7 @@ static bool Check_Radial( const int i, const int j, const int k, const int lv, c
 //                ParDens       : Input array storing the particle mass density on each cell
 //                JeansCoeff    : Pi*GAMMA/(SafetyFactor^2*G), where SafetyFactor = FlagTable_Jeans[lv]
 //                                --> Flag if dh^2 > JeansCoeff*Pres/Dens^2
+//                                --> When COMOVING is on, G has been replaced by a*G, where a is the scale factor
 //                Interf_Var    : Input array storing the density and phase for the interference condition
 //                Spectral_Cond : Input variable storing the spectral refinement condition
 //

--- a/src/Refine/Flag_Real.cpp
+++ b/src/Refine/Flag_Real.cpp
@@ -76,8 +76,12 @@ void Flag_Real( const int lv, const UseLBFunc_t UseLBFunc )
 #  endif // # if ( MODEL == ELBDM )
 
 #  if ( MODEL == HYDRO  &&  defined GRAVITY )
+#  ifdef COMOVING
+   const real JeansCoeff_Factor       = M_PI/( Time[lv]*SQR(FlagTable_Jeans[lv])*NEWTON_G ); // flag if dh^2 > JeansCoeff_Factor*Gamma*Pres/Dens^2
+#  else
    const real JeansCoeff_Factor       = M_PI/( SQR(FlagTable_Jeans[lv])*NEWTON_G ); // flag if dh^2 > JeansCoeff_Factor*Gamma*Pres/Dens^2
 #  endif
+   #  endif
 #  ifndef GRAVITY
    const OptPotBC_t OPT__BC_POT       = BC_POT_NONE;
 #  endif

--- a/src/Refine/Flag_Real.cpp
+++ b/src/Refine/Flag_Real.cpp
@@ -81,7 +81,7 @@ void Flag_Real( const int lv, const UseLBFunc_t UseLBFunc )
 #  else
    const real JeansCoeff_Factor       = M_PI/( SQR(FlagTable_Jeans[lv])*NEWTON_G ); // flag if dh^2 > JeansCoeff_Factor*Gamma*Pres/Dens^2
 #  endif
-   #  endif
+#  endif
 #  ifndef GRAVITY
    const OptPotBC_t OPT__BC_POT       = BC_POT_NONE;
 #  endif


### PR DESCRIPTION
I would like to suggest adding the scale factor to the Jeans coefficient when COMOVING is enabled.

When COMOVING is on, $P_c = P_p a^5$, $\rho_c = \rho_p a^3$, $\Delta x_c = \Delta x_p / a$, where the $a$, $P$, $\rho$, and $\Delta x$ are the scale factor, pressure, density, and cell size, respectively, and the subscripts $c$ and $p$ denotes comoving and physical variables.

The Jeans minimum pressure floor is  $P_p =\frac{1}{\gamma\pi} N^2 G \rho_p^2 \Delta x_p^2$ on the physical coordinates. Applying the coordinate conversion above, we obtain $P_c =a \frac{1}{\gamma\pi} N^2 G \rho_c^2 \Delta x_c^2$. So, I added `Time[lv]` to `JeansMinPres_Coeff`.

Similarly, the Jeans length is $\lambda_p = \sqrt{\frac{\pi \gamma}{G} \frac{P_p}{\rho_p^2}}$ on the physical coordinates, and this becomes $\lambda_c = \sqrt{a^{-1} \frac{\pi \gamma}{G} \frac{P_c}{\rho_c^2}}$ on the comoving coordinates. So, I added `Time[lv]` in the denominator of  `JeansCoeff_Factor`.