### PR TITLE
Apply dual-energy fix during interpolate iteration

### DIFF
--- a/src/Interpolation/Interpolate.cpp
+++ b/src/Interpolation/Interpolate.cpp
@@ -339,6 +339,19 @@ void Interpolate_Iterate( real CData[], const int CSize[3], const int CStart[3],
 #        endif
 
 
+//       use dual-energy fix before the general check
+#        ifdef DUAL_ENERGY
+         const bool CheckMinPres_No = false;
+         const real UseDual2FixEngy = HUGE_NUMBER;
+         char dummy;    // we do not record the dual-energy status here
+
+         if ( !FData_is_Prim )
+            Hydro_DualEnergyFix( Temp[DENS], Temp[MOMX], Temp[MOMY], Temp[MOMZ], Temp[ENGY], Temp[DUAL],
+                                 dummy, EoS_AuxArray_Flt[1], EoS_AuxArray_Flt[2],
+                                 CheckMinPres_No, NULL_REAL, UseDual2FixEngy, Emag );
+#        endif
+
+
 //       5-2. general check
          bool Fail_ThisCell
             = Hydro_IsUnphysical( (FData_is_Prim)?UNPHY_MODE_PRIM:UNPHY_MODE_CONS, Temp, NULL,


### PR DESCRIPTION
I would like to propose applying the dual-energy fix before performing the general check in the `Interpolate_Iterate` function. This helps avoid generating artificial shock after refining cells with a high Mach number.

I have attached snapshots from the Zeldovich pancake test problems with three different setups as an example. The first is the reference setup with `MAX_LEVEL=0` at z=2.5.
![static](https://github.com/user-attachments/assets/d48aef89-3cf8-4b13-9bf0-2bc78afb78b3)

Next, I made the following changes in the input parameters and rerun using the code before making the update in this PR.
- `MAX_LEVEL=1` in `Input__Parameter`
- `INT_OPP_SIGN_0TH_ORDER=0` in `Input__Parameter`
- set threshold density to 2.0 at level 0 in `Input__Flag_Rho`

Then, fluctuations appear in the density profile, and the pressure in the center increases compared to the reference result, which is likely caused by the failure of the interpolation due to the negative internal energy.
![before](https://github.com/user-attachments/assets/cda56bbd-0508-4c3e-ae9f-18406da7adaf)

The last figure shows the result of the updated code using the same input parameters. The dual energy fix avoids negative internal energy and achieves smooth interpolation, and the profiles agree with the reference result.
![after](https://github.com/user-attachments/assets/beae9aee-11be-4766-868a-df63ee7f8f11)

