### PR TITLE
Set the precision of the particle floating-point number to double by default

### DIFF
--- a/doc/wiki/Installation-related/Installation:-Option-List.md
+++ b/doc/wiki/Installation-related/Installation:-Option-List.md
@@ -87,7 +87,7 @@ disabled). See the "Restriction" of each option carefully.
 | `--feedback`          | `true`, `false` | `false` | Enable feedback from particles to grids (and vice versa) | See [[here \| Feedback]] for details | <a name="--feedback"></a> `FEEDBACK` |
 | `--par_attribute_flt` | &#8805; 0       | `0`     | Number of user-defined particle floating-point attributes | See [[here \| Adding-New-Simulations#particle-attributes]] for details | <a name="--par_attribute_flt"></a> `PAR_NATT_FLT_USER` |
 | `--par_attribute_int` | &#8805; 0       | `0`     | Number of user-defined particle integer        attributes | See [[here \| Adding-New-Simulations#particle-attributes]] for details | <a name="--par_attribute_int"></a> `PAR_NATT_INT_USER` |
-| `--double_par`        | `true`, `false` | Depend  | Enable double-precision floating-point accuracy for particles. It will be set to `--double` by default. | - | <a name="--double_par"></a> `FLOAT8_PAR` |
+| `--double_par`        | `true`, `false` | `true`  | Enable double-precision floating-point accuracy for particles. | - | <a name="--double_par"></a> `FLOAT8_PAR` |
 | `--long_par`          | `true`, `false` | `true`  | Enable long interger data type for particles. | - | <a name="--long_par"></a> `INT8_PAR` |
 
 ## Microphysics Options

--- a/example/test_problem/Hydro/CDM_LSS/Input__Parameter
+++ b/example/test_problem/Hydro/CDM_LSS/Input__Parameter
@@ -46,7 +46,7 @@ OPT__BC_POT                   1           # gravity boundary condition: (1=perio
 PAR_NPAR                      2097152     # total number of particles (must be set for PAR_INIT==1/3; must be an integer)
 PAR_INIT                      3           # initialization option for particles: (1=FUNCTION, 2=RESTART, 3=FILE->"PAR_IC")
 PAR_IC_FORMAT                 1           # data format of PAR_IC: (1=[attribute][id], 2=[id][attribute]; row-major) [1]
-PAR_IC_FLOAT8                -1           # floating-point precision for PAR_IC (<0: default, 0: single, 1: double) [default: same as FLOAT8_PAR]
+PAR_IC_FLOAT8                 0           # floating-point precision for PAR_IC (<0: default, 0: single, 1: double) [default: same as FLOAT8_PAR]
 PAR_IC_INT8                  -1           # integer width for PAR_IC (<0: default, 0: 32-bit, 1: 64-bit) [default: same as INT8_PAR]
 PAR_IC_MASS                  -1.0         # mass of all particles for PAR_INIT==3 (<0=off) [-1.0]
 PAR_IC_TYPE                  -1           # type of all particles for PAR_INIT==3 (<0=off) [-1]

--- a/src/configure.py
+++ b/src/configure.py
@@ -674,7 +674,7 @@ def load_arguments( sys_setting : SystemSetting ):
                        )
 
     parser.add_argument( "--double_par", type=str2bool, metavar="BOOLEAN", gamer_name="FLOAT8_PAR",
-                         default=None,
+                         default=True,
                          depend={"particle":True},
                          help="Enable double precision for particle floating-point attributes.\n"
                        )
@@ -901,9 +901,6 @@ def set_conditional_defaults( args ):
 
     if args["laplacian_four"] is None:
         args["laplacian_four"] = True if args["wave_scheme"] == "FD" else False
-
-    if args["double_par"] is None:
-        args["double_par"] = args["double"]
 
     if args["flux"] is None:
         args["flux"] = "HLLD" if args["mhd"] else "HLLC"


### PR DESCRIPTION

## Goal
- To alleviate the floating-point number precision issue as described in #441 

## Changes
- Set `--double_par` as true by default in `src/configure.py`
- Update wiki for the description of `--double_par`
- Set `PAR_IC_FLOAT8` as `0` (single precision) explicitly for test problems with `PAR_IC`.

## Tests
- Some selected test problems with particles are tested, and they can run successfully:
  - `Hydro/Plummer`
  - `Hydro/CDM_LSS`
  - `Hydro/AGORA_IsolatedGalaxy`
  - `ELBDM/HaloMerger`

## Warning
- The default results of the test problems with particles will change numerically and cannot be compared to the previous results bitwisely.
  - Most of the differences are not visible in their figures but they are present in the values in output `Particle_*.txt`.
  - Although still qualitatively similar, the figures of the T-rho diagram and the star formation rate of the `Hydro/AGORA_IsolatedGalaxy` show noticeable differences.

