### PR TITLE
Refactor `Hydro_IsUnphysical`

### DIFF
--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -142,7 +142,7 @@ bool Hydro_IsUnphysical( const IsUnphyMode_t Mode, const real Fields[],
                          const double EoS_AuxArray_Flt[], const int EoS_AuxArray_Int[],
                          const real *const EoS_Table[EOS_NTABLE_MAX],
                          const char File[], const int Line, const char Function[], const IsUnphVerb_t Verbose );
-bool Hydro_IsUnphysical_Single( const real Fields[], const char SingleFieldName[], const real Min, const real Max,
+bool Hydro_IsUnphysical_Single( const real Field, const char SingleFieldName[], const real Min, const real Max,
                                 const char File[], const int Line, const char Function[], const IsUnphVerb_t Verbose );
 #ifdef DUAL_ENERGY
 void Hydro_DualEnergyFix( const real Dens, const real MomX, const real MomY, const real MomZ,

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -136,9 +136,8 @@ real Hydro_CheckMinTemp( const real InTemp, const real MinTemp );
 real Hydro_CheckMinEntr( const real InEntr, const real MinEntr );
 real Hydro_CheckMinEintInEngy( const real Dens, const real MomX, const real MomY, const real MomZ, const real InEngy,
                                const real MinEint, const real Emag );
-bool Hydro_IsUnphysical( const IsUnphyMode_t Mode, const real Fields[], const char SingleFieldName[],
-                         const real Min, const real Max, const real Emag,
-                         const EoS_DE2P_t EoS_DensEint2Pres,
+bool Hydro_IsUnphysical( const IsUnphyMode_t Mode, const real Fields[],
+                         const real Emag, const EoS_DE2P_t EoS_DensEint2Pres,
                          const EoS_GUESS_t EoS_GuessHTilde, const EoS_H2TEM_t EoS_HTilde2Temp,
                          const double EoS_AuxArray_Flt[], const int EoS_AuxArray_Int[],
                          const real *const EoS_Table[EOS_NTABLE_MAX],

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -143,6 +143,8 @@ bool Hydro_IsUnphysical( const IsUnphyMode_t Mode, const real Fields[], const ch
                          const double EoS_AuxArray_Flt[], const int EoS_AuxArray_Int[],
                          const real *const EoS_Table[EOS_NTABLE_MAX],
                          const char File[], const int Line, const char Function[], const IsUnphVerb_t Verbose );
+bool Hydro_IsUnphysical_Single( const real Fields[], const char SingleFieldName[], const real Min, const real Max,
+                                const char File[], const int Line, const char Function[], const IsUnphVerb_t Verbose );
 #ifdef DUAL_ENERGY
 void Hydro_DualEnergyFix( const real Dens, const real MomX, const real MomY, const real MomZ,
                           real &Etot, real &Dual, char &DE_Status, const real Gamma_m1, const real _Gamma_m1,

--- a/include/Typedef.h
+++ b/include/Typedef.h
@@ -257,10 +257,9 @@ const Check_t
 // modes of Hydro_IsUnphysical()
 typedef int IsUnphyMode_t;
 const IsUnphyMode_t
-   UNPHY_MODE_SING         = 0,  // check single field
-   UNPHY_MODE_CONS         = 1,  // check conserved variables, including passive scalars
-   UNPHY_MODE_PRIM         = 2,  // check primitive variables, including passive scalars
-   UNPHY_MODE_PASSIVE_ONLY = 3;  // only check passive scalars
+   UNPHY_MODE_CONS         = 0,  // check conserved variables, including passive scalars
+   UNPHY_MODE_PRIM         = 1,  // check primitive variables, including passive scalars
+   UNPHY_MODE_PASSIVE_ONLY = 2;  // only check passive scalars
 
 
 // verbosity levels of Hydro_IsUnphysical()

--- a/src/EoS/Gamma/CPU_EoS_Gamma.cpp
+++ b/src/EoS/Gamma/CPU_EoS_Gamma.cpp
@@ -103,12 +103,8 @@ static real EoS_DensEint2Pres_Gamma( const real Dens, const real Eint, const rea
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Eint, "input internal energy",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -147,12 +143,8 @@ static real EoS_DensPres2Eint_Gamma( const real Dens, const real Pres, const rea
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Pres, "input pressure",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -191,12 +183,8 @@ static real EoS_DensPres2CSqr_Gamma( const real Dens, const real Pres, const rea
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Pres, "input pressure",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -237,12 +225,8 @@ static real EoS_DensEint2Temp_Gamma( const real Dens, const real Eint, const rea
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Eint, "input internal energy",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -284,12 +268,8 @@ static real EoS_DensTemp2Pres_Gamma( const real Dens, const real Temp, const rea
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Temp, "input temperature",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",     TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Temp, "input temperature", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -329,12 +309,8 @@ static real EoS_DensEint2Entr_Gamma( const real Dens, const real Eint, const rea
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Eint, "input internal energy",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 

--- a/src/EoS/Gamma/CPU_EoS_Gamma.cpp
+++ b/src/EoS/Gamma/CPU_EoS_Gamma.cpp
@@ -103,8 +103,8 @@ static real EoS_DensEint2Pres_Gamma( const real Dens, const real Eint, const rea
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -143,8 +143,8 @@ static real EoS_DensPres2Eint_Gamma( const real Dens, const real Pres, const rea
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -183,8 +183,8 @@ static real EoS_DensPres2CSqr_Gamma( const real Dens, const real Pres, const rea
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -225,8 +225,8 @@ static real EoS_DensEint2Temp_Gamma( const real Dens, const real Eint, const rea
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -268,8 +268,8 @@ static real EoS_DensTemp2Pres_Gamma( const real Dens, const real Temp, const rea
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",     TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Temp, "input temperature", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",     TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Temp, "input temperature", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -309,8 +309,8 @@ static real EoS_DensEint2Entr_Gamma( const real Dens, const real Eint, const rea
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 

--- a/src/EoS/GammaCR/CPU_EoS_GammaCR.cpp
+++ b/src/EoS/GammaCR/CPU_EoS_GammaCR.cpp
@@ -128,8 +128,8 @@ static real EoS_DensEint2Pres_GammaCR( const real Dens, const real Eint, const r
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -171,8 +171,8 @@ static real EoS_DensPres2Eint_GammaCR( const real Dens, const real Pres, const r
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -214,8 +214,8 @@ static real EoS_DensPres2CSqr_GammaCR( const real Dens, const real Pres, const r
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -260,8 +260,8 @@ static real EoS_DensEint2Temp_GammaCR( const real Dens, const real Eint, const r
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
    const real Gamma_m1  = (real)AuxArray_Flt[1];
@@ -303,8 +303,8 @@ static real EoS_DensTemp2Pres_GammaCR( const real Dens, const real Temp, const r
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",     TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Temp, "input temperature", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",     TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Temp, "input temperature", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -346,8 +346,8 @@ static real EoS_DensEint2Entr_GammaCR( const real Dens, const real Eint, const r
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 

--- a/src/EoS/GammaCR/CPU_EoS_GammaCR.cpp
+++ b/src/EoS/GammaCR/CPU_EoS_GammaCR.cpp
@@ -128,12 +128,8 @@ static real EoS_DensEint2Pres_GammaCR( const real Dens, const real Eint, const r
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Eint, "input internal energy",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -175,12 +171,8 @@ static real EoS_DensPres2Eint_GammaCR( const real Dens, const real Pres, const r
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Pres, "input pressure",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -222,12 +214,8 @@ static real EoS_DensPres2CSqr_GammaCR( const real Dens, const real Pres, const r
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Pres, "input pressure",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -272,14 +260,9 @@ static real EoS_DensEint2Temp_GammaCR( const real Dens, const real Eint, const r
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Eint, "input internal energy",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
-
 
    const real Gamma_m1  = (real)AuxArray_Flt[1];
    const real small_val = (real)AuxArray_Flt[6];
@@ -320,12 +303,8 @@ static real EoS_DensTemp2Pres_GammaCR( const real Dens, const real Temp, const r
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Temp, "input temperature",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",     TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Temp, "input temperature", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -367,12 +346,8 @@ static real EoS_DensEint2Entr_GammaCR( const real Dens, const real Eint, const r
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Eint, "input internal energy",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 

--- a/src/EoS/Isothermal/CPU_EoS_Isothermal.cpp
+++ b/src/EoS/Isothermal/CPU_EoS_Isothermal.cpp
@@ -65,7 +65,7 @@ void EoS_SetAuxArray_Isothermal( double AuxArray_Flt[], int AuxArray_Int[] )
 
 #  ifdef GAMER_DEBUG
    real Cs2 = (real)AuxArray_Flt[0];
-   Hydro_IsUnphysical_Single( &Cs2, "sound speed squared", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Cs2, "sound speed squared", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 } // FUNCTION : EoS_SetAuxArray_Isothermal
@@ -109,7 +109,7 @@ static real EoS_DensEint2Pres_Isothermal( const real Dens, const real Eint, cons
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -144,7 +144,7 @@ static real EoS_DensPres2Eint_Isothermal( const real Dens, const real Pres, cons
 
 // check
 #  ifdef GAMER_DEBUG
-   Hydro_IsUnphysical_Single( &Pres, "input pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Pres, "input pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -253,7 +253,7 @@ static real EoS_DensTemp2Pres_Isothermal( const real Dens, const real Temp, cons
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 

--- a/src/EoS/Isothermal/CPU_EoS_Isothermal.cpp
+++ b/src/EoS/Isothermal/CPU_EoS_Isothermal.cpp
@@ -65,9 +65,7 @@ void EoS_SetAuxArray_Isothermal( double AuxArray_Flt[], int AuxArray_Int[] )
 
 #  ifdef GAMER_DEBUG
    real Cs2 = (real)AuxArray_Flt[0];
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Cs2, "sound speed squared",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Cs2, "sound speed squared", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 } // FUNCTION : EoS_SetAuxArray_Isothermal
@@ -111,9 +109,7 @@ static real EoS_DensEint2Pres_Isothermal( const real Dens, const real Eint, cons
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -148,9 +144,7 @@ static real EoS_DensPres2Eint_Isothermal( const real Dens, const real Pres, cons
 
 // check
 #  ifdef GAMER_DEBUG
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Pres, "input pressure",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Pres, "input pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -259,9 +253,7 @@ static real EoS_DensTemp2Pres_Isothermal( const real Dens, const real Temp, cons
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 

--- a/src/EoS/User_Template/CPU_EoS_User_Template.cpp
+++ b/src/EoS/User_Template/CPU_EoS_User_Template.cpp
@@ -105,13 +105,9 @@ static real EoS_DensEint2Pres_User_Template( const real Dens, const real Eint, c
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
    if ( AuxArray_Int == NULL )   printf( "ERROR : AuxArray_Int == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 // note that some EoS may support Eint<0
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Eint, "input internal energy",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -124,9 +120,7 @@ static real EoS_DensEint2Pres_User_Template( const real Dens, const real Eint, c
 
 // check
 #  ifdef GAMER_DEBUG
-   if (  Hydro_IsUnphysical( UNPHY_MODE_SING, &Pres, "output pressure",
-                             (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE )  )
+   if (  Hydro_IsUnphysical_Single( &Pres, "output pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
    {
       printf( "Dens=%13.7e, Eint=%13.7e\n", Dens, Eint );
 #     if ( NCOMP_PASSIVE > 0 )
@@ -172,12 +166,8 @@ static real EoS_DensPres2Eint_User_Template( const real Dens, const real Pres, c
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
    if ( AuxArray_Int == NULL )   printf( "ERROR : AuxArray_Int == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Pres, "input pressure",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -191,9 +181,7 @@ static real EoS_DensPres2Eint_User_Template( const real Dens, const real Pres, c
 // check
 #  ifdef GAMER_DEBUG
 // note that some EoS may support Eint<0
-   if (  Hydro_IsUnphysical( UNPHY_MODE_SING, &Eint, "output internal energy",
-                             (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE )  )
+   if (  Hydro_IsUnphysical_Single( &Eint, "output internal energy", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
    {
       printf( "Dens=%13.7e, Pres=%13.7e\n", Dens, Pres );
 #     if ( NCOMP_PASSIVE > 0 )
@@ -239,12 +227,8 @@ static real EoS_DensPres2CSqr_User_Template( const real Dens, const real Pres, c
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
    if ( AuxArray_Int == NULL )   printf( "ERROR : AuxArray_Int == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Pres, "input pressure",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -257,9 +241,7 @@ static real EoS_DensPres2CSqr_User_Template( const real Dens, const real Pres, c
 
 // check
 #  ifdef GAMER_DEBUG
-   if (  Hydro_IsUnphysical( UNPHY_MODE_SING, &Cs2, "output sound speed squared",
-                             (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE )  )
+   if (  Hydro_IsUnphysical_Single( &Cs2, "output sound speed squared", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
    {
       printf( "Dens=%13.7e, Pres=%13.7e\n", Dens, Pres );
 #     if ( NCOMP_PASSIVE > 0 )
@@ -303,13 +285,9 @@ static real EoS_DensEint2Temp_User_Template( const real Dens, const real Eint, c
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 // note that some EoS may support Eint<0
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Eint, "input internal energy",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -322,9 +300,7 @@ static real EoS_DensEint2Temp_User_Template( const real Dens, const real Eint, c
 
 // check
 #  ifdef GAMER_DEBUG
-   if (  Hydro_IsUnphysical( UNPHY_MODE_SING, &Temp, "output temperature",
-                             (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE )  )
+   if (  Hydro_IsUnphysical_Single( &Temp, "output temperature", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
    {
       printf( "Dens=%13.7e, Eint=%13.7e\n", Dens, Eint );
 #     if ( NCOMP_PASSIVE > 0 )
@@ -367,12 +343,8 @@ static real EoS_DensTemp2Pres_User_Template( const real Dens, const real Temp, c
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Temp, "input temperature",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",     TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Temp, "input temperature", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -385,9 +357,7 @@ static real EoS_DensTemp2Pres_User_Template( const real Dens, const real Temp, c
 
 // check
 #  ifdef GAMER_DEBUG
-   if (  Hydro_IsUnphysical( UNPHY_MODE_SING, &Pres, "output pressure",
-                             (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE )  )
+   if (  Hydro_IsUnphysical_Single( &Pres, "output pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
    {
       printf( "Dens=%13.7e, Temp=%13.7e\n", Dens, Temp );
 #     if ( NCOMP_PASSIVE > 0 )
@@ -429,13 +399,9 @@ static real EoS_DensEint2Entr_User_Template( const real Dens, const real Eint, c
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "input density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 // note that some EoS may support Eint<0
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Eint, "input internal energy",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -448,9 +414,7 @@ static real EoS_DensEint2Entr_User_Template( const real Dens, const real Eint, c
 
 // check
 #  ifdef GAMER_DEBUG
-   if (  Hydro_IsUnphysical( UNPHY_MODE_SING, &Entr, "output entropy",
-                             (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE )  )
+   if (  Hydro_IsUnphysical_Single( &Entr, "output entropy", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
    {
       printf( "Dens=%13.7e, Eint=%13.7e\n", Dens, Eint );
 #     if ( NCOMP_PASSIVE > 0 )

--- a/src/EoS/User_Template/CPU_EoS_User_Template.cpp
+++ b/src/EoS/User_Template/CPU_EoS_User_Template.cpp
@@ -105,9 +105,9 @@ static real EoS_DensEint2Pres_User_Template( const real Dens, const real Eint, c
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
    if ( AuxArray_Int == NULL )   printf( "ERROR : AuxArray_Int == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 // note that some EoS may support Eint<0
-   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -120,7 +120,7 @@ static real EoS_DensEint2Pres_User_Template( const real Dens, const real Eint, c
 
 // check
 #  ifdef GAMER_DEBUG
-   if (  Hydro_IsUnphysical_Single( &Pres, "output pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
+   if (  Hydro_IsUnphysical_Single( Pres, "output pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
    {
       printf( "Dens=%13.7e, Eint=%13.7e\n", Dens, Eint );
 #     if ( NCOMP_PASSIVE > 0 )
@@ -166,8 +166,8 @@ static real EoS_DensPres2Eint_User_Template( const real Dens, const real Pres, c
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
    if ( AuxArray_Int == NULL )   printf( "ERROR : AuxArray_Int == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -181,7 +181,7 @@ static real EoS_DensPres2Eint_User_Template( const real Dens, const real Pres, c
 // check
 #  ifdef GAMER_DEBUG
 // note that some EoS may support Eint<0
-   if (  Hydro_IsUnphysical_Single( &Eint, "output internal energy", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
+   if (  Hydro_IsUnphysical_Single( Eint, "output internal energy", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
    {
       printf( "Dens=%13.7e, Pres=%13.7e\n", Dens, Pres );
 #     if ( NCOMP_PASSIVE > 0 )
@@ -227,8 +227,8 @@ static real EoS_DensPres2CSqr_User_Template( const real Dens, const real Pres, c
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
    if ( AuxArray_Int == NULL )   printf( "ERROR : AuxArray_Int == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Pres, "input pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -241,7 +241,7 @@ static real EoS_DensPres2CSqr_User_Template( const real Dens, const real Pres, c
 
 // check
 #  ifdef GAMER_DEBUG
-   if (  Hydro_IsUnphysical_Single( &Cs2, "output sound speed squared", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
+   if (  Hydro_IsUnphysical_Single( Cs2, "output sound speed squared", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
    {
       printf( "Dens=%13.7e, Pres=%13.7e\n", Dens, Pres );
 #     if ( NCOMP_PASSIVE > 0 )
@@ -285,9 +285,9 @@ static real EoS_DensEint2Temp_User_Template( const real Dens, const real Eint, c
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 // note that some EoS may support Eint<0
-   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -300,7 +300,7 @@ static real EoS_DensEint2Temp_User_Template( const real Dens, const real Eint, c
 
 // check
 #  ifdef GAMER_DEBUG
-   if (  Hydro_IsUnphysical_Single( &Temp, "output temperature", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
+   if (  Hydro_IsUnphysical_Single( Temp, "output temperature", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
    {
       printf( "Dens=%13.7e, Eint=%13.7e\n", Dens, Eint );
 #     if ( NCOMP_PASSIVE > 0 )
@@ -343,8 +343,8 @@ static real EoS_DensTemp2Pres_User_Template( const real Dens, const real Temp, c
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",     TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Temp, "input temperature", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",     TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Temp, "input temperature", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -357,7 +357,7 @@ static real EoS_DensTemp2Pres_User_Template( const real Dens, const real Temp, c
 
 // check
 #  ifdef GAMER_DEBUG
-   if (  Hydro_IsUnphysical_Single( &Pres, "output pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
+   if (  Hydro_IsUnphysical_Single( Pres, "output pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
    {
       printf( "Dens=%13.7e, Temp=%13.7e\n", Dens, Temp );
 #     if ( NCOMP_PASSIVE > 0 )
@@ -399,9 +399,9 @@ static real EoS_DensEint2Entr_User_Template( const real Dens, const real Eint, c
 #  ifdef GAMER_DEBUG
    if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
 
-   Hydro_IsUnphysical_Single( &Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "input density",         TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 // note that some EoS may support Eint<0
-   Hydro_IsUnphysical_Single( &Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Eint, "input internal energy", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // GAMER_DEBUG
 
 
@@ -414,7 +414,7 @@ static real EoS_DensEint2Entr_User_Template( const real Dens, const real Eint, c
 
 // check
 #  ifdef GAMER_DEBUG
-   if (  Hydro_IsUnphysical_Single( &Entr, "output entropy", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
+   if (  Hydro_IsUnphysical_Single( Entr, "output entropy", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
    {
       printf( "Dens=%13.7e, Eint=%13.7e\n", Dens, Eint );
 #     if ( NCOMP_PASSIVE > 0 )

--- a/src/Fluid/Flu_FixUp_Flux.cpp
+++ b/src/Fluid/Flu_FixUp_Flux.cpp
@@ -242,7 +242,7 @@ void Flu_FixUp_Flux( const int lv, const long TVar )
 
 #              if   ( MODEL == HYDRO )
 #              ifdef SRHD
-               if (  Hydro_IsUnphysical( UNPHY_MODE_CONS, CorrVal, NULL, NULL_REAL, NULL_REAL, NULL_REAL,
+               if (  Hydro_IsUnphysical( UNPHY_MODE_CONS, CorrVal, NULL_REAL,
                                          EoS_DensEint2Pres_CPUPtr, EoS_GuessHTilde_CPUPtr, EoS_HTilde2Temp_CPUPtr,
                                          EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table,
                                          ERROR_INFO, UNPHY_VERBOSE )  )

--- a/src/Fluid/Flu_Prepare.cpp
+++ b/src/Fluid/Flu_Prepare.cpp
@@ -208,7 +208,7 @@ void Flu_Prepare( const int lv, const double PrepTime,
                                                FLU_NXT, FLU_NXT, FLU_NXT, i, j, k );
 #           endif
 
-            if (  Hydro_IsUnphysical( UNPHY_MODE_CONS, fluid, NULL, NULL_REAL, NULL_REAL, Emag,
+            if (  Hydro_IsUnphysical( UNPHY_MODE_CONS, fluid, Emag,
                                       EoS_DensEint2Pres_CPUPtr, EoS_GuessHTilde_CPUPtr, EoS_HTilde2Temp_CPUPtr,
                                       EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table,
                                       ERROR_INFO, UNPHY_VERBOSE )  )

--- a/src/Interpolation/Interpolate.cpp
+++ b/src/Interpolation/Interpolate.cpp
@@ -373,7 +373,7 @@ void Interpolate_Iterate( real CData[], const int CSize[3], const int CStart[3],
 
 //                internal energy cannot be negative (even within machine precision) since a pressure floor has been applied
 //                when calling Hydro_Con2Pri()
-                  if (  Hydro_IsUnphysical_Single( &Eint, "interpolated internal energy", (real)0.0, HUGE_NUMBER,
+                  if (  Hydro_IsUnphysical_Single( Eint, "interpolated internal energy", (real)0.0, HUGE_NUMBER,
                                                    ERROR_INFO, UNPHY_SILENCE )  )
                      Fail_ThisCell = true;
                } // if ( EoS_DensPres2Eint_CPUPtr != NULL )

--- a/src/Interpolation/Interpolate.cpp
+++ b/src/Interpolation/Interpolate.cpp
@@ -374,10 +374,8 @@ void Interpolate_Iterate( real CData[], const int CSize[3], const int CStart[3],
 
 //                internal energy cannot be negative (even within machine precision) since a pressure floor has been applied
 //                when calling Hydro_Con2Pri()
-                  if (  Hydro_IsUnphysical( UNPHY_MODE_SING, &Eint, "interpolated internal energy",
-                                            (real)0.0, HUGE_NUMBER, NULL_REAL,
-                                            NULL, NULL, NULL, NULL, NULL, NULL,
-                                            ERROR_INFO, UNPHY_SILENCE )  )
+                  if (  Hydro_IsUnphysical_Single( &Eint, "interpolated internal energy", (real)0.0, HUGE_NUMBER,
+                                                   ERROR_INFO, UNPHY_SILENCE )  )
                      Fail_ThisCell = true;
                } // if ( EoS_DensPres2Eint_CPUPtr != NULL )
             } // if ( FData_is_Prim )

--- a/src/Interpolation/Interpolate.cpp
+++ b/src/Interpolation/Interpolate.cpp
@@ -341,8 +341,7 @@ void Interpolate_Iterate( real CData[], const int CSize[3], const int CStart[3],
 
 //       5-2. general check
          bool Fail_ThisCell
-            = Hydro_IsUnphysical( (FData_is_Prim)?UNPHY_MODE_PRIM:UNPHY_MODE_CONS, Temp, NULL,
-                                  NULL_REAL, NULL_REAL, Emag,
+            = Hydro_IsUnphysical( (FData_is_Prim)?UNPHY_MODE_PRIM:UNPHY_MODE_CONS, Temp, Emag,
                                   EoS_DensEint2Pres_CPUPtr, EoS_GuessHTilde_CPUPtr, EoS_HTilde2Temp_CPUPtr,
                                   EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table,
                                   ERROR_INFO, UNPHY_SILENCE );
@@ -445,8 +444,7 @@ void Interpolate_Iterate( real CData[], const int CSize[3], const int CStart[3],
                               EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table, NULL );
 
 #              ifdef GAMER_DEBUG
-               if (  Hydro_IsUnphysical( UNPHY_MODE_CONS, Cons, NULL,
-                                         NULL_REAL, NULL_REAL, Emag,
+               if (  Hydro_IsUnphysical( UNPHY_MODE_CONS, Cons, Emag,
                                          EoS_DensEint2Pres_CPUPtr, EoS_GuessHTilde_CPUPtr, EoS_HTilde2Temp_CPUPtr,
                                          EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table,
                                          ERROR_INFO, UNPHY_VERBOSE )  )

--- a/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_RTVD.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_RTVD.cpp
@@ -231,12 +231,8 @@ void CPU_AdvanceX( real u[][ CUBE(FLU_NXT) ], const real dt, const real dx,
                                 EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, NULL );
 
 #        ifdef CHECK_UNPHYSICAL_IN_FLUID
-         Hydro_IsUnphysical( UNPHY_MODE_SING, &p,        "pressure",
-                             (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE );
-         Hydro_IsUnphysical( UNPHY_MODE_SING, &ux[0][i], "density",
-                             TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( &p,        "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( &ux[0][i], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #        endif
 
          c    = FABS( vx ) + SQRT(  EoS->DensPres2CSqr_FuncPtr( ux[0][i], p, Passive, EoS->AuxArrayDevPtr_Flt,
@@ -297,12 +293,8 @@ void CPU_AdvanceX( real u[][ CUBE(FLU_NXT) ], const real dt, const real dx,
                                 EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, NULL );
 
 #        ifdef CHECK_UNPHYSICAL_IN_FLUID
-         Hydro_IsUnphysical( UNPHY_MODE_SING, &p,            "pressure",
-                             (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE );
-         Hydro_IsUnphysical( UNPHY_MODE_SING, &u_half[0][i], "density",
-                             TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( &p,            "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( &u_half[0][i], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #        endif
 
          c    = FABS( vx ) + SQRT(  EoS->DensPres2CSqr_FuncPtr( u_half[0][i], p, Passive, EoS->AuxArrayDevPtr_Flt,
@@ -385,12 +377,8 @@ void CPU_AdvanceX( real u[][ CUBE(FLU_NXT) ], const real dt, const real dx,
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
       for (int i=3; i<FLU_NXT-3; i++)
       {
-         Hydro_IsUnphysical( UNPHY_MODE_SING, &ux[0][i], "density",
-                             TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE );
-         Hydro_IsUnphysical( UNPHY_MODE_SING, &ux[4][i], "energy",
-                             TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( &ux[0][i], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( &ux[4][i], "energy",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
       }
 #     endif
 

--- a/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_RTVD.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_RTVD.cpp
@@ -231,8 +231,8 @@ void CPU_AdvanceX( real u[][ CUBE(FLU_NXT) ], const real dt, const real dx,
                                 EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, NULL );
 
 #        ifdef CHECK_UNPHYSICAL_IN_FLUID
-         Hydro_IsUnphysical_Single( &p,        "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-         Hydro_IsUnphysical_Single( &ux[0][i], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( p,        "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( ux[0][i], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #        endif
 
          c    = FABS( vx ) + SQRT(  EoS->DensPres2CSqr_FuncPtr( ux[0][i], p, Passive, EoS->AuxArrayDevPtr_Flt,
@@ -293,8 +293,8 @@ void CPU_AdvanceX( real u[][ CUBE(FLU_NXT) ], const real dt, const real dx,
                                 EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, NULL );
 
 #        ifdef CHECK_UNPHYSICAL_IN_FLUID
-         Hydro_IsUnphysical_Single( &p,            "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-         Hydro_IsUnphysical_Single( &u_half[0][i], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( p,            "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( u_half[0][i], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #        endif
 
          c    = FABS( vx ) + SQRT(  EoS->DensPres2CSqr_FuncPtr( u_half[0][i], p, Passive, EoS->AuxArrayDevPtr_Flt,
@@ -377,8 +377,8 @@ void CPU_AdvanceX( real u[][ CUBE(FLU_NXT) ], const real dt, const real dx,
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
       for (int i=3; i<FLU_NXT-3; i++)
       {
-         Hydro_IsUnphysical_Single( &ux[0][i], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-         Hydro_IsUnphysical_Single( &ux[4][i], "energy",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( ux[0][i], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( ux[4][i], "energy",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
       }
 #     endif
 

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_ConstrainedTransport.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_ConstrainedTransport.cpp
@@ -670,9 +670,7 @@ void MHD_HalfStepPrimitive( const real g_Flu_In[][ CUBE(FLU_NXT) ],
 
 //    check negative density
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &Output_1Cell[DENS], "density",
-                          TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &Output_1Cell[DENS], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
 

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_ConstrainedTransport.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_ConstrainedTransport.cpp
@@ -670,7 +670,7 @@ void MHD_HalfStepPrimitive( const real g_Flu_In[][ CUBE(FLU_NXT) ],
 
 //    check negative density
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical_Single( &Output_1Cell[DENS], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( Output_1Cell[DENS], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
 

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
@@ -1429,8 +1429,8 @@ void Hydro_Pri2Char( real InOut[], const real Dens, const real Pres, const real 
 #  endif
 
 #  if ( defined CHECK_UNPHYSICAL_IN_FLUID  &&  !defined MHD )
-   Hydro_IsUnphysical_Single( &Pres, "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Dens, "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Pres, "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -1519,8 +1519,8 @@ void Hydro_Char2Pri( real InOut[], const real Dens, const real Pres, const real 
 #  endif
 
 #  if ( defined CHECK_UNPHYSICAL_IN_FLUID  &&  !defined MHD )
-   Hydro_IsUnphysical_Single( &Pres, "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Dens, "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Pres, "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Dens, "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -1622,8 +1622,8 @@ void Hydro_GetEigenSystem( const real CC_Var[], real EigenVal[][NWAVE],
 #  endif
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical_Single( &CC_Var[4], "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &CC_Var[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( CC_Var[4], "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( CC_Var[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -1733,8 +1733,8 @@ void Hydro_GetEigenSystem( const real CC_Var[], real EigenVal[][NWAVE],
    }
    else {
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical_Single( &a2_min_Cs2, "a2_min_Cs2", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical_Single( &Cf2_min_a2, "Cf2_min_a2", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( a2_min_Cs2, "a2_min_Cs2", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( Cf2_min_a2, "Cf2_min_a2", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       const real _Cf2_min_Cs2 = (real)1.0 / Cf2_min_Cs2;
@@ -2111,14 +2111,14 @@ void Hydro_HancockPredict( real fcCon[][NCOMP_LR], const real fcPri[][NCOMP_LR],
 
 #     else
 
-      if (  Hydro_IsUnphysical_Single( &fcCon[f][DENS], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_SILENCE )  )
+      if (  Hydro_IsUnphysical_Single( fcCon[f][DENS], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_SILENCE )  )
          reset_cell = true;
 
 #     ifndef BAROTROPIC_EOS
-      if (  Hydro_IsUnphysical_Single( &fcCon[f][4],    "energy",   TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_SILENCE )  )
+      if (  Hydro_IsUnphysical_Single( fcCon[f][4],    "energy",   TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_SILENCE )  )
          reset_cell = true;
 
-      if (  Hydro_IsUnphysical_Single( &fcPri[f][4],    "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_SILENCE )  )
+      if (  Hydro_IsUnphysical_Single( fcPri[f][4],    "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_SILENCE )  )
          reset_cell = true;
 #     endif // #ifndef BAROTROPIC_EOS
 #     endif // #ifdef SRHD ... else ...

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
@@ -2102,8 +2102,7 @@ void Hydro_HancockPredict( real fcCon[][NCOMP_LR], const real fcPri[][NCOMP_LR],
    for (int f=0; f<6; f++)
    {
 #     ifdef SRHD
-      if (  Hydro_IsUnphysical( UNPHY_MODE_CONS, fcCon[f], NULL,
-                                NULL_REAL, NULL_REAL, NULL_REAL,
+      if (  Hydro_IsUnphysical( UNPHY_MODE_CONS, fcCon[f], NULL_REAL,
                                 EoS->DensEint2Pres_FuncPtr,
                                 EoS->GuessHTilde_FuncPtr, EoS->HTilde2Temp_FuncPtr,
                                 EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table,

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
@@ -1429,12 +1429,8 @@ void Hydro_Pri2Char( real InOut[], const real Dens, const real Pres, const real 
 #  endif
 
 #  if ( defined CHECK_UNPHYSICAL_IN_FLUID  &&  !defined MHD )
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Pres, "pressure",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Pres, "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -1523,12 +1519,8 @@ void Hydro_Char2Pri( real InOut[], const real Dens, const real Pres, const real 
 #  endif
 
 #  if ( defined CHECK_UNPHYSICAL_IN_FLUID  &&  !defined MHD )
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Pres, "pressure",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Dens, "density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Pres, "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Dens, "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -1630,12 +1622,8 @@ void Hydro_GetEigenSystem( const real CC_Var[], real EigenVal[][NWAVE],
 #  endif
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &CC_Var[4], "pressure",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &CC_Var[0], "density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &CC_Var[4], "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &CC_Var[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -1745,12 +1733,8 @@ void Hydro_GetEigenSystem( const real CC_Var[], real EigenVal[][NWAVE],
    }
    else {
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &a2_min_Cs2, "a2_min_Cs2",
-                          (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &Cf2_min_a2, "Cf2_min_a2",
-                          (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &a2_min_Cs2, "a2_min_Cs2", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &Cf2_min_a2, "Cf2_min_a2", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       const real _Cf2_min_Cs2 = (real)1.0 / Cf2_min_Cs2;
@@ -2128,20 +2112,14 @@ void Hydro_HancockPredict( real fcCon[][NCOMP_LR], const real fcPri[][NCOMP_LR],
 
 #     else
 
-      if (  Hydro_IsUnphysical( UNPHY_MODE_SING, &fcCon[f][DENS], "density",
-                                TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                                ERROR_INFO, UNPHY_SILENCE )  )
+      if (  Hydro_IsUnphysical_Single( &fcCon[f][DENS], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_SILENCE )  )
          reset_cell = true;
 
 #     ifndef BAROTROPIC_EOS
-      if (  Hydro_IsUnphysical( UNPHY_MODE_SING, &fcCon[f][4], "energy",
-                                TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                                ERROR_INFO, UNPHY_SILENCE )  )
+      if (  Hydro_IsUnphysical_Single( &fcCon[f][4],    "energy",   TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_SILENCE )  )
          reset_cell = true;
 
-      if (  Hydro_IsUnphysical( UNPHY_MODE_SING, &fcPri[f][4], "pressure",
-                                (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                                ERROR_INFO, UNPHY_SILENCE )  )
+      if (  Hydro_IsUnphysical_Single( &fcPri[f][4],    "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_SILENCE )  )
          reset_cell = true;
 #     endif // #ifndef BAROTROPIC_EOS
 #     endif // #ifdef SRHD ... else ...

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_FluUtility.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_FluUtility.cpp
@@ -1188,7 +1188,7 @@ real Hydro_Con2Pres( const real Dens, const real MomX, const real MomY, const re
 
 // check unphysical results
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   if (  Hydro_IsUnphysical_Single( &Pres, "output pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
+   if (  Hydro_IsUnphysical_Single( Pres, "output pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
    {
       printf( "Input: Dens %14.7e MomX %14.7e MomY %14.7e MomZ %14.7e Engy %14.7e",
               Dens, MomX, MomY, MomZ, Engy );

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_FluUtility.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_FluUtility.cpp
@@ -932,7 +932,7 @@ bool Hydro_IsUnphysical( const IsUnphyMode_t Mode, const real Fields[],
 
 //       print out the unphysical values
 #        if ( !defined __CUDACC__  ||  defined CHECK_UNPHYSICAL_IN_FLUID )
-         if ( UnphyCell && Verbose )
+         if ( UnphyCell  &&  Verbose )
          {
             printf( "ERROR : unphysical conserved variables at file <%s>, line <%d>, function <%s> !!\n",
                     File, Line, Function );
@@ -1008,7 +1008,7 @@ bool Hydro_IsUnphysical( const IsUnphyMode_t Mode, const real Fields[],
 
 //       print out the unphysical values
 #        if ( !defined __CUDACC__  ||  defined CHECK_UNPHYSICAL_IN_FLUID )
-         if ( UnphyCell && Verbose )
+         if ( UnphyCell  &&  Verbose )
          {
             printf( "ERROR : unphysical primitive variables at file <%s>, line <%d>, function <%s> !!\n",
                     File, Line, Function );
@@ -1045,7 +1045,7 @@ bool Hydro_IsUnphysical( const IsUnphyMode_t Mode, const real Fields[],
 
 //       print out the unphysical values
 #        if ( !defined __CUDACC__  ||  defined CHECK_UNPHYSICAL_IN_FLUID )
-         if ( UnphyCell && Verbose )
+         if ( UnphyCell  &&  Verbose )
          {
             printf( "ERROR : unphysical passive scalars at file <%s>, line <%d>, function <%s> !!\n",
                     File, Line, Function );
@@ -1098,7 +1098,8 @@ GPU_DEVICE
 bool Hydro_IsUnphysical_Single( const real Fields[], const char SingleFieldName[], const real Min, const real Max,
                                 const char File[], const int Line, const char Function[], const IsUnphVerb_t Verbose )
 {
-   // check
+
+// check
 #  ifdef GAMER_DEBUG
    if ( Fields == NULL )   printf( "ERROR : access a NULL pointer at file <%s>, line <%d>, function <%s> !!\n",
                                    File, Line, Function );
@@ -1112,7 +1113,7 @@ bool Hydro_IsUnphysical_Single( const real Fields[], const char SingleFieldName[
 
 // print out the unphysical value
 #  if ( !defined __CUDACC__  ||  defined CHECK_UNPHYSICAL_IN_FLUID )
-   if ( UnphyCell && Verbose )
+   if ( UnphyCell  &&  Verbose )
       printf( "ERROR : invalid %s = %14.7e (min %14.7e, max %14.7e) at file <%s>, line <%d>, function <%s> !!\n",
                (SingleFieldName==NULL)?"unknown field":SingleFieldName, Fields[0], Min, Max,
                File, Line, Function );

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_FluUtility.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_FluUtility.cpp
@@ -43,7 +43,7 @@ static bool Hydro_IsUnphysical( const IsUnphyMode_t Mode, const real Fields[],
                                 const real *const EoS_Table[EOS_NTABLE_MAX],
                                 const char File[], const int Line, const char Function[], const IsUnphVerb_t Verbose );
 GPU_DEVICE
-static bool Hydro_IsUnphysical_Single( const real Fields[], const char SingleFieldName[], const real Min, const real Max,
+static bool Hydro_IsUnphysical_Single( const real Field, const char SingleFieldName[], const real Min, const real Max,
                                        const char File[], const int Line, const char Function[], const IsUnphVerb_t Verbose );
 #ifdef SRHD
 GPU_DEVICE
@@ -1082,7 +1082,7 @@ bool Hydro_IsUnphysical( const IsUnphyMode_t Mode, const real Fields[],
 // Function    :  Hydro_IsUnphysical_Single
 // Description :  Check if the input field is NAN or lies outside the accepted range
 //
-// Parameter   :  Fields            : Field data to be checked
+// Parameter   :  Field             : Field data to be checked
 //                SingleFieldName   : Name of the target field
 //                Min/Max           : Accepted range
 //                File              : __FILE__
@@ -1095,27 +1095,21 @@ bool Hydro_IsUnphysical( const IsUnphyMode_t Mode, const real Fields[],
 //                false --> Otherwise
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE
-bool Hydro_IsUnphysical_Single( const real Fields[], const char SingleFieldName[], const real Min, const real Max,
+bool Hydro_IsUnphysical_Single( const real Field, const char SingleFieldName[], const real Min, const real Max,
                                 const char File[], const int Line, const char Function[], const IsUnphVerb_t Verbose )
 {
-
-// check
-#  ifdef GAMER_DEBUG
-   if ( Fields == NULL )   printf( "ERROR : access a NULL pointer at file <%s>, line <%d>, function <%s> !!\n",
-                                   File, Line, Function );
-#  endif
 
    bool UnphyCell = false;
 
 // check if the input single field is NAN or lies outside the accepted range
-   if ( Fields[0] < Min  ||  Fields[0] > Max  ||  Fields[0] != Fields[0] )
+   if ( Field < Min  ||  Field > Max  ||  Field != Field )
       UnphyCell = true;
 
 // print out the unphysical value
 #  if ( !defined __CUDACC__  ||  defined CHECK_UNPHYSICAL_IN_FLUID )
    if ( UnphyCell  &&  Verbose )
       printf( "ERROR : invalid %s = %14.7e (min %14.7e, max %14.7e) at file <%s>, line <%d>, function <%s> !!\n",
-               (SingleFieldName==NULL)?"unknown field":SingleFieldName, Fields[0], Min, Max,
+               (SingleFieldName==NULL)?"unknown field":SingleFieldName, Field, Min, Max,
                File, Line, Function );
 #  endif
 

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_FluUtility.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_FluUtility.cpp
@@ -219,8 +219,7 @@ void Hydro_Con2Pri( const real In[], real Out[], const real MinPres,
    real HTilde, Factor, Temp, LorentzFactor;
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_CONS, In, NULL,
-                       NULL_REAL, NULL_REAL, NULL_REAL,
+   Hydro_IsUnphysical( UNPHY_MODE_CONS, In, NULL_REAL,
                        EoS_DensEint2Pres, EoS_GuessHTilde, EoS_HTilde2Temp,
                        EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table,
                        ERROR_INFO, UNPHY_VERBOSE );

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_FluUtility.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_FluUtility.cpp
@@ -1217,9 +1217,7 @@ real Hydro_Con2Pres( const real Dens, const real MomX, const real MomY, const re
 
 // check unphysical results
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   if (  Hydro_IsUnphysical( UNPHY_MODE_SING, &Pres, "output pressure",
-                             (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE )  )
+   if (  Hydro_IsUnphysical_Single( &Pres, "output pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE )  )
    {
       printf( "Input: Dens %14.7e MomX %14.7e MomY %14.7e MomZ %14.7e Engy %14.7e",
               Dens, MomX, MomY, MomZ, Engy );

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_FullStepUpdate.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_FullStepUpdate.cpp
@@ -178,8 +178,7 @@ void Hydro_FullStepUpdate( const real g_Input[][ CUBE(FLU_NXT) ], real g_Output[
 
 //       5-1. check
 //       --> allow pressure to be zero to tolerate round-off errors
-         if (  Hydro_IsUnphysical( UNPHY_MODE_CONS, Output_1Cell, NULL,
-                                   NULL_REAL, NULL_REAL, Emag,
+         if (  Hydro_IsUnphysical( UNPHY_MODE_CONS, Output_1Cell, Emag,
                                    EoS->DensEint2Pres_FuncPtr,
                                    EoS->GuessHTilde_FuncPtr, EoS->HTilde2Temp_FuncPtr,
                                    EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table,

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_Exact.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_Exact.cpp
@@ -210,10 +210,10 @@ void Hydro_RiemannSolver_Exact( const int XYZ, real Flux_Out[], const real L_In[
       L_star[0] = L[0]*POW( L_star[4]/L[4], (real)1.0/Gamma );    // solution of density
 
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical_Single( &L[4],      "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical_Single( &L[0],      "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical_Single( &L_star[4], "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical_Single( &L_star[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( L[4],      "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( L[0],      "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( L_star[4], "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( L_star[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       real a_L    = SQRT( Gamma * L[4] / L[0] );                  // sound speed of left region
@@ -239,10 +239,10 @@ void Hydro_RiemannSolver_Exact( const int XYZ, real Flux_Out[], const real L_In[
       R_star[0] = R[0]*POW( R_star[4]/R[4], (real)1.0/Gamma ); // solution of density
 
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical_Single( &R[4],      "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical_Single( &R[0],      "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical_Single( &R_star[4], "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical_Single( &R_star[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( R[4],      "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( R[0],      "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( R_star[4], "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( R_star[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       real a_R    = SQRT( Gamma * R[4] / R[0] ); // sound speed of right region
@@ -262,10 +262,10 @@ void Hydro_RiemannSolver_Exact( const int XYZ, real Flux_Out[], const real L_In[
    eival[3] = L_star[1];
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical_Single( &R[4], "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &R[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &L[4], "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &L[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( R[4], "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( R[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( L[4], "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( L[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
    if ( L[4] < L_star[4] ) // left shock
@@ -273,7 +273,7 @@ void Hydro_RiemannSolver_Exact( const int XYZ, real Flux_Out[], const real L_In[
       Temp = (real)0.5/Gamma*( Gamma_p1*L_star[4]/L[4] + Gamma_m1 );
 
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical_Single( &Temp, "value", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( Temp, "value", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       eival[0] = L[1] - SQRT( Gamma*L[4]/L[0] )*SQRT( Temp );
@@ -286,7 +286,7 @@ void Hydro_RiemannSolver_Exact( const int XYZ, real Flux_Out[], const real L_In[
       Temp = (real)0.5/Gamma*( Gamma_p1*R_star[4]/R[4] + Gamma_m1 );
 
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical_Single( &Temp, "value", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( Temp, "value", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       eival[4] = R[1] + SQRT( Gamma*R[4]/R[0] )*SQRT( Temp );
@@ -372,7 +372,7 @@ real Solve_f( const real rho, const real p, const real p_star, const real Gamma 
       Temp   = A/(p_star+B);
 
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical_Single( &Temp, "value", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( Temp, "value", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       f = (p_star-p)*SQRT( Temp );
@@ -381,8 +381,8 @@ real Solve_f( const real rho, const real p, const real p_star, const real Gamma 
    else
    {
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical_Single( &p,   "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical_Single( &rho, "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( p,   "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( rho, "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       real a = SQRT( Gamma*p/rho );

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_Exact.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_Exact.cpp
@@ -210,18 +210,10 @@ void Hydro_RiemannSolver_Exact( const int XYZ, real Flux_Out[], const real L_In[
       L_star[0] = L[0]*POW( L_star[4]/L[4], (real)1.0/Gamma );    // solution of density
 
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &L[4],      "pressure",
-                          (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &L[0],      "density",
-                          TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &L_star[4], "pressure",
-                          (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &L_star[0], "density",
-                          TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &L[4],      "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &L[0],      "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &L_star[4], "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &L_star[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       real a_L    = SQRT( Gamma * L[4] / L[0] );                  // sound speed of left region
@@ -247,18 +239,10 @@ void Hydro_RiemannSolver_Exact( const int XYZ, real Flux_Out[], const real L_In[
       R_star[0] = R[0]*POW( R_star[4]/R[4], (real)1.0/Gamma ); // solution of density
 
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &R[4],      "pressure",
-                          (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &R[0],      "density",
-                          TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &R_star[4], "pressure",
-                          (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &R_star[0], "density",
-                          TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &R[4],      "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &R[0],      "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &R_star[4], "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &R_star[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       real a_R    = SQRT( Gamma * R[4] / R[0] ); // sound speed of right region
@@ -278,18 +262,10 @@ void Hydro_RiemannSolver_Exact( const int XYZ, real Flux_Out[], const real L_In[
    eival[3] = L_star[1];
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &R[4], "pressure",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &R[0], "density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &L[4], "pressure",
-                       (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &L[0], "density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &R[4], "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &R[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &L[4], "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &L[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
    if ( L[4] < L_star[4] ) // left shock
@@ -297,9 +273,7 @@ void Hydro_RiemannSolver_Exact( const int XYZ, real Flux_Out[], const real L_In[
       Temp = (real)0.5/Gamma*( Gamma_p1*L_star[4]/L[4] + Gamma_m1 );
 
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &Temp, "value",
-                          (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &Temp, "value", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       eival[0] = L[1] - SQRT( Gamma*L[4]/L[0] )*SQRT( Temp );
@@ -312,9 +286,7 @@ void Hydro_RiemannSolver_Exact( const int XYZ, real Flux_Out[], const real L_In[
       Temp = (real)0.5/Gamma*( Gamma_p1*R_star[4]/R[4] + Gamma_m1 );
 
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &Temp, "value",
-                          (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &Temp, "value", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       eival[4] = R[1] + SQRT( Gamma*R[4]/R[0] )*SQRT( Temp );
@@ -400,9 +372,7 @@ real Solve_f( const real rho, const real p, const real p_star, const real Gamma 
       Temp   = A/(p_star+B);
 
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &Temp, "value",
-                          (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &Temp, "value", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       f = (p_star-p)*SQRT( Temp );
@@ -411,12 +381,8 @@ real Solve_f( const real rho, const real p, const real p_star, const real Gamma 
    else
    {
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &p,   "pressure",
-                          (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &rho, "density",
-                          TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &p,   "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &rho, "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       real a = SQRT( Gamma*p/rho );

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLC.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLC.cpp
@@ -409,8 +409,8 @@ void Hydro_RiemannSolver_HLLC( const int XYZ, real Flux_Out[], const real L_In[]
    Hydro_Rotate3D( R, XYZ, true, MAG_OFFSET );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical_Single( &L[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &R[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( L[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( R[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -440,8 +440,8 @@ void Hydro_RiemannSolver_HLLC( const int XYZ, real Flux_Out[], const real L_In[]
    Cs_R  = SQRT(  EoS_DensPres2CSqr( R[0], P_R, R+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table )  );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical_Single( &P_R, "pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &P_L, "pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( P_R, "pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( P_L, "pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -487,7 +487,7 @@ void Hydro_RiemannSolver_HLLC( const int XYZ, real Flux_Out[], const real L_In[]
    Cs_Roe   = SQRT( Cs2_Roe );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical_Single( &Cs2_Roe, "Cs2_Roe", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Cs2_Roe, "Cs2_Roe", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 // maximum and minimum eigenvalues
@@ -538,8 +538,8 @@ void Hydro_RiemannSolver_HLLC( const int XYZ, real Flux_Out[], const real L_In[]
    W_R = u_R + Cs_R*q_R;
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical_Single( &q_L, "q_L", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &q_R, "q_R", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( q_L, "q_L", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( q_R, "q_R", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLC.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLC.cpp
@@ -77,13 +77,11 @@ void Hydro_RiemannSolver_HLLC( const int XYZ, real Flux_Out[], const real L_In[]
    Hydro_Rotate3D( R, XYZ, true, MAG_OFFSET );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_CONS, L, NULL,
-                       NULL_REAL, NULL_REAL, NULL_REAL,
+   Hydro_IsUnphysical( UNPHY_MODE_CONS, L, NULL_REAL,
                        EoS_DensEint2Pres, EoS_GuessHTilde, EoS_HTilde2Temp,
                        EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table,
                        ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_CONS, R, NULL,
-                       NULL_REAL, NULL_REAL, NULL_REAL,
+   Hydro_IsUnphysical( UNPHY_MODE_CONS, R, NULL_REAL,
                        EoS_DensEint2Pres, EoS_GuessHTilde, EoS_HTilde2Temp,
                        EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table,
                        ERROR_INFO, UNPHY_VERBOSE );
@@ -112,13 +110,11 @@ void Hydro_RiemannSolver_HLLC( const int XYZ, real Flux_Out[], const real L_In[]
                   EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL, &rFactor );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_PRIM, PL, NULL,
-                       NULL_REAL, NULL_REAL, NULL_REAL,
+   Hydro_IsUnphysical( UNPHY_MODE_PRIM, PL, NULL_REAL,
                        EoS_DensEint2Pres, EoS_GuessHTilde, EoS_HTilde2Temp,
                        EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table,
                        ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_PRIM, PR, NULL,
-                       NULL_REAL, NULL_REAL, NULL_REAL,
+   Hydro_IsUnphysical( UNPHY_MODE_PRIM, PR, NULL_REAL,
                        EoS_DensEint2Pres, EoS_GuessHTilde, EoS_HTilde2Temp,
                        EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table,
                        ERROR_INFO, UNPHY_VERBOSE );

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLC.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLC.cpp
@@ -413,12 +413,8 @@ void Hydro_RiemannSolver_HLLC( const int XYZ, real Flux_Out[], const real L_In[]
    Hydro_Rotate3D( R, XYZ, true, MAG_OFFSET );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &L[0], "density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &R[0], "density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &L[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &R[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -448,12 +444,8 @@ void Hydro_RiemannSolver_HLLC( const int XYZ, real Flux_Out[], const real L_In[]
    Cs_R  = SQRT(  EoS_DensPres2CSqr( R[0], P_R, R+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table )  );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &P_R, "pressure",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &P_L, "pressure",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &P_R, "pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &P_L, "pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -499,9 +491,7 @@ void Hydro_RiemannSolver_HLLC( const int XYZ, real Flux_Out[], const real L_In[]
    Cs_Roe   = SQRT( Cs2_Roe );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Cs2_Roe, "Cs2_Roe",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Cs2_Roe, "Cs2_Roe", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 // maximum and minimum eigenvalues
@@ -552,12 +542,8 @@ void Hydro_RiemannSolver_HLLC( const int XYZ, real Flux_Out[], const real L_In[]
    W_R = u_R + Cs_R*q_R;
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &q_L, "q_L",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &q_R, "q_R",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &q_L, "q_L", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &q_R, "q_R", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLD.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLD.cpp
@@ -231,8 +231,8 @@ void Hydro_RiemannSolver_HLLD( const int XYZ, real Flux_Out[], const real L_In[]
    sqrt_RhoRst    = SQRT( Con_Rst[0] );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical_Single( &Con_Lst[0], "Con_Lst[0]", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &Con_Rst[0], "Con_Rst[0]", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Con_Lst[0], "Con_Lst[0]", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Con_Rst[0], "Con_Rst[0]", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
    tmp_1          = FABS( Bx );

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLD.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLD.cpp
@@ -231,12 +231,8 @@ void Hydro_RiemannSolver_HLLD( const int XYZ, real Flux_Out[], const real L_In[]
    sqrt_RhoRst    = SQRT( Con_Rst[0] );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Con_Lst[0], "Con_Lst[0]",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Con_Rst[0], "Con_Rst[0]",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Con_Lst[0], "Con_Lst[0]", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Con_Rst[0], "Con_Rst[0]", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
    tmp_1          = FABS( Bx );

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLE.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLE.cpp
@@ -321,12 +321,8 @@ void Hydro_RiemannSolver_HLLE( const int XYZ, real Flux_Out[], const real L_In[]
    Hydro_Rotate3D( R, XYZ, true, MAG_OFFSET );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &L[0], "density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &R[0], "density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &L[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &R[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -381,12 +377,8 @@ void Hydro_RiemannSolver_HLLE( const int XYZ, real Flux_Out[], const real L_In[]
    a2_R  = EoS_DensPres2CSqr( R[0], P_R, R+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &P_L, "pressure",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &P_R, "pressure",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &P_L, "pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &P_R, "pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 #  if ( defined GAMER_DEBUG  &&  defined MHD )
@@ -517,9 +509,7 @@ void Hydro_RiemannSolver_HLLE( const int XYZ, real Flux_Out[], const real L_In[]
    a2_Roe  = Gamma*_Rho_Roe*Hydro_CheckMinPres( a2_Roe*Rho_Roe*_Gamma, MinPres );   // apply pressure floor
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &a2_Roe, "a2_Roe",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &a2_Roe, "a2_Roe", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // #ifdef CHECK_UNPHYSICAL_IN_FLUID
 
 #  ifdef MHD
@@ -540,14 +530,10 @@ void Hydro_RiemannSolver_HLLE( const int XYZ, real Flux_Out[], const real L_In[]
    Cf2_min_Cs2_Roe = SQRT( SQR(Ca2_min_a2_Roe) + (real)4.0*a2_Roe*Cat2_Roe );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &a2_Roe, "a2_Roe",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &a2_Roe,      "a2_Roe",     (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 
 #  ifdef MHD
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Gamma_m1_mY, "Gamma_m1-Y",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Gamma_m1_mY, "Gamma_m1-Y", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 #  endif // #ifdef CHECK_UNPHYSICAL_IN_FLUID
 
@@ -630,12 +616,8 @@ void Hydro_RiemannSolver_HLLE( const int XYZ, real Flux_Out[], const real L_In[]
    MaxV_R = FMAX( MaxV_R, ZERO );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &q_L, "q_L",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &q_R, "q_R",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &q_L, "q_L", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &q_R, "q_R", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLE.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLE.cpp
@@ -77,13 +77,11 @@ void Hydro_RiemannSolver_HLLE( const int XYZ, real Flux_Out[], const real L_In[]
    Hydro_Rotate3D( R, XYZ, true, MAG_OFFSET );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_CONS, L, NULL,
-                       NULL_REAL, NULL_REAL, NULL_REAL,
+   Hydro_IsUnphysical( UNPHY_MODE_CONS, L, NULL_REAL,
                        EoS_DensEint2Pres, EoS_GuessHTilde, EoS_HTilde2Temp,
                        EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table,
                        ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_CONS, R, NULL,
-                       NULL_REAL, NULL_REAL, NULL_REAL,
+   Hydro_IsUnphysical( UNPHY_MODE_CONS, R, NULL_REAL,
                        EoS_DensEint2Pres, EoS_GuessHTilde, EoS_HTilde2Temp,
                        EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table,
                        ERROR_INFO, UNPHY_VERBOSE );

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLE.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLE.cpp
@@ -319,8 +319,8 @@ void Hydro_RiemannSolver_HLLE( const int XYZ, real Flux_Out[], const real L_In[]
    Hydro_Rotate3D( R, XYZ, true, MAG_OFFSET );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical_Single( &L[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &R[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( L[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( R[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 
@@ -375,8 +375,8 @@ void Hydro_RiemannSolver_HLLE( const int XYZ, real Flux_Out[], const real L_In[]
    a2_R  = EoS_DensPres2CSqr( R[0], P_R, R+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical_Single( &P_L, "pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &P_R, "pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( P_L, "pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( P_R, "pressure", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 #  if ( defined GAMER_DEBUG  &&  defined MHD )
@@ -507,7 +507,7 @@ void Hydro_RiemannSolver_HLLE( const int XYZ, real Flux_Out[], const real L_In[]
    a2_Roe  = Gamma*_Rho_Roe*Hydro_CheckMinPres( a2_Roe*Rho_Roe*_Gamma, MinPres );   // apply pressure floor
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical_Single( &a2_Roe, "a2_Roe", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( a2_Roe, "a2_Roe", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif // #ifdef CHECK_UNPHYSICAL_IN_FLUID
 
 #  ifdef MHD
@@ -528,10 +528,10 @@ void Hydro_RiemannSolver_HLLE( const int XYZ, real Flux_Out[], const real L_In[]
    Cf2_min_Cs2_Roe = SQRT( SQR(Ca2_min_a2_Roe) + (real)4.0*a2_Roe*Cat2_Roe );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical_Single( &a2_Roe,      "a2_Roe",     (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( a2_Roe,      "a2_Roe",     (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 
 #  ifdef MHD
-   Hydro_IsUnphysical_Single( &Gamma_m1_mY, "Gamma_m1-Y", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Gamma_m1_mY, "Gamma_m1-Y", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 #  endif // #ifdef CHECK_UNPHYSICAL_IN_FLUID
 
@@ -614,8 +614,8 @@ void Hydro_RiemannSolver_HLLE( const int XYZ, real Flux_Out[], const real L_In[]
    MaxV_R = FMAX( MaxV_R, ZERO );
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical_Single( &q_L, "q_L", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &q_R, "q_R", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( q_L, "q_L", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( q_R, "q_R", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
 

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_Roe.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_Roe.cpp
@@ -173,12 +173,8 @@ void Hydro_RiemannSolver_Roe( const int XYZ, real Flux_Out[], const real L_In[],
 #  endif
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &L[0], "density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &R[0], "density",
-                       TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &L[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &R[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
    RhoL_sqrt       = SQRT( L[0] );
@@ -217,9 +213,7 @@ void Hydro_RiemannSolver_Roe( const int XYZ, real Flux_Out[], const real L_In[],
    Bn_star      = SQRT( Gamma_m1_mY )*Bn;
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &Gamma_m1_mY, "Gamma_m1-Y",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &Gamma_m1_mY, "Gamma_m1-Y", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
    if ( Bn == ZERO ) {
@@ -256,9 +250,7 @@ void Hydro_RiemannSolver_Roe( const int XYZ, real Flux_Out[], const real L_In[],
    a2 -= X;
 #  endif
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical( UNPHY_MODE_SING, &a2, "a2",
-                       (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                       ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( &a2, "a2", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
    a  = SQRT( a2 );
 
@@ -320,12 +312,8 @@ void Hydro_RiemannSolver_Roe( const int XYZ, real Flux_Out[], const real L_In[],
    }
    else {
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &a2_min_Cs2, "a2_min_Cs2",
-                          (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &Cf2_min_a2, "Cf2_min_a2",
-                          (real)0.0, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &a2_min_Cs2, "a2_min_Cs2", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &Cf2_min_a2, "Cf2_min_a2", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       const real _Cf2_min_Cs2 = ONE/Cf2_min_Cs2;

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_Roe.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_Roe.cpp
@@ -173,8 +173,8 @@ void Hydro_RiemannSolver_Roe( const int XYZ, real Flux_Out[], const real L_In[],
 #  endif
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical_Single( &L[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-   Hydro_IsUnphysical_Single( &R[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( L[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( R[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
    RhoL_sqrt       = SQRT( L[0] );
@@ -213,7 +213,7 @@ void Hydro_RiemannSolver_Roe( const int XYZ, real Flux_Out[], const real L_In[],
    Bn_star      = SQRT( Gamma_m1_mY )*Bn;
 
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical_Single( &Gamma_m1_mY, "Gamma_m1-Y", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( Gamma_m1_mY, "Gamma_m1-Y", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
 
    if ( Bn == ZERO ) {
@@ -250,7 +250,7 @@ void Hydro_RiemannSolver_Roe( const int XYZ, real Flux_Out[], const real L_In[],
    a2 -= X;
 #  endif
 #  ifdef CHECK_UNPHYSICAL_IN_FLUID
-   Hydro_IsUnphysical_Single( &a2, "a2", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+   Hydro_IsUnphysical_Single( a2, "a2", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #  endif
    a  = SQRT( a2 );
 
@@ -312,8 +312,8 @@ void Hydro_RiemannSolver_Roe( const int XYZ, real Flux_Out[], const real L_In[],
    }
    else {
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical_Single( &a2_min_Cs2, "a2_min_Cs2", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical_Single( &Cf2_min_a2, "Cf2_min_a2", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( a2_min_Cs2, "a2_min_Cs2", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( Cf2_min_a2, "Cf2_min_a2", (real)0.0, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
 
       const real _Cf2_min_Cs2 = ONE/Cf2_min_Cs2;

--- a/src/Model_Hydro/GPU_Hydro/CUFLU_FluidSolver_RTVD.cu
+++ b/src/Model_Hydro/GPU_Hydro/CUFLU_FluidSolver_RTVD.cu
@@ -196,8 +196,8 @@ __device__ void CUFLU_Advance( real g_Fluid_In [][5][ CUBE(FLU_NXT) ],
                              EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, NULL );
 
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical_Single( &p,        "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical_Single( &Fluid[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( p,        "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( Fluid[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
       c    = FABS( vx ) + SQRT(  EoS->DensPres2CSqr_FuncPtr( Fluid[0], p, Passive, EoS->AuxArrayDevPtr_Flt,
                                                              EoS->AuxArrayDevPtr_Int, EoS->Table )  );
@@ -255,8 +255,8 @@ __device__ void CUFLU_Advance( real g_Fluid_In [][5][ CUBE(FLU_NXT) ],
                                 EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, NULL );
 
 #        ifdef CHECK_UNPHYSICAL_IN_FLUID
-         Hydro_IsUnphysical_Single( &p,             "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-         Hydro_IsUnphysical_Single( &Fluid_half[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( p,             "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( Fluid_half[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #        endif
 
          c    = FABS( vx ) + SQRT(  EoS->DensPres2CSqr_FuncPtr( Fluid_half[0], p, Passive, EoS->AuxArrayDevPtr_Flt,
@@ -344,8 +344,8 @@ __device__ void CUFLU_Advance( real g_Fluid_In [][5][ CUBE(FLU_NXT) ],
 
 //       check negative density and energy
 #        ifdef CHECK_UNPHYSICAL_IN_FLUID
-         Hydro_IsUnphysical_Single( &Fluid[4], "energy",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
-         Hydro_IsUnphysical_Single( &Fluid[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( Fluid[4], "energy",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( Fluid[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #        endif
 
 

--- a/src/Model_Hydro/GPU_Hydro/CUFLU_FluidSolver_RTVD.cu
+++ b/src/Model_Hydro/GPU_Hydro/CUFLU_FluidSolver_RTVD.cu
@@ -196,12 +196,8 @@ __device__ void CUFLU_Advance( real g_Fluid_In [][5][ CUBE(FLU_NXT) ],
                              EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, NULL );
 
 #     ifdef CHECK_UNPHYSICAL_IN_FLUID
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &p,        "pressure",
-                          (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
-      Hydro_IsUnphysical( UNPHY_MODE_SING, &Fluid[0], "density",
-                          TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                          ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &p,        "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+      Hydro_IsUnphysical_Single( &Fluid[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #     endif
       c    = FABS( vx ) + SQRT(  EoS->DensPres2CSqr_FuncPtr( Fluid[0], p, Passive, EoS->AuxArrayDevPtr_Flt,
                                                              EoS->AuxArrayDevPtr_Int, EoS->Table )  );
@@ -259,12 +255,8 @@ __device__ void CUFLU_Advance( real g_Fluid_In [][5][ CUBE(FLU_NXT) ],
                                 EoS->AuxArrayDevPtr_Flt, EoS->AuxArrayDevPtr_Int, EoS->Table, NULL );
 
 #        ifdef CHECK_UNPHYSICAL_IN_FLUID
-         Hydro_IsUnphysical( UNPHY_MODE_SING, &p,             "pressure",
-                             (real)0.0,   HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE );
-         Hydro_IsUnphysical( UNPHY_MODE_SING, &Fluid_half[0], "density",
-                             TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( &p,             "pressure", (real)0.0,   HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( &Fluid_half[0], "density",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #        endif
 
          c    = FABS( vx ) + SQRT(  EoS->DensPres2CSqr_FuncPtr( Fluid_half[0], p, Passive, EoS->AuxArrayDevPtr_Flt,
@@ -352,12 +344,8 @@ __device__ void CUFLU_Advance( real g_Fluid_In [][5][ CUBE(FLU_NXT) ],
 
 //       check negative density and energy
 #        ifdef CHECK_UNPHYSICAL_IN_FLUID
-         Hydro_IsUnphysical( UNPHY_MODE_SING, &Fluid[4], "energy",
-                             TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE );
-         Hydro_IsUnphysical( UNPHY_MODE_SING, &Fluid[0], "density",
-                             TINY_NUMBER, HUGE_NUMBER, NULL_REAL, NULL, NULL, NULL, NULL, NULL, NULL,
-                             ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( &Fluid[4], "energy",  TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
+         Hydro_IsUnphysical_Single( &Fluid[0], "density", TINY_NUMBER, HUGE_NUMBER, ERROR_INFO, UNPHY_VERBOSE );
 #        endif
 
 

--- a/src/Refine/Flag_Real.cpp
+++ b/src/Refine/Flag_Real.cpp
@@ -433,8 +433,7 @@ void Flag_Real( const int lv, const UseLBFunc_t UseLBFunc )
                                                 Fluid[MOMZ][k][j][i], Fluid[ENGY][k][j][i] };
 
 #                    ifdef CHECK_UNPHYSICAL_IN_FLUID
-                     Hydro_IsUnphysical( UNPHY_MODE_CONS, Cons, NULL,
-                                         NULL_REAL, NULL_REAL, NULL_REAL,
+                     Hydro_IsUnphysical( UNPHY_MODE_CONS, Cons, NULL_REAL,
                                          EoS_DensEint2Pres_CPUPtr, EoS_GuessHTilde_CPUPtr, EoS_HTilde2Temp_CPUPtr,
                                          EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table,
                                          ERROR_INFO, UNPHY_VERBOSE );


### PR DESCRIPTION
## Summary
Refactor the `Hydro_IsUnphysical` function by splitting it into two separate functions: `Hydro_IsUnphysical` and `Hydro_IsUnphysical_Single`.

## Rationale
The original `Hydro_IsUnphysical` function is called at 127 different places, handling both single-field and multi-field checks within the same function. The large amount of calls makes it hard to maintain the code while changing the header.

## Changes
* [`include/Prototype.h`](diffhunk://#diff-99eb5d5664fe0e75da0e69c3a473984de0d6efbcb469ff4ef10a1930aa84145dL139-R146): Split the `Hydro_IsUnphysical` function into `Hydro_IsUnphysical` and `Hydro_IsUnphysical_Single`.
Original `Hydro_IsUnphysical`:
```c++
bool Hydro_IsUnphysical( const IsUnphyMode_t Mode, const real Fields[], const char SingleFieldName[],
                         const real Min, const real Max, const real Emag,
                         const EoS_DE2P_t EoS_DensEint2Pres,
                         const EoS_GUESS_t EoS_GuessHTilde, const EoS_H2TEM_t EoS_HTilde2Temp,
                         const double EoS_AuxArray_Flt[], const int EoS_AuxArray_Int[],
                         const real *const EoS_Table[EOS_NTABLE_MAX],
                         const char File[], const int Line, const char Function[], const IsUnphVerb_t Verbose );
```
Refactored `Hydro_IsUnphysical`, removing `Mode=UNPHY_MODE_SING` and the parameters `SingleFieldName`, `Min` and `Max`:
```c++
bool Hydro_IsUnphysical( const IsUnphyMode_t Mode, const real Fields[],
                         const real Emag, const EoS_DE2P_t EoS_DensEint2Pres,
                         const EoS_GUESS_t EoS_GuessHTilde, const EoS_H2TEM_t EoS_HTilde2Temp,
                         const double EoS_AuxArray_Flt[], const int EoS_AuxArray_Int[],
                         const real *const EoS_Table[EOS_NTABLE_MAX],
                         const char File[], const int Line, const char Function[], const IsUnphVerb_t Verbose );
```
New `Hydro_IsUnphysical_Single`:
```c++
bool Hydro_IsUnphysical_Single( const real Fields[], const char SingleFieldName[], const real Min, const real Max,
                                const char File[], const int Line, const char Function[], const IsUnphVerb_t Verbose );
```
* [`include/Typedef.h`](diffhunk://#diff-56c7ea4918441d93ca0c20f5a2638836ed7ace28632a576ea8207236e6955d80L260-R262): Updated `IsUnphyMode_t` enumeration to remove the `UNPHY_MODE_SING` mode and renumber the remaining modes.
* Replaced 113 calls to `Hydro_IsUnphysical` with `Hydro_IsUnphysical_Single`.
* Update 14 calls to `Hydro_IsUnphysical` with the new header.

## Tests
- [x] `Riemann` test problem with `--debug=true --flux=ROE` and set `Riemann_Prob = 3`.
- [x] The regression test prototype with having now.
- [x] `GAMER_CompareData` for the `blastwave` test problem between this PR branch and 026374de4df972196cad7a407f3a5d459ac2ebd4.