### PR TITLE
Fix the bug when ELBDM_BASE_SPECTRAL with OPT__FREEZE_FLUID

### DIFF
--- a/src/Model_ELBDM/CPU_ELBDM/CPU_ELBDMSolver_FFT.cpp
+++ b/src/Model_ELBDM/CPU_ELBDM/CPU_ELBDMSolver_FFT.cpp
@@ -220,7 +220,8 @@ void CPU_ELBDMSolver_FFT( const real dt, const double PrepTime, const int SaveSg
 
 
 // advance wave function by exp( -i*dt*k^2/(2*ELBDM_ETA) ) in the k-space using FFT
-   Psi_Advance_FFT( PsiR, PsiI, local_y_start_after_transpose, local_ny_after_transpose, total_local_size, dt );
+   if ( !OPT__FREEZE_FLUID )  // skip both the FFT and the advancement for OPT__FREEZE_FLUID
+      Psi_Advance_FFT( PsiR, PsiI, local_y_start_after_transpose, local_ny_after_transpose, total_local_size, dt );
 
 
 // rearrange data from slab back to patch


### PR DESCRIPTION
## Issue
It is a bug that `ELBDM_BASE_SPECTRAL` does not support `OPT__FREEZE_FLUID`.
For other fluid solvers, the dt is reset to 0.0 inside `InvokeSolver()` to freeze the fluid (`OPT__FREEZE_FLUID`).
However, for the `ELBDM_BASE_SPECTRAL`, it calls its own `CPU_ELBDMSolver_FFT()` rather than invoking `InvokeSolver()` in `Flu_AdvanceDt()`. And the option `OPT__FREEZE_FLUID` was not taken into account in `CPU_ELBDMSolver_FFT()` previously.
As a result, the fluid data was always updated if `ELBDM_BASE_SPECTRAL` was on, even though `OPT__FREEZE_FLUID` was enabled.

## Changes
Now, if both `OPT__FREEZE_FLUID` and `ELBDM_BASE_SPECTRAL` are on, the fluid data will not be updated in `CPU_ELBDMSolver_FFT()`.

Note that we adopted a different approach here to freeze the fluid than the other fluid solver.
In `InvokeSolver()`, it just reset the time-step dt to zero and still entered the solver as usual.
However, in `CPU_ELBDMSolver_FFT()`, we do not adopt the same approach because the forward and backward FFT will still introduce rounding-error differences even if the dt of the advancement in k-space is zero.
Therefore, we skip the whole FFT process instead to keep the fluid data intact.

## Tests
- Run `ELBDM/GaussianWavePacket` test problem
  - In `Input__Parameter`
    - Set `OPT__BC_FLU_*` to `1`
    - Set `ELBDM_BASE_SPECTRAL` to `1`
    - Set `OPT__FREEZE_FLUID` to `1`
  - In `Input__TestProb`
    - Set `Gau_PeriodicN` to `10`
- Before fixing the bug, the fluid is not frozen
  ![Orig](https://github.com/user-attachments/assets/8752882c-fb70-4ead-8f2a-f810f588e5b0)
- After fixing the bug, the fluid is correctly frozen
  ![Fixed](https://github.com/user-attachments/assets/cd83fcb2-dbe0-48f9-ae8a-cb0fc8e39014)
