### PR TITLE
Update the magnetic energy when enforcing consistency in the interface magnetic field

### DIFF
--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -557,7 +557,7 @@ void MHD_AllocateElectricArray( const int lv );
 void MHD_Aux_Check_InterfaceB( const char *comment );
 void MHD_Aux_Check_DivergenceB( const bool Verbose, const char *comment );
 void MHD_FixUp_Electric( const int lv );
-void MHD_SameInterfaceB( const int lv );
+void MHD_SameInterfaceB( const int lv, const bool update_energy );
 void MHD_CopyPatchInterfaceBField( const int lv, const int PID, const int SibID, const int MagSg );
 void MHD_BoundaryCondition_Outflow( real **Array, const int BC_Face, const int NVar, const int GhostSize,
                                     const int ArraySizeX, const int ArraySizeY, const int ArraySizeZ,

--- a/src/Init/Init_GAMER.cpp
+++ b/src/Init/Init_GAMER.cpp
@@ -246,8 +246,9 @@ void Init_GAMER( int *argc, char ***argv )
 
 // ensure B field consistency on the shared interfaces between sibling patches
 #  if ( MODEL == HYDRO  &&  defined MHD )
+   const bool update_energy_No = false;
    if ( OPT__SAME_INTERFACE_B )
-   for (int lv=0; lv<NLEVEL; lv++)  MHD_SameInterfaceB( lv );
+   for (int lv=0; lv<NLEVEL; lv++)  MHD_SameInterfaceB( lv, update_energy_No );
 #  endif
 
 

--- a/src/Main/EvolveLevel.cpp
+++ b/src/Main/EvolveLevel.cpp
@@ -303,6 +303,24 @@ void EvolveLevel( const int lv, const double dTime_FaLv )
 
       } // if ( OPT__OVERLAP_MPI ) ... else ...
 
+#     if ( MODEL == HYDRO  &&  defined MHD )
+      if ( OPT__SAME_INTERFACE_B )
+      {
+         const bool update_energy_Yes = true;
+
+         TIMING_FUNC(   Buf_GetBufferData( lv, SaveSg_Flu, SaveSg_Mag, NULL_INT, DATA_GENERAL,
+                                           _ENGY, _MAG, Flu_ParaBuf, USELB_YES  ),
+                        Timer_GetBuf[lv][0],   TIMER_ON   );
+
+         TIMING_FUNC(   MHD_SameInterfaceB( lv, update_energy_Yes ),
+                        Timer_Flu_Advance[lv],   TIMER_ON   );
+
+         TIMING_FUNC(   Buf_GetBufferData( lv, SaveSg_Flu, SaveSg_Mag, NULL_INT, DATA_GENERAL,
+                                           _ENGY, _MAG, Flu_ParaBuf, USELB_YES  ),
+                        Timer_GetBuf[lv][0],   TIMER_ON   );
+      } // if ( OPT__SAME_INTERFACE_B )
+#     endif // #if ( MODEL == HYDRO  &&  defined MHD )
+
       amr->FluSg    [lv]             = SaveSg_Flu;
       amr->FluSgTime[lv][SaveSg_Flu] = TimeNew;
 #     ifdef MHD

--- a/src/Main/Main.cpp
+++ b/src/Main/Main.cpp
@@ -703,8 +703,9 @@ int main( int argc, char *argv[] )
          if ( OPT__VERBOSE  &&  MPI_Rank == 0 )
             Aux_Message( stdout, "   MHD_SameInterfaceB                       ... " );
 
+         const bool update_energy_Yes = true;
          for (int lv=0; lv<NLEVEL; lv++)
-         TIMING_FUNC(   MHD_SameInterfaceB( lv ),     Timer_Main[6],   TIMER_ON   );
+         TIMING_FUNC(   MHD_SameInterfaceB( lv, update_energy_Yes ),     Timer_Main[6],   TIMER_ON   );
 
          if ( OPT__VERBOSE  &&  MPI_Rank == 0 )
             Aux_Message( stdout, "done\n" );

--- a/src/Model_Hydro/MHD_SameInterfaceB.cpp
+++ b/src/Model_Hydro/MHD_SameInterfaceB.cpp
@@ -18,11 +18,12 @@
 //                5. Mainly for debugging purposes since this consistency should already be guaranteed
 //                   even when disabling OPT__SAME_INTERFACE_B
 //
-// Parameter   :  lv : AMR level
+// Parameter   :  lv            : AMR level
+//                update_energy : Whether to update the magnetic energy
 //
 // Return      :  Longitudinal B field on the interfaces between sibling patches
 //-------------------------------------------------------------------------------------------------------
-void MHD_SameInterfaceB( const int lv )
+void MHD_SameInterfaceB( const int lv, const bool update_energy )
 {
 
 // check
@@ -32,24 +33,78 @@ void MHD_SameInterfaceB( const int lv )
 #  endif
 
 
+   const int FluSg = amr->FluSg[lv];
    const int MagSg = amr->MagSg[lv];
 
 // iterate over all real and buffer patches
 #  pragma omp parallel for schedule( runtime )
    for (int PID=0; PID<amr->num[lv]; PID++)
    {
+      real ***Emag_old = NULL;
+
+      if ( update_energy )   Aux_AllocateArray3D( Emag_old, 3, PS1, PS1 );
+
 //    use the B field on the +x/+y/+z sides to overwrite that on the -x/-y/-z sides
 //    --> skip s=1/3/5
       for (int s=0; s<6; s+=2)
       {
+         const int d      = s/2;
          const int SibPID = amr->patch[0][lv][PID]->sibling[s];
 
+         if ( SibPID < 0 )   continue;
+
 //       some buffer patches may have magnetic == NULL --> skip them
-         if ( SibPID >= 0  &&
-              amr->patch[MagSg][lv][   PID]->magnetic != NULL  &&
-              amr->patch[MagSg][lv][SibPID]->magnetic != NULL     )
-            MHD_CopyPatchInterfaceBField( lv, PID, s, MagSg );
-      }
+         if ( amr->patch[MagSg][lv][   PID]->magnetic == NULL  ||
+              amr->patch[MagSg][lv][SibPID]->magnetic == NULL     )   continue;
+
+         if ( update_energy )
+         {
+            int ii, jj, kk;
+            real u[NCOMP_TOTAL];
+
+            for (int j=0; j<PS1; j++)
+            for (int i=0; i<PS1; i++)
+            {
+               switch ( d )
+               {
+                  case 0: ii = 0;  jj = i;  kk = j;  break;
+                  case 1: ii = j;  jj = 0;  kk = i;  break;
+                  case 2: ii = i;  jj = j;  kk = 0;  break;
+               }
+
+               for (int v=0; v<NCOMP_TOTAL; v++)   u[v] = amr->patch[FluSg][lv][PID]->fluid[v][kk][jj][ii];
+
+               Emag_old[d][j][i] = MHD_GetCellCenteredBEnergyInPatch( lv, PID, ii, jj, kk, MagSg );
+            }
+         } // if ( update_energy )
+
+         MHD_CopyPatchInterfaceBField( lv, SibPID, s+1, MagSg );
+
+         if ( update_energy )
+         {
+            int ii, jj, kk;
+            real u[NCOMP_TOTAL];
+
+            for (int j=0; j<PS1; j++)
+            for (int i=0; i<PS1; i++)
+            {
+               switch ( d )
+               {
+                  case 0: ii = 0;  jj = i;  kk = j;  break;
+                  case 1: ii = j;  jj = 0;  kk = i;  break;
+                  case 2: ii = i;  jj = j;  kk = 0;  break;
+               }
+
+               for (int v=0; v<NCOMP_TOTAL; v++)   u[v] = amr->patch[FluSg][lv][PID]->fluid[v][kk][jj][ii];
+
+               const real Emag = MHD_GetCellCenteredBEnergyInPatch( lv, PID, ii, jj, kk, MagSg );
+
+               amr->patch[FluSg][lv][PID]->fluid[ENGY][kk][jj][ii] += (Emag - Emag_old[d][j][i]);
+            }
+         } // if ( update_energy )
+      } // for (int s=0; s<6; s+=2)
+
+      if ( update_energy )   Aux_DeallocateArray3D( Emag_old );
    } // for (int PID=0; PID<amr->num[lv]; PID++)
 
 } // FUNCTION : MHD_SameInterfaceB


### PR DESCRIPTION
Currently, if `MINMOD_MAX_ITER` is enabled to reduce the minmod coefficient in each patch, the output of the magnetic field may become inconsistent due to variations in the minmod coefficient across nearby patches.

To address this issue, enabling `OPT__SAME_INTERFACE_B` enforces consistency of the magnetic field at patch interfaces. However, in the current implementation, the magnetic energy at the interface is not updated.

This PR ensures that magnetic energy is updated when `OPT__SAME_INTERFACE_B` is enabled.