### PR TITLE
Fix minor bug in ELBDM_GetTimeStep_Gravity to properly check AnyCell across all ranks

### DIFF
--- a/src/Model_ELBDM/ELBDM_GetTimeStep_Gravity.cpp
+++ b/src/Model_ELBDM/ELBDM_GetTimeStep_Gravity.cpp
@@ -142,7 +142,7 @@ real GetMaxPot( const int lv )
 
 
 // check
-   if ( MaxPot_AllRank == 0.0  &&  AnyCell  &&  MPI_Rank == 0 )
+   if ( MaxPot_AllRank == 0.0  &&  AnyCell_AllRank  &&  MPI_Rank == 0 )
       Aux_Error( ERROR_INFO, "MaxPot == 0.0 at lv %d !!\n", lv );
 
 


### PR DESCRIPTION
Before this fix, the code only checked `AnyCell` on MPI_Rank 0, which could miss cells that are taken into account on other ranks.
This change ensures the error message is only raised when `AnyCell_AllRank` is true.