### PR TITLE
Call gr_check_consistency to check the linked Grackle library

### DIFF
--- a/include/Typedef.h
+++ b/include/Typedef.h
@@ -35,7 +35,7 @@ typedef int  long_par;
 #endif
 
 #ifdef SUPPORT_GRACKLE
-#include <grackle_float.h>
+#include <grackle.h>
 #if   defined GRACKLE_FLOAT_8
 typedef double real_che;
 #elif defined GRACKLE_FLOAT_4

--- a/src/Grackle/Grackle_Init.cpp
+++ b/src/Grackle/Grackle_Init.cpp
@@ -3,6 +3,13 @@
 
 #ifdef SUPPORT_GRACKLE
 
+// whether gr_check_consistency() is defined
+// --> it is introduced in the version 3.3.1-dev of
+//     the Grackle library to perform some consistency checks
+// --> set it to 0 to disable the check if an older version is being used
+#define HAVE_GR_CHECK_CONSISTENCY 1
+
+
 
 
 
@@ -29,6 +36,14 @@ void Grackle_Init()
 
 // check
 // errors
+#  if ( HAVE_GR_CHECK_CONSISTENCY )
+   if ( gr_check_consistency() != GR_SUCCESS )
+      Aux_Error( ERROR_INFO, "Error occurs in gr_check_consistency() in %s !!\n", __FUNCTION__ );
+#  else
+   if ( MPI_Rank == 0 )
+      Aux_Message( stderr, "WARNING : Checking with the Grackle function \"gr_check_consistency()\" is not enabled in %s !!\n", __FUNCTION__ );
+#  endif
+
    if ( typeid(real_che) != typeid(gr_float) )
       Aux_Error( ERROR_INFO, "inconsistent floating-point type: GAMER (real_che) = %d, Grackle (gr_float) = %d !!\n",
                  sizeof(real_che), sizeof(gr_float) );


### PR DESCRIPTION
## Goal
- To resolve #394 
- To avoid the error due to inconsistent Grackle libraries.

## Background
- A new API function, [gr_check_consistency()](https://grackle.readthedocs.io/en/latest/Reference.html#c.gr_check_consistency), was added in Grackle recently. See https://github.com/grackle-project/grackle/pull/279 for details.

## Changes
- Use the `gr_check_consistency` provided in the Grackle library to add a check in `src/Grackle/Grackle_Init.cpp`.
- A preprocessor macro `HAVE_GR_CHECK_CONSISTENCY` is defined in case an older version of the Grackle library is used.
- Change from `#include <grackle_float.h>` to `#include <grackle.h>` because there is a warning message saying it is a deprecated header. See [here](https://github.com/grackle-project/grackle/blob/main/src/include/grackle_float.h.in#L11-L20).
   >      "You are using a deprecated header file; include the public "
   >      "\"grackle.h\" header file instead! In a future Grackle version, "
   >      "\"grackle_float.h\" may cease to exist (or contents may change in an "
   >      "incompatible manner)."

## Validation Tests
- The latest Grackle is installed (as single precision and double precision separately).
  ```
  The Grackle Version 3.3.1-dev
  Git Branch   main
  Git Revision 78d15722b213ab7f3b3f19e0e9d4649d7566bee5
  ```
- Set the `GRACKLE_PATH` in the machine config file.
  ```
  GRACKLE_PATH   /MY/PATH/TO/GRACKLE/
  ``` 
- Set the `LD_LIBRARY_PATH` in the job script.
  ```
  export LD_LIBRARY_PATH=/MY/PATH/TO/GRACKLE/lib:$LD_LIBRARY_PATH
  echo $LD_LIBRARY_PATH 1>>log 2>&1
  ``` 
- Run the default low-resolution `Hydro/AGORA_IsolatedGalaxy` test problem for two steps.

- Different combinations of single/double precision of `GRACKLE_PATH` and `LD_LIBRARY_PATH` are compiled and run.
  -  `GRACKLE_PATH` is single, `LD_LIBRARY_PATH` is single
     - No error message 
  -  `GRACKLE_PATH` is single, `LD_LIBRARY_PATH` is double
      ```
      Grackle_Init ...
      ERROR: Inconsistent floating-point precisions.
             size of gr_float in the headers used during compilation = 4
             size of gr_float in the library linked against during runtime = 8
      ********************************************************************************
      ERROR : Error occurs in gr_check_consistency() in Grackle_Init !!
              Rank <0>, file <Grackle/Grackle_Init.cpp>, line <41>, function <Grackle_Init>
      ********************************************************************************
      ``` 
      * Without the check, there will be errors in Grackle
      ```
      WARNING: metal density exceeds total density!
      Mean molecular weight not converged!                     NaN
                     NaN                     NaN
      ```
  -  `GRACKLE_PATH` is double, `LD_LIBRARY_PATH` is single
      ```
      Grackle_Init ...
      ERROR: Inconsistent floating-point precisions.
             size of gr_float in the headers used during compilation = 8
             size of gr_float in the library linked against during runtime = 4
      ********************************************************************************
      ERROR : Error occurs in gr_check_consistency() in Grackle_Init !!
              Rank <0>, file <Grackle/Grackle_Init.cpp>, line <41>, function <Grackle_Init>
      ********************************************************************************
      ``` 
      * Without the check, there will be errors in Grackle
      ```
      MULTI_COOL iter,j,k =       10001           1         174
       T  F  T  F  T  F  T  F  T  F  T  F  T  F  T  F
      MULTI_COOL iter >        10000  at j,k =           1         488
      inside if statement solve rate cool:           0         255
      FATAL error (2) in MULTI_COOL
      ```
  -  `GRACKLE_PATH` is double, `LD_LIBRARY_PATH` is double
     - No error message  