### PR TITLE
Add new machine `perlmutter`

### DIFF
--- a/configs/perlmutter.config
+++ b/configs/perlmutter.config
@@ -12,6 +12,7 @@ HDF5_PATH       /opt/cray/pe/hdf5/default/gnu/12.3
 GRACKLE_PATH
 GSL_PATH
 LIBYT_PATH
+CUFFTDX_PATH
 
 # compilers
 CXX     CC
@@ -24,9 +25,9 @@ CXXFLAG -O2
 
 OPENMPFLAG -fopenmp
 
-#LIBFLAG -flag1
+#LIBFLAG
 
-NVCCFLAG_COM -O3 -I/opt/cray/pe/mpich/8.1.28/ofi/gnu/12.3/include #
+NVCCFLAG_COM -O3 -I/opt/cray/pe/mpich/8.1.28/ofi/gnu/12.3/include
 #NVCCFLAG_COM -use_fast_math
 NVCCFLAG_FLU -Xptxas -dlcm=ca -prec-div=false -ftz=true
 NVCCFLAG_POT -Xptxas -dlcm=ca

--- a/configs/perlmutter.config
+++ b/configs/perlmutter.config
@@ -1,23 +1,21 @@
 # NERSC Perlmutter (HPE Cray Compiler Wrappers)
 # No need to load any modules, just use the default environment.
-
-# 1. Paths
 CUDA_PATH       /opt/nvidia/hpc_sdk/Linux_x86_64/23.9/cuda/12.2/
-FFTW2_PATH      /path/to/fftw2
+FFTW2_PATH
 FFTW3_PATH      /opt/cray/pe/fftw/3.3.10.6/x86_milan/
 MPI_PATH        /opt/cray/pe/craype/2.7.30/  # This is actually the path to CC (just for perlmutter).
 HDF5_PATH       /opt/cray/pe/hdf5/default/gnu/12.3
 #HDF5_PATH       /opt/cray/pe/hdf5-parallel/1.12.2.9/gnu/12.3/
-GRACKLE_PATH    /path/to/grackle
-GSL_PATH        /path/to/gsl
-LIBYT_PATH      /path/to/libyt
+GRACKLE_PATH
+GSL_PATH
+LIBYT_PATH
 
-# 2. Compiler type
+# compilers
 CXX     CC
 CXX_MPI CC                # MPI compiler (The MPI_PATH/bin/ will be combined automatically)
 
-# 3. Compiler flags
-CXXFLAG -target-accel=nvidia80
+# flags
+CXXFLAG -target-accel=nvidia80   # Also available in the environment variable
 CXXFLAG -g
 CXXFLAG -O2
 
@@ -26,16 +24,9 @@ OPENMPFLAG -fopenmp
 #LIBFLAG -flag1
 
 NVCCFLAG_COM -O3 -I/opt/cray/pe/mpich/8.1.28/ofi/gnu/12.3/include #
-#NVCCFLAG -ccbin YOUR_HOST_COMPILER
-#NVCCFLAG -ccbin CC
 #NVCCFLAG_COM -use_fast_math
 NVCCFLAG_FLU -Xptxas -dlcm=ca -prec-div=false -ftz=true
 NVCCFLAG_POT -Xptxas -dlcm=ca
 
-# 4. Set the GPU Compute Capability
-# GPU_COMPUTE_CAPABILITY = major_verison*100 + minor_version*10
-# (e.g. GeForce RTX 4090 has GPU_COMPUTE_CAPABILITY 890 (8*100 + 9*10))
-# You can also set it to -1 to determine the value automatically using `get_gpu_compute_capability()` in `configure.py`.
-# References: https://developer.nvidia.com/cuda-gpus
-#             https://en.wikipedia.org/wiki/CUDA#GPUs_supported
-GPU_COMPUTE_CAPABILITY 800
+# gpu
+GPU_COMPUTE_CAPABILITY 800    # NVIDIA A100

--- a/configs/perlmutter.config
+++ b/configs/perlmutter.config
@@ -1,5 +1,8 @@
 # NERSC Perlmutter (HPE Cray Compiler Wrappers)
-# No need to load any modules, just use the default environment.
+
+### Caution!! Load the module below before compiling
+### module load gcc-native/12.3
+
 CUDA_PATH       /opt/nvidia/hpc_sdk/Linux_x86_64/23.9/cuda/12.2/
 FFTW2_PATH
 FFTW3_PATH      /opt/cray/pe/fftw/3.3.10.6/x86_milan/

--- a/configs/perlmutter.config
+++ b/configs/perlmutter.config
@@ -1,0 +1,41 @@
+# NERSC Perlmutter (HPE Cray Compiler Wrappers)
+# No need to load any modules, just use the default environment.
+
+# 1. Paths
+CUDA_PATH       /opt/nvidia/hpc_sdk/Linux_x86_64/23.9/cuda/12.2/
+FFTW2_PATH      /path/to/fftw2
+FFTW3_PATH      /opt/cray/pe/fftw/3.3.10.6/x86_milan/
+MPI_PATH        /opt/cray/pe/craype/2.7.30/  # This is actually the path to CC (just for perlmutter).
+HDF5_PATH       /opt/cray/pe/hdf5/default/gnu/12.3
+#HDF5_PATH       /opt/cray/pe/hdf5-parallel/1.12.2.9/gnu/12.3/
+GRACKLE_PATH    /path/to/grackle
+GSL_PATH        /path/to/gsl
+LIBYT_PATH      /path/to/libyt
+
+# 2. Compiler type
+CXX     CC
+CXX_MPI CC                # MPI compiler (The MPI_PATH/bin/ will be combined automatically)
+
+# 3. Compiler flags
+CXXFLAG -target-accel=nvidia80
+CXXFLAG -g
+CXXFLAG -O2
+
+OPENMPFLAG -fopenmp
+
+#LIBFLAG -flag1
+
+NVCCFLAG_COM -O3 -I/opt/cray/pe/mpich/8.1.28/ofi/gnu/12.3/include #
+#NVCCFLAG -ccbin YOUR_HOST_COMPILER
+#NVCCFLAG -ccbin CC
+#NVCCFLAG_COM -use_fast_math
+NVCCFLAG_FLU -Xptxas -dlcm=ca -prec-div=false -ftz=true
+NVCCFLAG_POT -Xptxas -dlcm=ca
+
+# 4. Set the GPU Compute Capability
+# GPU_COMPUTE_CAPABILITY = major_verison*100 + minor_version*10
+# (e.g. GeForce RTX 4090 has GPU_COMPUTE_CAPABILITY 890 (8*100 + 9*10))
+# You can also set it to -1 to determine the value automatically using `get_gpu_compute_capability()` in `configure.py`.
+# References: https://developer.nvidia.com/cuda-gpus
+#             https://en.wikipedia.org/wiki/CUDA#GPUs_supported
+GPU_COMPUTE_CAPABILITY 800

--- a/example/queue/submit_perlmutter_cpu.job
+++ b/example/queue/submit_perlmutter_cpu.job
@@ -1,0 +1,18 @@
+#!/bin/bash
+#SBATCH --account=YOUR_ACCOUNT
+#SBATCH --job-name=GAMER_CPU
+#SBATCH --qos=debug
+#SBATCH --time=0:30:00
+#SBATCH --nodes=1
+#SBATCH --mail-type=BEGIN,END,FAIL
+#SBATCH --mail-user=YOUR_EMAIL
+
+## Do not modify the following lines
+#SBATCH --constraint=cpu
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=256
+export OMP_PROC_BIND=spread
+export OMP_PLACES=threads
+
+module load gcc-native/12.3
+srun ./gamer

--- a/example/queue/submit_perlmutter_cpu.job
+++ b/example/queue/submit_perlmutter_cpu.job
@@ -7,12 +7,15 @@
 #SBATCH --mail-type=BEGIN,END,FAIL
 #SBATCH --mail-user=YOUR_EMAIL
 
-## Do not modify the following lines
+########## Do NOT modify this block ##########
 #SBATCH --constraint=cpu
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=256
 export OMP_PROC_BIND=spread
 export OMP_PLACES=threads
+##############################################
 
 module load gcc-native/12.3
+module list  # Record the loaded modules
+
 srun ./gamer

--- a/example/queue/submit_perlmutter_gpu.job
+++ b/example/queue/submit_perlmutter_gpu.job
@@ -1,0 +1,19 @@
+#!/bin/bash
+#SBATCH --account=YOUR_ACCOUNT_g
+#SBATCH --job-name=GAMER_GPU
+#SBATCH --qos=debug
+#SBATCH --time=0:30:00
+#SBATCH --nodes=1
+#SBATCH --mail-type=BEGIN,END,FAIL
+#SBATCH --mail-user=YOUR_EMAIL
+
+## Do not modify the following lines
+#SBATCH --constraint=gpu
+#SBATCH --ntasks-per-node=4
+#SBATCH --cpus-per-task=32
+#SBATCH --gpus-per-task=1
+export OMP_PROC_BIND=spread
+export OMP_PLACES=threads
+
+module load gcc-native/12.3
+srun ./gamer

--- a/example/queue/submit_perlmutter_gpu.job
+++ b/example/queue/submit_perlmutter_gpu.job
@@ -7,13 +7,16 @@
 #SBATCH --mail-type=BEGIN,END,FAIL
 #SBATCH --mail-user=YOUR_EMAIL
 
-## Do not modify the following lines
+########## Do NOT modify this block ##########
 #SBATCH --constraint=gpu
 #SBATCH --ntasks-per-node=4
 #SBATCH --cpus-per-task=32
 #SBATCH --gpus-per-task=1
 export OMP_PROC_BIND=spread
 export OMP_PLACES=threads
+##############################################
 
 module load gcc-native/12.3
+module list  # Record the loaded modules
+
 srun ./gamer


### PR DESCRIPTION
## Summary
This pull request introduces a configuration file and job submission scripts for running GAMER on the [NERSC Perlmutter](https://docs.nersc.gov/systems/perlmutter/architecture/) supercomputer, adding a new configuration file tailored for Perlmutter's environment and two job submission scripts for CPU and GPU nodes.

## Changes

### Configuration file:

* `configs/perlmutter.config`: Added a new configuration file tailored for the NERSC Perlmutter system, including paths for `CUDA`, `FFTW3`, `MPI`, and `HDF5` libraries, compiler settings, and GPU-specific flags for NVIDIA A100 GPUs.

### Job Submission Scripts:

* `example/queue/submit_perlmutter_cpu.job`: Added a new SLURM job submission script for running jobs on Perlmutter's CPU nodes.
* `example/queue/submit_perlmutter_gpu.job`: Added a new SLURM job submission script for running jobs on Perlmutter's GPU nodes.

## Usage
Before doing anything, please:
```bash
module load gcc-native/12.3
```

## Tests
- [x] Run two Quick Start demos.
- [x] Submit a GPU node job with 4 nodes for the 3D blast wave.
- [x] Submit a CPU node job with 4 nodes for the 3D blast wave.
- [ ] Run the regression tests.

For the regression test:
`python regression_test.py --machine=perlmutter -e level2`
```
> Test name           : Error code      Reason
> MHD_ABC_MHD         : SUCCESS         
> BlastWave_MHD       : COMPARISON      Fail data comparison.
> Riemann_MHD         : COMPARISON      Fail data comparison.
> BlastWave_Hydro     : COMPARISON      Fail data comparison.
> Riemann_Hydro       : COMPARISON      Fail data comparison.
> AcousticWave_Hydro  : SUCCESS         
> Riemann_SRHD        : SUCCESS         
> Plummer_Gravity     : SUCCESS 
```
But the regression test itself has problem on running on other machine. So this is just for a reference.

## Performance
### 3D blastwave
#### 256x256x256+`MAX_LEVEL=3`:
4 GPU nodes: 682.3 s.
2 GPU nodes: 700.6 s.
1 GPU nodes: 1029.6 s.
4 CPU nodes: 1551.0 s.
2 CPU nodes: 2585.1 s.
1 CPU nodes: 4444.3 s.

#### 128x128x128+`MAX_LEVEL=3`:
4 GPU nodes: 354.8 s.
2 GPU nodes: 265.6 s.
1 GPU nodes: 329.3 s.