### PR TITLE
Fftw.cpp malloc size fix

### DIFF
--- a/src/Init/Init_FFTW.cpp
+++ b/src/Init/Init_FFTW.cpp
@@ -54,7 +54,7 @@ size_t ComputeTotalSize(int* size) {
 #  else
    mpi_index_int local_nz, local_z_start, local_ny_after_transpose, local_y_start_after_transpose;
 
-   return (size_t)fftw_mpi_local_size_3d_transposed(size[2], size[1], size[0]),
+   return (size_t)fftw_mpi_local_size_3d_transposed(size[2], size[1], size[0],
                                                     MPI_COMM_WORLD, &local_nz, &local_z_start, &local_ny_after_transpose,
                                                     &local_y_start_after_transpose);
 #  endif


### PR DESCRIPTION
## Summary:
This PR reduce the virtual memory requirement of gamer with FFTW3.
 
## Changes:
### Init/Init_FFTW.cpp
1. Add `fftw_mpi_local_size_3d_transposed()` to `ComputePaddedTotalSize()` and `ComputeTotalSize()` for mpi supported situation to enhance the estimation of memory requirement.
2. Original `MemUnit` estimation is not proper, it can't decrease the memory usage per rank with mpi.  So we replace the value `MemUnit` from `amr->NPatchComma[0][1]*PS1` to `amr->NPatchComma[0][1]/MPI_NRank`
3. Add variable check to the `MemUnit` related `malloc` and `realloc` to prevent error in after usage.

## Tests:
- [x] `SERIAL` support
- [x] `OPT__FFTW_STARTUP = 1`  support