### PR TITLE
Fix output HDF5 bugs when there are no objects in the HaloMerger test problem

### DIFF
--- a/src/TestProblem/ELBDM/HaloMerger/Init_TestProb_ELBDM_HaloMerger.cpp
+++ b/src/TestProblem/ELBDM/HaloMerger/Init_TestProb_ELBDM_HaloMerger.cpp
@@ -1893,7 +1893,8 @@ void Init_TestProb_ELBDM_HaloMerger()
 #  endif // ifdef MASSIVE_PARTICLES
 #  ifdef SUPPORT_HDF5
    Output_HDF5_InputTest_Ptr = LoadInputTestProb;
-   Output_HDF5_UserPara_Ptr  = Output_HDF5_UserPara_HaloMerger;
+   Output_HDF5_UserPara_Ptr  = ( HaloMerger_Halo_Num > 0  ||  HaloMerger_Soliton_Num > 0  ||  HaloMerger_ParCloud_Num > 0 )
+                               ? Output_HDF5_UserPara_HaloMerger : NULL;
 #  endif
 
 #  endif // if ( MODEL == ELBDM  &&  defined GRAVITY )


### PR DESCRIPTION
### Issue
When `OPT__INIT = 3` is adopted in the `HaloMerger` test problem, there will be an error
```
Output_DumpData_Total_HDF5 (DumpID = 0)     ...
********************************************************************************
ERROR : HDF5_Output_t structure must not be empty !!
        Rank <0>, file <Output/Output_DumpData_Total_HDF5.cpp>, line <4057>, function <GetCompound_General>
********************************************************************************
```
This is because `HaloMerger_Halo_Num`, `HaloMerger_ParCloud_Num`, and `HaloMerger_Soliton_Num` are all 0 in this case, and the output structure becomes empty. 

### Solution
Set `Output_HDF5_UserPara_Ptr` to NULL when `HaloMerger_Halo_Num`, `HaloMerger_ParCloud_Num`, and `HaloMerger_Soliton_Num` are all 0.