### PR TITLE
Set the lower limit for `MemUnit` as `1` in `Init_FFTw.cpp`

### DIFF
--- a/src/Init/Init_FFTW.cpp
+++ b/src/Init/Init_FFTW.cpp
@@ -358,13 +358,13 @@ void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf
 #  endif // GAMER_DEBUG
 
 
-   const int SSize[2]   = { ( InPlacePad ? 2*(FFT_Size[0]/2+1) : FFT_Size[0] ), FFT_Size[1] };             // padded slab size in the x and y directions
-   const int PSSize     = PS1*PS1;                                                                         // patch slice size
-   const int MemUnit    = (amr->NPatchComma[0][1]/MPI_NRank == 0 ) ? 1 : amr->NPatchComma[0][1]/MPI_NRank; // set arbitrarily; divided by MPI_NRank so
-                                                                                                           // that the memory consumption per rank for
-                                                                                                           // arrays like TempBuf_Var[MPI_NRank] reduces
-                                                                                                           // when launching more ranks
-   const int AveNz      = FFT_Size[2]/MPI_NRank + ( ( FFT_Size[2]%MPI_NRank == 0 ) ? 0 : 1 );              // average slab thickness
+   const int SSize[2]   = { ( InPlacePad ? 2*(FFT_Size[0]/2+1) : FFT_Size[0] ), FFT_Size[1] }; // padded slab size in the x and y directions
+   const int PSSize     = PS1*PS1;                                                             // patch slice size
+   const int MemUnit    = MAX(1, amr->NPatchComma[0][1]/MPI_NRank);                            // set arbitrarily; divided by MPI_NRank so that the
+                                                                                               // memory consumption per rank for arrays like
+                                                                                               // TempBuf_Var[MPI_NRank] reduces when launching
+                                                                                               // more ranks
+   const int AveNz      = FFT_Size[2]/MPI_NRank + ( ( FFT_Size[2]%MPI_NRank == 0 ) ? 0 : 1 );  // average slab thickness
    const int Scale0     = amr->scale[0];
 
    int   Cr[3];                        // corner coordinates of each patch normalized to the base-level grid size

--- a/src/Init/Init_FFTW.cpp
+++ b/src/Init/Init_FFTW.cpp
@@ -360,7 +360,7 @@ void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf
 
    const int SSize[2]   = { ( InPlacePad ? 2*(FFT_Size[0]/2+1) : FFT_Size[0] ), FFT_Size[1] }; // padded slab size in the x and y directions
    const int PSSize     = PS1*PS1;                                                             // patch slice size
-   const int MemUnit    = MAX(1, amr->NPatchComma[0][1]/MPI_NRank);                            // set arbitrarily; divided by MPI_NRank so that the
+   const int MemUnit    = MAX( 1, amr->NPatchComma[0][1]/MPI_NRank );                          // set arbitrarily; divided by MPI_NRank so that the
                                                                                                // memory consumption per rank for arrays like
                                                                                                // TempBuf_Var[MPI_NRank] reduces when launching
                                                                                                // more ranks

--- a/src/Init/Init_FFTW.cpp
+++ b/src/Init/Init_FFTW.cpp
@@ -358,11 +358,13 @@ void Patch2Slab( real *VarS, real *SendBuf_Var, real *RecvBuf_Var, long *SendBuf
 #  endif // GAMER_DEBUG
 
 
-   const int SSize[2]   = { ( InPlacePad ? 2*(FFT_Size[0]/2+1) : FFT_Size[0] ), FFT_Size[1] };  // padded slab size in the x and y directions
-   const int PSSize     = PS1*PS1;                          // patch slice size
-   const int MemUnit    = amr->NPatchComma[0][1]/MPI_NRank; // set arbitrarily; divided by MPI_NRank so that the memory consumption per rank for arrays
-                                                            // like TempBuf_Var[MPI_NRank] reduces when launching more ranks
-   const int AveNz      = FFT_Size[2]/MPI_NRank + ( ( FFT_Size[2]%MPI_NRank == 0 ) ? 0 : 1 );   // average slab thickness
+   const int SSize[2]   = { ( InPlacePad ? 2*(FFT_Size[0]/2+1) : FFT_Size[0] ), FFT_Size[1] };             // padded slab size in the x and y directions
+   const int PSSize     = PS1*PS1;                                                                         // patch slice size
+   const int MemUnit    = (amr->NPatchComma[0][1]/MPI_NRank == 0 ) ? 1 : amr->NPatchComma[0][1]/MPI_NRank; // set arbitrarily; divided by MPI_NRank so
+                                                                                                           // that the memory consumption per rank for
+                                                                                                           // arrays like TempBuf_Var[MPI_NRank] reduces
+                                                                                                           // when launching more ranks
+   const int AveNz      = FFT_Size[2]/MPI_NRank + ( ( FFT_Size[2]%MPI_NRank == 0 ) ? 0 : 1 );              // average slab thickness
    const int Scale0     = amr->scale[0];
 
    int   Cr[3];                        // corner coordinates of each patch normalized to the base-level grid size


### PR DESCRIPTION
* Set the lower limit for `MemUnit` as `1`, to avoid `0` memory size for extreme cases with small patches per rank (i.e., `amr->NPatchComma[0][1] < MPI_NRank`).