### PR TITLE
Record more CPU information

### DIFF
--- a/src/Auxiliary/Aux_GetCPUInfo.cpp
+++ b/src/Auxiliary/Aux_GetCPUInfo.cpp
@@ -22,7 +22,11 @@ void Aux_GetCPUInfo( const char *FileName )
    FILE *Note = fopen( FileName, "a" );
    char *line = NULL;
    size_t len = 0;
-   char String[2][100];
+   char String[2][MAX_STRING];
+   char Trash[MAX_STRING];
+   int SocketNow = -1, SocketPrevious = -1;
+   int CorePerSocket = 0, NSocket = 0;
+   bool PrintInfo = true;
 
 
 // 1. get the CPU info
@@ -39,6 +43,18 @@ void Aux_GetCPUInfo( const char *FileName )
    while ( getline(&line, &len, CPUInfo) != -1 )
    {
       sscanf( line, "%s%s", String[0], String[1] );
+
+      if (  strcmp( String[0], "physical" ) == 0  &&  strcmp( String[1], "id" ) == 0 )
+      {
+         sscanf( line, "%s%s%s%d", String[0], String[1], Trash, &SocketNow );
+         if ( SocketNow != SocketPrevious )
+         {
+            SocketPrevious = SocketNow;
+            NSocket++;
+         }
+      }
+
+      if ( !PrintInfo )   continue;
 
       if (  strcmp( String[0], "model" ) == 0  &&  strcmp( String[1], "name" ) == 0  )
       {
@@ -62,7 +78,8 @@ void Aux_GetCPUInfo( const char *FileName )
       {
          memcpy( line, "CPU Cores", 9 );
          fprintf( Note, "%s", line );
-         break;
+         sscanf( line, "%s%s%s%d", String[0], String[1], Trash, &CorePerSocket );
+         PrintInfo = false;
       }
    }
 
@@ -71,6 +88,10 @@ void Aux_GetCPUInfo( const char *FileName )
       free( line );
       line = NULL;
    }
+
+   fprintf( Note, "%-15s : %d\n", "Socket(s)", NSocket );
+// assuming the CPUs in the node are the same
+   fprintf( Note, "%-15s : %d\n", "Core per Node", CorePerSocket*NSocket );
 
    fclose( CPUInfo );
 


### PR DESCRIPTION
This PR appends CPU information to `Record__Note`. The number of sockets and the total number of cores per node are now recorded.

## Results

### Part of `Record__Note`

<details>
<summary>eureka</summary>

<pre>
Device Diagnosis
***********************************************************************************
MPI_Rank =   0, hostname =   eureka00, PID =  4644
CPU Info :
CPU Type        : AMD Ryzen Threadripper 2950X 16-Core Processor
CPU MHz         : 2200.000
Cache Size      : 512 KB
CPU Cores       : 16
Socket(s)       : 1
Core per Socket : 16
Total Memory    : 125.6 GB

MPI_Rank =   1, hostname =   eureka00, PID =  4645
CPU Info :
CPU Type        : AMD Ryzen Threadripper 2950X 16-Core Processor
CPU MHz         : 2200.000
Cache Size      : 512 KB
CPU Cores       : 16
Socket(s)       : 1
Core per Socket : 16
Total Memory    : 125.6 GB
***********************************************************************************
</pre>
</details>


<details>
<summary>On Taiwania 3</summary>

<pre>
Device Diagnosis
***********************************************************************************
MPI_Rank =   0, hostname =     lgn301, PID = 2751598
CPU Info :
CPU Type        : Intel(R) Xeon(R) Platinum 8280 CPU @ 2.70GHz
CPU MHz         : 3154.728
Cache Size      : 39424 KB
CPU Cores       : 28
Socket(s)       : 2
Core per Node   : 56
Total Memory    : 375.6 GB

MPI_Rank =   1, hostname =     lgn301, PID = 2751599
CPU Info :
CPU Type        : Intel(R) Xeon(R) Platinum 8280 CPU @ 2.70GHz
CPU MHz         : 3154.728
Cache Size      : 39424 KB
CPU Cores       : 28
Socket(s)       : 2
Core per Node   : 56
Total Memory    : 375.6 GB
***********************************************************************************
</pre>