### PR TITLE
Add alias expand to support alias command

### DIFF
--- a/tool/config/config_autocomplete.sh
+++ b/tool/config/config_autocomplete.sh
@@ -25,7 +25,13 @@ __gamer_configure_autocomplete() {
     local configure_filename configure_command
     if [[ "${COMP_WORDS[0]}" == "python"* ]]; then
         configure_filename=${COMP_WORDS[1]}
-        configure_command="${COMP_WORDS[0]} ${COMP_WORDS[1]}"
+        local alias_expanded
+        alias_expanded=$(alias -- "${COMP_WORDS[0]}" 2>/dev/null | sed -E "s/^alias ${COMP_WORDS[0]}='([^']+)'/\1/")
+        if [[ -n "$alias_expanded" ]]; then
+            configure_command="${alias_expanded} ${configure_filename}"
+        else
+            configure_command="${COMP_WORDS[0]} ${COMP_WORDS[1]}"
+        fi
     else
         configure_filename=${COMP_WORDS[0]}
         configure_command="${COMP_WORDS[0]}"


### PR DESCRIPTION
# Bug fix #424
## Description
This pull request fix #424. Make user able to use autocomplete with python `alias` setting 

## Changes
1. Add a local variable `alias_expanded` in `/tool/config/config_autocomplete.sh` with definition:
    ```bash
    alias_expanded=$(alias -- "${COMP_WORDS[0]}" 2>/dev/null | sed -E "s/^alias ${COMP_WORDS[0]}='([^']+)'/\1/")
    ```
2. Add a condition for assigning variable  `configure_command`
    * If `alias_expanded` is not empty: `configure_command=${alias_expanded} ${COMP_WORDS[1]}`
    * If `alias_expanded` is empty:        `configure_command=${COMP_WORDS[0] ${COMP_WORDS[1]}}`

## Tests
- [x] `./configure [tab] [tab]`
- [x] `python configure [tab] [tab]` (w/ `alias` setting: `alias python="python3")
- [x] `python3 configure [tab] [tab]`