### PR TITLE
Fix type of `JEANS_MIN_PRES` in `Solver()`

### DIFF
--- a/src/Main/InvokeSolver.cpp
+++ b/src/Main/InvokeSolver.cpp
@@ -553,7 +553,7 @@ void Solver( const Solver_t TSolver, const int lv, const double TimeNew, const d
                                            NEWTON_G*SQR(JEANS_MIN_PRES_NCELL*amr->dh[JEANS_MIN_PRES_LEVEL])/(GAMMA*M_PI) : NULL_REAL;
 #  endif
 #  else
-   const real JEANS_MIN_PRES     = false;
+   const bool JEANS_MIN_PRES     = false;
    const real JeansMinPres_Coeff = NULL_REAL;
 #  endif
 


### PR DESCRIPTION
## Summary
This pull request makes a minor fix in the `src/Main/InvokeSolver.cpp` file by correcting the type of the `JEANS_MIN_PRES` variable from `real` to `bool`. Although I do not know why compilers do not complain about it, this change improves type safety anyway.

## Change
- Fixed the type of `JEANS_MIN_PRES` from `real` to `bool` to accurately reflect its intended use as a boolean flag (`src/Main/InvokeSolver.cpp`).

## Tests
Pass regression tests of `BlastWave_Hydro`, `Riemann_Hydro`, `BlastWave_MHD`, `Riemann_MHD`, `MHD_ABC_MHD`, `AcousticWave_Hydro`, `Riemann_SRHD`, `Plummer_Particle`, and `Plummer_Gravity` on both `spock` and `perlmutter`.