### PR TITLE
[Bugfix] Fix the use of uninitialized variable in Par_EquilibriumIC

### DIFF
--- a/src/Particle/Par_EquilibriumIC.cpp
+++ b/src/Particle/Par_EquilibriumIC.cpp
@@ -543,7 +543,9 @@ double Par_EquilibriumIC::Set_Velocity( const double x )
          break;
          }
       sum_mes += prob_dens[k] *pow(psi_per-psi[k],0.5) *delta;
-      if(k==params.Cloud_MassProfNBin-1)index_ass = params.Cloud_MassProfNBin-1;
+      if(k==params.Cloud_MassProfNBin-1){index_ass = params.Cloud_MassProfNBin-1;
+         par = (sum_mes-sum_rad)/(prob_dens[index_ass] *pow(psi_per-psi[index_ass],0.5) *delta);
+         }
    }
    psi_ass = psi[index_ass] +delta *par;
    double kim =-2*(psi_ass-psi_per);


### PR DESCRIPTION
## Issue
The variable `par` in `Par_EquilibriumIC::Set_Velocity()` is uninitialized if `k` loops to `params.Cloud_MassProfNBin-1` without ever `sum_mes>sum_rad` in the for loop.

The resulting velocity of that particle will be polluted and become something unpredictable.
This may lead to extremely large particle velocity and extremely small time-steps.

## Change
Assign a value to `par` when `k==params.Cloud_MassProfNBin-1` in a similar way.

## Note
Related Issue:
- #295 

Related PR:
- #315