### PR TITLE
Update Forerunner I job script

### DIFF
--- a/example/queue/submit_forerunnerI_gnu.job
+++ b/example/queue/submit_forerunnerI_gnu.job
@@ -27,6 +27,5 @@ module load gnu_13.2.0/gcc/13.2.0 gnu_13.2.0/fftw/3.3.10 gnu_13.2.0/gsl/2.8.0 gn
 module list 1>>$LOG_FILE 2>&1
 
 # See: https://docs.open-mpi.org/en/v5.0.x/man-openmpi/man1/mpirun.1.html#the-map-by-option
-# There are 8 NUMA nodes on each node, 4 per socket
-mpirun -map-by ppr:2:numa:pe=7 --report-bindings ./gamer 1>>$LOG_FILE 2>&1
+mpirun -map-by ppr:16:node:pe=7 --report-bindings ./gamer 1>>$LOG_FILE 2>&1
 echo "=============================================================" >> $LOG_FILE

--- a/example/queue/submit_forerunnerI_intel.job
+++ b/example/queue/submit_forerunnerI_intel.job
@@ -27,6 +27,5 @@ module load intel/2024_01_46 oneapi_2024/fftw/3.3.10 oneapi_2024/gsl/2.8.0 oneap
 module list 1>>$LOG_FILE 2>&1
 
 # See: https://docs.open-mpi.org/en/v5.0.x/man-openmpi/man1/mpirun.1.html#the-map-by-option
-# There are 8 NUMA nodes on each node, 4 per socket
-mpirun -map-by ppr:2:numa:pe=7 --report-bindings ./gamer 1>>$LOG_FILE 2>&1
+mpirun -map-by ppr:16:node:pe=7 --report-bindings ./gamer 1>>$LOG_FILE 2>&1
 echo "=============================================================" >> $LOG_FILE


### PR DESCRIPTION
## Issue
Encountered by the user, the old job script doesn't work for Forerunner-I now.
We previously expect the NUMA nodes to be the same in all the nodes on Forerunner-I, and it should launch 16 MPI ranks per node and 7 OpenMP threads per rank (112 CPUs per node in total).

Now, this is still the same for some nodes. However, for some other nodes, it will request only 4 MPI ranks, and there are 28 OpenMP threads per rank. Worse, the CPU core IDs in `Record__Note` in the same rank are repeated 4 times. Only 28 CPUs in total are actually used per node. This will make the performance bad because not all the resources on the nodes are used, and the parallelization is not full.

## Change
As @koarakawaii once suggested to me a while ago, we can use `-map-by ppr:16:node:pe=7` instead to avoid this problem.