### PR TITLE
Add unphysical checks for high speed or high energy in Flu_Close()

### DIFF
--- a/src/Fluid/Flu_Close.cpp
+++ b/src/Fluid/Flu_Close.cpp
@@ -475,6 +475,19 @@ bool Unphysical( const real Fluid[], const int CheckMode, const real Emag )
    }
 #  endif // #ifndef BAROTROPIC_EOS
 
+#  ifndef SRHD
+   if ( OPT__UNIT )
+   {
+//    check whether the speed is larger than the speed of light
+      if ( SQR(Fluid[MOMX]) + SQR(Fluid[MOMY]) + SQR(Fluid[MOMZ]) >= SQR(Fluid[DENS]*Const_c/UNIT_V) )
+         return true;
+
+//    check whether the total energy is larger than the relativistic rest-mass energy
+      if ( Fluid[ENGY] >= Fluid[DENS] * SQR(Const_c/UNIT_V) )
+         return true;
+   }
+#  endif // #ifndef SRHD
+
 
 // if all checks above pass, return false
 // =================================================


### PR DESCRIPTION
## Motivations
Currently, the unphysically high velocity and energy can be obtained by the fluid solver without being caught and corrected.

For example, when the density is $+\varepsilon$ to machine precision while the momentum density is finite after the update, we can get huge kinetic energy, which is not physical. And this high energy can have a tremendous dynamical effect in the simulations later. With the check, we can avoid keeping running with an unrealistic explosion.

In non-relativistic simulations, we expect the speed of the fluid to be much less than the speed of light and the energy much less than the rest-mass energy. When these cases happen, it usually hints that there is an unphysical update numerically, and we should invoke the correction for it. The relativistic limit here is just a bottom-line check. We hope that when the numerical issue happens, the speed/energy will be much larger than this limit. Otherwise, it will be hard to catch it, as there is no general upper limit for the speed and energy.

## Changes
- Add a speed check against the speed of light
- Add a total energy check against the rest-mass energy
