### PR TITLE
Replace MPI_C_BOOL with MPI_CXX_BOOL

### DIFF
--- a/src/LoadBalance/LB_Refine.cpp
+++ b/src/LoadBalance/LB_Refine.cpp
@@ -105,7 +105,7 @@ void LB_Refine( const int FaLv )
    bool Send = SwitchFinerLevelsToWaveScheme;
    bool Recv;
 
-   MPI_Allreduce( &Send, &Recv, 1, MPI_C_BOOL, MPI_LOR, MPI_COMM_WORLD );
+   MPI_Allreduce( &Send, &Recv, 1, MPI_CXX_BOOL, MPI_LOR, MPI_COMM_WORLD );
 
    SwitchFinerLevelsToWaveScheme = Recv;
 #  endif

--- a/src/MPI/MPI_Alltoallv_GAMER.cpp
+++ b/src/MPI/MPI_Alltoallv_GAMER.cpp
@@ -37,7 +37,7 @@ void MPI_Alltoallv_GAMER( T *SendBuf, long *Send_NCount, long *Send_NDisp, MPI_D
 
    bool use_mpi_gamer_flag = false;
    if (  ( Send_NDisp[MPI_NRank-1] > __INT_MAX__ ) || ( Recv_NDisp[MPI_NRank-1] > __INT_MAX__ )  )    use_mpi_gamer_flag = true;
-   MPI_Allreduce( MPI_IN_PLACE, &use_mpi_gamer_flag , 1, MPI_C_BOOL, MPI_LOR, MPI_COMM_WORLD );
+   MPI_Allreduce( MPI_IN_PLACE, &use_mpi_gamer_flag , 1, MPI_CXX_BOOL, MPI_LOR, MPI_COMM_WORLD );
 
    if ( use_mpi_gamer_flag )
    {

--- a/src/Model_ELBDM/ELBDM_GetTimeStep_Gravity.cpp
+++ b/src/Model_ELBDM/ELBDM_GetTimeStep_Gravity.cpp
@@ -138,7 +138,7 @@ real GetMaxPot( const int lv )
    bool AnyCell_AllRank;
 
    MPI_Allreduce( &MaxPot, &MaxPot_AllRank, 1, MPI_GAMER_REAL, MPI_MAX, MPI_COMM_WORLD );
-   MPI_Reduce( &AnyCell, &AnyCell_AllRank, 1, MPI_C_BOOL, MPI_LOR, 0, MPI_COMM_WORLD );
+   MPI_Reduce( &AnyCell, &AnyCell_AllRank, 1, MPI_CXX_BOOL, MPI_LOR, 0, MPI_COMM_WORLD );
 
 
 // check

--- a/src/Refine/Sync_UseWaveFlag.cpp
+++ b/src/Refine/Sync_UseWaveFlag.cpp
@@ -22,7 +22,7 @@ void Sync_UseWaveFlag( const int lv )
     bool recv;
     bool send = amr->use_wave_flag[lv];
 
-    MPI_Allreduce( &send, &recv, 1, MPI_C_BOOL, MPI_LOR, MPI_COMM_WORLD );
+    MPI_Allreduce( &send, &recv, 1, MPI_CXX_BOOL, MPI_LOR, MPI_COMM_WORLD );
 
     amr->use_wave_flag[lv] = recv;
 


### PR DESCRIPTION
This PR replaces `MPI_C_BOOL` with `MPI_CXX_BOOL` throughout GAMER.

Reference: Table 3.4 in the [MPI documentation](https://www.mpi-forum.org/docs/mpi-5.0/mpi50-report.pdf) 