### PR TITLE
Bug fix for computing CPU socket number

### DIFF
--- a/src/Auxiliary/Aux_GetCPUInfo.cpp
+++ b/src/Auxiliary/Aux_GetCPUInfo.cpp
@@ -1,4 +1,6 @@
 #include "GAMER.h"
+#include <algorithm>
+#include <vector>
 
 
 
@@ -24,7 +26,8 @@ void Aux_GetCPUInfo( const char *FileName )
    size_t len = 0;
    char String[2][MAX_STRING];
    char Trash[MAX_STRING];
-   int SocketNow = -1, SocketPrevious = -1;
+   int SocketNow;
+   std::vector<int> SocketList;
    int CorePerSocket = 0, NSocket = 0;
    bool GotFirstCPUInfo = false;
 
@@ -47,12 +50,15 @@ void Aux_GetCPUInfo( const char *FileName )
       if (  strcmp( String[0], "physical" ) == 0  &&  strcmp( String[1], "id" ) == 0 )
       {
          sscanf( line, "%s%s%s%d", String[0], String[1], Trash, &SocketNow );
-         if ( SocketNow != SocketPrevious )
-         {
-            SocketPrevious = SocketNow;
-            NSocket++;
-         }
+         SocketList.push_back(SocketNow);
       }
+      // Required for std::unique to work
+      std::sort(SocketList.begin(), SocketList.end());
+      // Moves unique elements to front, returns iterator to new end
+      auto last = std::unique(SocketList.begin(), SocketList.end());
+      // Remove trailing duplicates
+      SocketList.erase(last, SocketList.end());
+      NSocket = SocketList.size();
 
       if ( GotFirstCPUInfo )   continue;
 

--- a/src/Auxiliary/Aux_GetCPUInfo.cpp
+++ b/src/Auxiliary/Aux_GetCPUInfo.cpp
@@ -84,7 +84,7 @@ void Aux_GetCPUInfo( const char *FileName )
       }
    }
 
-   for (const auto& masked: SocketMask)
+   for ( const auto& masked: SocketMask )
    {
       if ( masked ) NSocket ++;
    }

--- a/src/Auxiliary/Aux_GetCPUInfo.cpp
+++ b/src/Auxiliary/Aux_GetCPUInfo.cpp
@@ -53,15 +53,6 @@ void Aux_GetCPUInfo( const char *FileName )
          SocketList.push_back(SocketNow);
       }
 
-   // do sorting because std::unique removes consecutive duplicating elements
-      std::sort(SocketList.begin(), SocketList.end());
-   // moves unique elements to front, returns iterator to new end
-      auto last = std::unique(SocketList.begin(), SocketList.end());
-   // remove trailing duplicates from last to end
-      SocketList.erase(last, SocketList.end());
-   // obtain ultimate list size
-      NSocket = SocketList.size();
-
       if ( GotFirstCPUInfo )   continue;
 
       if (  strcmp( String[0], "model" ) == 0  &&  strcmp( String[1], "name" ) == 0  )
@@ -90,6 +81,15 @@ void Aux_GetCPUInfo( const char *FileName )
          GotFirstCPUInfo = true;
       }
    }
+
+// do sorting because std::unique removes consecutive duplicating elements
+   std::sort(SocketList.begin(), SocketList.end());
+// moves unique elements to front, returns iterator to new end
+   auto last = std::unique(SocketList.begin(), SocketList.end());
+// remove trailing duplicates from last to end
+   SocketList.erase(last, SocketList.end());
+// obtain ultimate list size
+   NSocket = SocketList.size();
 
    if ( line != NULL )
    {

--- a/src/Auxiliary/Aux_GetCPUInfo.cpp
+++ b/src/Auxiliary/Aux_GetCPUInfo.cpp
@@ -50,7 +50,7 @@ void Aux_GetCPUInfo( const char *FileName )
       {
          sscanf( line, "%s%s%s%d", String[0], String[1], Trash, &SocketNow );
          if ( (SocketNow + 1) > SocketMask.size() )
-            SocketMask.resize(SocketNow+1, false);
+            SocketMask.resize( SocketNow+1, false );
          if ( !SocketMask[SocketNow] )
             SocketMask[SocketNow] = true;
       }

--- a/src/Auxiliary/Aux_GetCPUInfo.cpp
+++ b/src/Auxiliary/Aux_GetCPUInfo.cpp
@@ -52,12 +52,14 @@ void Aux_GetCPUInfo( const char *FileName )
          sscanf( line, "%s%s%s%d", String[0], String[1], Trash, &SocketNow );
          SocketList.push_back(SocketNow);
       }
-      // Required for std::unique to work
+
+   // do sorting because std::unique removes consecutive duplicating elements
       std::sort(SocketList.begin(), SocketList.end());
-      // Moves unique elements to front, returns iterator to new end
+   // moves unique elements to front, returns iterator to new end
       auto last = std::unique(SocketList.begin(), SocketList.end());
-      // Remove trailing duplicates
+   // remove trailing duplicates from last to end
       SocketList.erase(last, SocketList.end());
+   // obtain ultimate list size
       NSocket = SocketList.size();
 
       if ( GotFirstCPUInfo )   continue;

--- a/src/Auxiliary/Aux_GetCPUInfo.cpp
+++ b/src/Auxiliary/Aux_GetCPUInfo.cpp
@@ -1,5 +1,4 @@
 #include "GAMER.h"
-#include <algorithm>
 #include <vector>
 
 
@@ -27,7 +26,7 @@ void Aux_GetCPUInfo( const char *FileName )
    char String[2][MAX_STRING];
    char Trash[MAX_STRING];
    int SocketNow;
-   std::vector<int> SocketList;
+   std::vector<bool> SocketMask = {false};
    int CorePerSocket = 0, NSocket = 0;
    bool GotFirstCPUInfo = false;
 
@@ -50,7 +49,10 @@ void Aux_GetCPUInfo( const char *FileName )
       if (  strcmp( String[0], "physical" ) == 0  &&  strcmp( String[1], "id" ) == 0 )
       {
          sscanf( line, "%s%s%s%d", String[0], String[1], Trash, &SocketNow );
-         SocketList.push_back(SocketNow);
+         if ( (SocketNow + 1) > SocketMask.size() )
+            SocketMask.resize(SocketNow+1, false);
+         if ( !SocketMask[SocketNow] )
+            SocketMask[SocketNow] = true;
       }
 
       if ( GotFirstCPUInfo )   continue;
@@ -82,14 +84,10 @@ void Aux_GetCPUInfo( const char *FileName )
       }
    }
 
-// do sorting because std::unique removes consecutive duplicating elements
-   std::sort(SocketList.begin(), SocketList.end());
-// moves unique elements to front, returns iterator to new end
-   auto last = std::unique(SocketList.begin(), SocketList.end());
-// remove trailing duplicates from last to end
-   SocketList.erase(last, SocketList.end());
-// obtain ultimate list size
-   NSocket = SocketList.size();
+   for (const auto& masked: SocketMask)
+   {
+      if ( masked ) NSocket ++;
+   }
 
    if ( line != NULL )
    {


### PR DESCRIPTION
* Use C++ Standard vector `SocketMask` and the mask method proposed by @hfhsieh (see discussion below) to compute the CPU socket number.