### PR TITLE
Use defined data type `vla` to do pointer -> pointer of array conversion

### DIFF
--- a/tool/analysis/gamer_extract_profile/Main.cpp
+++ b/tool/analysis/gamer_extract_profile/Main.cpp
@@ -282,8 +282,9 @@ void GetRMS()
    double x, x1, x2, y, y1, y2, z, z1, z2;   // (x,y,z) : relative coordinates to the vector "Center"
    real   pass[NCOMP_PASSIVE];
 
+   typedef real (*vla)[NIn][ArraySize][ArraySize][ArraySize];
    real *Field1D = new real [NPG*8*NIn*ArraySize*ArraySize*ArraySize];
-   real (*Field)[NIn][ArraySize][ArraySize][ArraySize] = ( real(*)[NIn][ArraySize][ArraySize][ArraySize] )Field1D;
+   vla Field = ( vla )Field1D;
 
 
 // determine the target variables
@@ -547,8 +548,9 @@ void ShellAverage()
    double x, x1, x2, y, y1, y2, z, z1, z2;   // (x,y,z) : relative coordinates to the vector "Center"
    real   pass[NCOMP_PASSIVE];
 
+   typedef real (*vla)[NIn][ArraySize][ArraySize][ArraySize];
    real *Field1D = new real [NPG*8*NIn*ArraySize*ArraySize*ArraySize];
-   real (*Field)[NIn][ArraySize][ArraySize][ArraySize] = ( real(*)[NIn][ArraySize][ArraySize][ArraySize] )Field1D;
+   vla Field = ( vla )Field1D;
 
 
 // determine the target variables


### PR DESCRIPTION
* Use defined data type `vla` to do pointer -> pointer of array conversion to avoid trigger compilation error:
   ```
   Main.cpp:286:11: error: cannot initialize a variable of type 'real (*)[NIn][ArraySize][ArraySize][ArraySize]' (aka 'float (*)[NIn][ArraySize][ArraySize][ArraySize]') with an rvalue of type 'real (*)[NIn][ArraySize][ArraySize][ArraySize]' (aka 'float (*)[NIn][ArraySize][ArraySize][ArraySize]')
   real (*Field)[NIn][ArraySize][ArraySize][ArraySize] = ( real(*)[NIn][ArraySize][ArraySize][ArraySize] )Field1D;
          ^                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   Main.cpp:551:11: error: cannot initialize a variable of type 'real (*)[NIn][ArraySize][ArraySize][ArraySize]' (aka 'float (*)[NIn][ArraySize][ArraySize][ArraySize]') with an rvalue of type 'real (*)[NIn][ArraySize][ArraySize][ArraySize]' (aka 'float (*)[NIn][ArraySize][ArraySize][ArraySize]')
   real (*Field)[NIn][ArraySize][ArraySize][ArraySize] = ( real(*)[NIn][ArraySize][ArraySize][ArraySize] )Field1D;
          ^                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ```
   when using `CLANG++`
* ~Results thus produced has not yet been compared to any reference answer.~
* Using the same input snapshot, result obtained on NCTS AMD machine and that on `spock` have difference around machine precision level