### PR TITLE
Optimization CTU CUDA kernel

### DIFF
--- a/src/GPU_API/CUAPI_Asyn_FluidSolver.cu
+++ b/src/GPU_API/CUAPI_Asyn_FluidSolver.cu
@@ -44,7 +44,7 @@ void CUFLU_FluidSolver_MHM(
    const bool JeansMinPres, const real JeansMinPres_Coeff,
    const EoS_t EoS, const MicroPhy_t MicroPhy );
 #elif ( FLU_SCHEME == CTU )
-#ifndef MHD
+#if !defined MHD  &&  !defined FLOAT8
 __global__
 void CUFLU_DR_FCVar(
    const real   g_Flu_Array_In [][NCOMP_TOTAL][ CUBE(FLU_NXT) ],
@@ -56,7 +56,7 @@ void CUFLU_DR_FCVar(
    const long PassiveFloor, const bool FracPassive, const int NFrac,
    const bool JeansMinPres, const real JeansMinPres_Coeff,
    const EoS_t EoS );
-#endif // #ifndef MHD
+#endif // #if !defined MHD  &&  !defined FLOAT8
 __global__
 void CUFLU_FluidSolver_CTU(
    const real   g_Flu_Array_In [][NCOMP_TOTAL][ CUBE(FLU_NXT) ],
@@ -590,7 +590,7 @@ void CUAPI_Asyn_FluidSolver( real h_Flu_Array_In[][FLU_NIN ][ CUBE(FLU_NXT) ],
 
 #        elif ( FLU_SCHEME == CTU )
 
-#        ifndef MHD
+#        if !defined MHD  &&  !defined FLOAT8
          CUFLU_DR_FCVar <<< NPatch_per_Stream[s], BlockDim_FluidSolver, 0, Stream[s] >>>
             ( d_Flu_Array_F_In  + UsedPatch[s],
               d_Mag_Array_F_In  + UsedPatch[s],
@@ -599,7 +599,7 @@ void CUAPI_Asyn_FluidSolver( real h_Flu_Array_In[][FLU_NIN ][ CUBE(FLU_NXT) ],
               MinDens, MinPres, MinEint,
               PassiveFloor, FracPassive, NFrac,
               JeansMinPres, JeansMinPres_Coeff, EoS );
-#        endif // #ifndef MHD
+#        endif // #if !defined MHD  &&  !defined FLOAT8
 
          CUFLU_FluidSolver_CTU <<< NPatch_per_Stream[s], BlockDim_FluidSolver, 0, Stream[s] >>>
             ( d_Flu_Array_F_In  + UsedPatch[s],

--- a/src/GPU_API/CUAPI_Asyn_FluidSolver.cu
+++ b/src/GPU_API/CUAPI_Asyn_FluidSolver.cu
@@ -44,6 +44,19 @@ void CUFLU_FluidSolver_MHM(
    const bool JeansMinPres, const real JeansMinPres_Coeff,
    const EoS_t EoS, const MicroPhy_t MicroPhy );
 #elif ( FLU_SCHEME == CTU )
+#ifndef MHD
+__global__
+void CUFLU_DR_FCVar(
+   const real   g_Flu_Array_In [][NCOMP_TOTAL][ CUBE(FLU_NXT) ],
+   const real   g_Mag_Array_In [][NCOMP_MAG][ FLU_NXT_P1*SQR(FLU_NXT) ],
+         real   g_FC_Var       [][6][NCOMP_TOTAL_PLUS_MAG][ CUBE(N_FC_VAR)    ],
+   const LR_Limiter_t LR_Limiter, const real MinMod_Coeff,
+   const real dt, const real dh,
+   const real MinDens, const real MinPres, const real MinEint,
+   const long PassiveFloor, const bool FracPassive, const int NFrac,
+   const bool JeansMinPres, const real JeansMinPres_Coeff,
+   const EoS_t EoS );
+#endif // #ifndef MHD
 __global__
 void CUFLU_FluidSolver_CTU(
    const real   g_Flu_Array_In [][NCOMP_TOTAL][ CUBE(FLU_NXT) ],
@@ -576,6 +589,17 @@ void CUAPI_Asyn_FluidSolver( real h_Flu_Array_In[][FLU_NIN ][ CUBE(FLU_NXT) ],
               JeansMinPres, JeansMinPres_Coeff, EoS, MicroPhy );
 
 #        elif ( FLU_SCHEME == CTU )
+
+#        ifndef MHD
+         CUFLU_DR_FCVar <<< NPatch_per_Stream[s], BlockDim_FluidSolver, 0, Stream[s] >>>
+            ( d_Flu_Array_F_In  + UsedPatch[s],
+              d_Mag_Array_F_In  + UsedPatch[s],
+              d_FC_Var          + UsedPatch[s],
+              LR_Limiter, MinMod_Coeff, dt, dh,
+              MinDens, MinPres, MinEint,
+              PassiveFloor, FracPassive, NFrac,
+              JeansMinPres, JeansMinPres_Coeff, EoS );
+#        endif // #ifndef MHD
 
          CUFLU_FluidSolver_CTU <<< NPatch_per_Stream[s], BlockDim_FluidSolver, 0, Stream[s] >>>
             ( d_Flu_Array_F_In  + UsedPatch[s],

--- a/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_CTU.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_CTU.cpp
@@ -153,7 +153,7 @@ void Hydro_TGradientCorrection(       real g_FC_Var   [][NCOMP_TOTAL_PLUS_MAG][ 
 //                EoS                : EoS object
 //-------------------------------------------------------------------------------------------------------
 #ifdef __CUDACC__
-#ifndef MHD
+#if !defined MHD  &&  !defined FLOAT8
 // scalar slope limiter (component-wise; no CHAR_RECONSTRUCTION needed)
 GPU_DEVICE
 real Hydro_LimitSlope_Scalar( const real vL, const real vC, const real vR,
@@ -183,7 +183,7 @@ real Hydro_LimitSlope_Scalar( const real vL, const real vC, const real vR,
    }
 }
 
-// fused kernel: Con2Pri + PPM slope + face-centered data reconstruction (replaces CUFLU_PPM_Slope + CUFLU_DR_FCVar)
+// fused kernel: Con2Pri + PPM slope + face-centered data reconstruction
 // eliminates g_PriVar and g_Slope_PPM global roundtrip by computing Con2Pri inline during slab loading
 // and computing PPM limited slopes on-the-fly from the 5-slab shared-memory window
 __global__
@@ -234,13 +234,12 @@ void CUFLU_DR_FCVar(
                                     { 0.0,       0.0, 0.0, 1.0,       0.0 },
                                     { 1.0, NULL_REAL, 0.0, 0.0, NULL_REAL } };
 
-   for (int k_fc = 0; k_fc < N_FC_VAR; k_fc++)
+// sliding-window prologue: load all 5 slabs for k_fc=0 before entering the loop
    {
-//    cooperatively load 5 z-slabs into shared memory, computing Con2Pri inline from g_Flu_Array_In
-      const int k_cc = k_fc + NGhost;
+      const int k_cc_0 = NGhost;
       for (int slab = 0; slab < 5; slab++)
       {
-         const int k_slab = k_cc - 2 + slab;
+         const int k_slab = k_cc_0 - 2 + slab;
          CGPU_LOOP( idx_xy, NIn2 )
          {
             real ConVar[NCOMP_TOTAL], PriVar_tmp[NCOMP_LR];
@@ -255,7 +254,20 @@ void CUFLU_DR_FCVar(
                s_PriVar[slab][v][idx_xy] = PriVar_tmp[v];
          }
       }
-      __syncthreads();
+   }
+   __syncthreads();
+
+// ring-buffer base: physical slot for logical slab 0 (k_cc-2)
+   int base = 0;
+
+   for (int k_fc = 0; k_fc < N_FC_VAR; k_fc++)
+   {
+//    map logical slab indices 0-4 to physical ring slots
+      const int rs0 = base;
+      const int rs1 = (base + 1 < 5) ? base + 1 : base - 4;
+      const int rs2 = (base + 2 < 5) ? base + 2 : base - 3;
+      const int rs3 = (base + 3 < 5) ? base + 3 : base - 2;
+      const int rs4 = (base + 4 < 5) ? base + 4 : base - 1;
 
 //    process all (i_fc, j_fc) in this k-plane
       CGPU_LOOP( idx_ij, N_FC_VAR2 )
@@ -269,7 +281,7 @@ void CUFLU_DR_FCVar(
 
          real cc_C_ncomp[NCOMP_LR], fcCon[6][NCOMP_LR], fcPri[6][NCOMP_LR], dfc[NCOMP_LR], dfc6[NCOMP_LR];
 
-         for (int v = 0; v < NCOMP_LR; v++)   cc_C_ncomp[v] = s_PriVar[2][v][xy_C];
+         for (int v = 0; v < NCOMP_LR; v++)   cc_C_ncomp[v] = s_PriVar[rs2][v][xy_C];
 
          Hydro_GetEigenSystem( cc_C_ncomp, EigenVal, LEigenVec, REigenVec, &EoS );
 
@@ -278,9 +290,9 @@ void CUFLU_DR_FCVar(
             const int faceL      = 2*d;
             const int faceR      = faceL + 1;
 
-//          slab/xy indices for +-1 neighbors; z-dir uses slabs 1/3, x/y-dir uses center slab 2
-            const int slab_L = (d == 2) ? 1 : 2;
-            const int slab_R = (d == 2) ? 3 : 2;
+//          slab/xy indices for +-1 neighbors; z-dir uses ring slots rs1/rs3, x/y uses rs2
+            const int slab_L = (d == 2) ? rs1 : rs2;
+            const int slab_R = (d == 2) ? rs3 : rs2;
             const int  xy_L  = (d == 0) ? xy_C - 1     : (d == 1) ? xy_C - NIn   : xy_C;
             const int  xy_R  = (d == 0) ? xy_C + 1     : (d == 1) ? xy_C + NIn   : xy_C;
             const int  xy_LL = (d == 0) ? xy_C - 2     : (d == 1) ? xy_C - 2*NIn : -1;
@@ -300,13 +312,13 @@ void CUFLU_DR_FCVar(
                if ( LR_Limiter == LR_LIMITER_ATHENA )
                {
 //                all +-1 and +-2 neighbors from shmem (5-slab window covers k_cc-2..k_cc+2)
-                  const real cc_LL = (d < 2) ? s_PriVar[2    ][v][xy_LL]
-                                             : s_PriVar[0    ][v][xy_C  ];
+                  const real cc_LL = (d < 2) ? s_PriVar[rs2][v][xy_LL]
+                                             : s_PriVar[rs0][v][xy_C  ];
                   const real cc_L  = s_PriVar[slab_L][v][xy_L];
                   const real cc_C  = cc_C_ncomp[v];
                   const real cc_R  = s_PriVar[slab_R][v][xy_R];
-                  const real cc_RR = (d < 2) ? s_PriVar[2    ][v][xy_RR]
-                                             : s_PriVar[4    ][v][xy_C  ];
+                  const real cc_RR = (d < 2) ? s_PriVar[rs2][v][xy_RR]
+                                             : s_PriVar[rs4][v][xy_C  ];
 
                   real tmp, rho, cc_abs_max;
                   real d_L, d_R, dd_L, dd_C, dd_R;
@@ -370,12 +382,12 @@ void CUFLU_DR_FCVar(
                   const real cc_R_val = s_PriVar[slab_R][v][xy_R];
                   const real cc_C_val = cc_C_ncomp[v];
 //                +-2 cell values for slope stencil at C-1 and C+1
-                  const real cc_LL_val = (d == 0) ? s_PriVar[2][v][xy_C - 2    ]
-                                       : (d == 1) ? s_PriVar[2][v][xy_C - 2*NIn]
-                                       :            s_PriVar[0][v][xy_C        ];
-                  const real cc_RR_val = (d == 0) ? s_PriVar[2][v][xy_C + 2    ]
-                                       : (d == 1) ? s_PriVar[2][v][xy_C + 2*NIn]
-                                       :            s_PriVar[4][v][xy_C        ];
+                  const real cc_LL_val = (d == 0) ? s_PriVar[rs2][v][xy_C - 2    ]
+                                       : (d == 1) ? s_PriVar[rs2][v][xy_C - 2*NIn]
+                                       :            s_PriVar[rs0][v][xy_C        ];
+                  const real cc_RR_val = (d == 0) ? s_PriVar[rs2][v][xy_C + 2    ]
+                                       : (d == 1) ? s_PriVar[rs2][v][xy_C + 2*NIn]
+                                       :            s_PriVar[rs4][v][xy_C        ];
                   const real dcc_L = Hydro_LimitSlope_Scalar( cc_LL_val, cc_L_val, cc_C_val, LR_Limiter, MinMod_Coeff );
                   const real dcc_C = Hydro_LimitSlope_Scalar( cc_L_val,  cc_C_val, cc_R_val, LR_Limiter, MinMod_Coeff );
                   const real dcc_R = Hydro_LimitSlope_Scalar( cc_C_val,  cc_R_val, cc_RR_val, LR_Limiter, MinMod_Coeff );
@@ -557,10 +569,33 @@ void CUFLU_DR_FCVar(
             g_FC_Var_1PG[f][v][idx_fc_out] = fcCon[f][v];
 
       } // CGPU_LOOP( idx_ij, N_FC_VAR2 )
+
+      __syncthreads(); // ensure all reads of s_PriVar[rs0] (cc_LL, d=2) finish before overwriting it
+
+//    sliding window: load the next "+2" slab into the slot being evicted (rs0),
+//    then advance base so rs0 becomes rs4 for the next iteration
+      if ( k_fc < N_FC_VAR - 1 )
+      {
+         const int k_new = k_fc + NGhost + 3;  // = (k_fc+1) + NGhost + 2
+         CGPU_LOOP( idx_xy, NIn2 )
+         {
+            real ConVar[NCOMP_TOTAL], PriVar_tmp[NCOMP_LR];
+            for (int v = 0; v < NCOMP_TOTAL; v++)
+               ConVar[v] = g_Flu_Array_In_1PG[v][ k_new*NIn2 + idx_xy ];
+            Hydro_Con2Pri( ConVar, PriVar_tmp, MinPres, PassiveFloor, FracPassive, NFrac, c_FracIdx,
+                           JeansMinPres, JeansMinPres_Coeff,
+                           EoS.DensEint2Pres_FuncPtr, EoS.DensPres2Eint_FuncPtr,
+                           EoS.GuessHTilde_FuncPtr, EoS.HTilde2Temp_FuncPtr,
+                           EoS.AuxArrayDevPtr_Flt, EoS.AuxArrayDevPtr_Int, EoS.Table, NULL, NULL );
+            for (int v = 0; v < NCOMP_LR; v++)
+               s_PriVar[base][v][idx_xy] = PriVar_tmp[v];
+         }
+         base = (base + 1 < 5) ? base + 1 : 0;
+      }
       __syncthreads();
    } // for (int k_fc=0; k_fc<N_FC_VAR; k_fc++)
 }
-#endif // #ifndef MHD
+#endif // #if !defined MHD  &&  !defined FLOAT8
 #endif // __CUDACC__
 
 #ifdef __CUDACC__
@@ -630,10 +665,10 @@ void CPU_FluidSolver_CTU(
 #  else
    const bool CorrHalfVel          = false;
 #  endif
-#  if !( defined __CUDACC__  &&  !defined MHD )
+#  if !( defined __CUDACC__  &&  !defined MHD  &&  !defined FLOAT8 )
    const bool CorrHalfVel_No       = false;
 #  endif
-#  if !( defined __CUDACC__  &&  !defined MHD )
+#  if !( defined __CUDACC__  &&  !defined MHD  &&  !defined FLOAT8 )
    const bool Con2Pri_Yes          = true;
 #  endif
 #  ifdef MHD
@@ -663,10 +698,10 @@ void CPU_FluidSolver_CTU(
 //          --> necessary because different patch groups are computed by different OpenMP threads or CUDA blocks in parallel
          real (*const g_FC_Var_1PG   )[NCOMP_TOTAL_PLUS_MAG][ CUBE(N_FC_VAR)    ] = g_FC_Var   [P];
          real (*const g_FC_Flux_1PG  )[NCOMP_TOTAL_PLUS_MAG][ CUBE(N_FC_FLUX)   ] = g_FC_Flux  [P];
-#        if !( defined __CUDACC__  &&  !defined MHD )
+#        if !( defined __CUDACC__  &&  !defined MHD  &&  !defined FLOAT8 )
          real (*const g_PriVar_1PG   )                      [ CUBE(FLU_NXT)     ] = g_PriVar   [P];
 #        endif
-#        if !( defined __CUDACC__  &&  !defined MHD )
+#        if !( defined __CUDACC__  &&  !defined MHD  &&  !defined FLOAT8 )
          real (*const g_Slope_PPM_1PG)[NCOMP_LR            ][ CUBE(N_SLOPE_PPM) ] = g_Slope_PPM[P];
 #        endif
 
@@ -674,7 +709,7 @@ void CPU_FluidSolver_CTU(
          real (*const g_FC_Mag_Half_1PG)[ FLU_NXT_P1*SQR(FLU_NXT) ] = g_FC_Mag_Half[P];
          real (*const g_EC_Ele_1PG     )[ CUBE(N_EC_ELE)          ] = g_EC_Ele     [P];
          real (*const g_PriVar_Half_1PG)[ CUBE(FLU_NXT) ]           = g_PriVar_1PG;
-#        elif !defined __CUDACC__
+#        elif !( defined __CUDACC__  &&  !defined FLOAT8 )
          real (*const g_FC_Mag_Half_1PG)[ FLU_NXT_P1*SQR(FLU_NXT) ] = NULL;
          real (*const g_EC_Ele_1PG     )[ CUBE(N_EC_ELE)          ] = NULL;
 #        endif
@@ -682,8 +717,8 @@ void CPU_FluidSolver_CTU(
 
 //       1. evaluate the face-centered values at the half time-step
 //          GPU non-MHD: CUFLU_DR_FCVar has already filled g_FC_Var; skip here
-//          CPU or GPU+MHD: full inline
-#        if !( defined __CUDACC__  &&  !defined MHD )
+//          CPU or GPU+MHD or GPU+FLOAT8: full inline
+#        if !( defined __CUDACC__  &&  !defined MHD  &&  !defined FLOAT8 )
          Hydro_DataReconstruction( g_Flu_Array_In[P], g_Mag_Array_In[P], g_PriVar_1PG, g_FC_Var_1PG, g_Slope_PPM_1PG,
                                    NULL, Con2Pri_Yes, LR_Limiter, MinMod_Coeff, dt, dh,
                                    MinDens, MinPres, MinEint, PassiveFloor, FracPassive, NFrac, c_FracIdx,
@@ -691,9 +726,9 @@ void CPU_FluidSolver_CTU(
 #        endif
 
 
-//       2-4. GPU non-MHD: k-slab pipeline — half-step Riemanns into shmem ping-pong buffers,
+//       2-4. GPU non-MHD non-FLOAT8: k-slab pipeline — half-step Riemanns into shmem ping-pong buffers,
 //            inline TGrad from shmem; eliminates ~50 MB DRAM roundtrip of g_FC_Flux_1PG[half-step]
-#        if ( defined __CUDACC__  &&  !defined MHD )
+#        if ( defined __CUDACC__  &&  !defined MHD  &&  !defined FLOAT8 )
          {
             const int  N_FC_VAR2  = SQR(N_FC_VAR);
             const real dt_dh2     = (real)0.5*dt/dh;
@@ -926,7 +961,7 @@ void CPU_FluidSolver_CTU(
 
          } // k-slab block
 
-#        else // !( defined __CUDACC__  &&  !defined MHD ): CPU or MHD — standard path
+#        else // !( defined __CUDACC__  &&  !defined MHD  &&  !defined FLOAT8 ): CPU, MHD, or FLOAT8 — standard path
 
 //       2. evaluate the face-centered half-step fluxes by solving the Riemann problem
          Hydro_ComputeFlux( g_FC_Var_1PG, g_FC_Flux_1PG, N_HF_FLUX, 0, 0, CorrHalfVel_No,
@@ -951,7 +986,7 @@ void CPU_FluidSolver_CTU(
          Hydro_TGradientCorrection( g_FC_Var_1PG, g_FC_Flux_1PG, g_Mag_Array_In[P], g_FC_Mag_Half_1PG, g_EC_Ele_1PG, g_PriVar_1PG,
                                     dt, dh, MinDens, MinEint, PassiveFloor );
 
-#        endif // #if ( defined __CUDACC__  &&  !defined MHD )
+#        endif // #if ( defined __CUDACC__  &&  !defined MHD  &&  !defined FLOAT8 )
 
 
 //       5. evaluate the cell-centered primitive variables at the half time-step

--- a/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_CTU.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_CTU.cpp
@@ -153,6 +153,417 @@ void Hydro_TGradientCorrection(       real g_FC_Var   [][NCOMP_TOTAL_PLUS_MAG][ 
 //                EoS                : EoS object
 //-------------------------------------------------------------------------------------------------------
 #ifdef __CUDACC__
+#ifndef MHD
+// scalar slope limiter (component-wise; no CHAR_RECONSTRUCTION needed)
+GPU_DEVICE
+real Hydro_LimitSlope_Scalar( const real vL, const real vC, const real vR,
+                               const LR_Limiter_t LR_Limiter, const real MinMod_Coeff )
+{
+   const real SL = vC - vL;
+   const real SR = vR - vC;
+   if ( SL * SR <= (real)0.0 ) return (real)0.0;
+   const real SC = (real)0.5 * ( SL + SR );
+   switch ( LR_Limiter )
+   {
+      case LR_LIMITER_CENTRAL:
+         return SC;
+      case LR_LIMITER_VANLEER:
+         return (real)2.0 * SL * SR / ( SL + SR );
+      case LR_LIMITER_GMINMOD:
+         return SIGN(SC) * FMIN( MinMod_Coeff*FABS(SL), FMIN( MinMod_Coeff*FABS(SR), FABS(SC) ) );
+      case LR_LIMITER_ALBADA:
+         return SL * SR * ( SL + SR ) / ( SL*SL + SR*SR );
+      case LR_LIMITER_VL_GMINMOD: {
+         const real SA = (real)2.0 * SL * SR / ( SL + SR );
+         return SIGN(SC) * FMIN( MinMod_Coeff*FABS(SL),
+                           FMIN( MinMod_Coeff*FABS(SR),
+                           FMIN( FABS(SC), FABS(SA) ) ) );
+      }
+      default: return (real)0.0;
+   }
+}
+
+// fused kernel: Con2Pri + PPM slope + face-centered data reconstruction (replaces CUFLU_PPM_Slope + CUFLU_DR_FCVar)
+// eliminates g_PriVar and g_Slope_PPM global roundtrip by computing Con2Pri inline during slab loading
+// and computing PPM limited slopes on-the-fly from the 5-slab shared-memory window
+__global__
+__launch_bounds__( FLU_BLOCK_SIZE_X )
+void CUFLU_DR_FCVar(
+   const real   g_Flu_Array_In [][NCOMP_TOTAL][ CUBE(FLU_NXT) ],
+   const real   g_Mag_Array_In [][NCOMP_MAG][ FLU_NXT_P1*SQR(FLU_NXT) ],
+         real   g_FC_Var       [][6][NCOMP_TOTAL_PLUS_MAG][ CUBE(N_FC_VAR)    ],
+   const LR_Limiter_t LR_Limiter, const real MinMod_Coeff,
+   const real dt, const real dh,
+   const real MinDens, const real MinPres, const real MinEint,
+   const long PassiveFloor, const bool FracPassive, const int NFrac,
+   const bool JeansMinPres, const real JeansMinPres_Coeff,
+   const EoS_t EoS )
+{
+   const int P = blockIdx.x;
+   const real (*const g_Flu_Array_In_1PG)[CUBE(FLU_NXT)] = g_Flu_Array_In[P];
+         real (*const g_FC_Var_1PG   )[NCOMP_TOTAL_PLUS_MAG][CUBE(N_FC_VAR)] = g_FC_Var[P];
+
+// 5 z-slabs of PriVar: covers (k_cc-2..k_cc+2) for each k_fc plane
+// Con2Pri computed inline from g_Flu_Array_In; eliminates g_PriVar + g_Slope_PPM global roundtrip
+   __shared__ real s_PriVar[5][NCOMP_LR][ SQR(FLU_NXT) ];
+
+   const int NIn           = FLU_NXT;
+   const int NGhost        = LR_GHOST_SIZE;
+   const int N_FC_VAR2     = SQR( N_FC_VAR );
+   const int NIn2          = SQR( NIn );
+   const real dt_dh2       = (real)0.5*dt/dh;
+   const int idx_wave[NWAVE] = { 0, 1, 2, 3, 4 };
+
+#  if (  ( RSOLVER == HLLE || RSOLVER == HLLC || RSOLVER == HLLD )  &&  defined HLL_NO_REF_STATE  )
+#  ifdef HLL_INCLUDE_ALL_WAVES
+   const bool HLL_Include_All_Waves = true;
+#  else
+   const bool HLL_Include_All_Waves = false;
+#  endif
+#  endif
+
+   real EigenVal[3][NWAVE];
+   real LEigenVec[NWAVE][NWAVE] = { { 0.0, NULL_REAL, 0.0, 0.0, NULL_REAL },
+                                    { 1.0,       0.0, 0.0, 0.0, NULL_REAL },
+                                    { 0.0,       0.0, 1.0, 0.0,       0.0 },
+                                    { 0.0,       0.0, 0.0, 1.0,       0.0 },
+                                    { 0.0, NULL_REAL, 0.0, 0.0, NULL_REAL } };
+   real REigenVec[NWAVE][NWAVE] = { { 1.0, NULL_REAL, 0.0, 0.0, NULL_REAL },
+                                    { 1.0,       0.0, 0.0, 0.0,       0.0 },
+                                    { 0.0,       0.0, 1.0, 0.0,       0.0 },
+                                    { 0.0,       0.0, 0.0, 1.0,       0.0 },
+                                    { 1.0, NULL_REAL, 0.0, 0.0, NULL_REAL } };
+
+   for (int k_fc = 0; k_fc < N_FC_VAR; k_fc++)
+   {
+//    cooperatively load 5 z-slabs into shared memory, computing Con2Pri inline from g_Flu_Array_In
+      const int k_cc = k_fc + NGhost;
+      for (int slab = 0; slab < 5; slab++)
+      {
+         const int k_slab = k_cc - 2 + slab;
+         CGPU_LOOP( idx_xy, NIn2 )
+         {
+            real ConVar[NCOMP_TOTAL], PriVar_tmp[NCOMP_LR];
+            for (int v = 0; v < NCOMP_TOTAL; v++)
+               ConVar[v] = g_Flu_Array_In_1PG[v][ k_slab*NIn2 + idx_xy ];
+            Hydro_Con2Pri( ConVar, PriVar_tmp, MinPres, PassiveFloor, FracPassive, NFrac, c_FracIdx,
+                           JeansMinPres, JeansMinPres_Coeff,
+                           EoS.DensEint2Pres_FuncPtr, EoS.DensPres2Eint_FuncPtr,
+                           EoS.GuessHTilde_FuncPtr, EoS.HTilde2Temp_FuncPtr,
+                           EoS.AuxArrayDevPtr_Flt, EoS.AuxArrayDevPtr_Int, EoS.Table, NULL, NULL );
+            for (int v = 0; v < NCOMP_LR; v++)
+               s_PriVar[slab][v][idx_xy] = PriVar_tmp[v];
+         }
+      }
+      __syncthreads();
+
+//    process all (i_fc, j_fc) in this k-plane
+      CGPU_LOOP( idx_ij, N_FC_VAR2 )
+      {
+         const int i_fc      = idx_ij % N_FC_VAR;
+         const int j_fc      = idx_ij / N_FC_VAR;
+         const int i_cc      = i_fc + NGhost;
+         const int j_cc      = j_fc + NGhost;
+         const int idx_fc_out = k_fc*N_FC_VAR2 + idx_ij;
+         const int xy_C      = j_cc*NIn + i_cc;
+
+         real cc_C_ncomp[NCOMP_LR], fcCon[6][NCOMP_LR], fcPri[6][NCOMP_LR], dfc[NCOMP_LR], dfc6[NCOMP_LR];
+
+         for (int v = 0; v < NCOMP_LR; v++)   cc_C_ncomp[v] = s_PriVar[2][v][xy_C];
+
+         Hydro_GetEigenSystem( cc_C_ncomp, EigenVal, LEigenVec, REigenVec, &EoS );
+
+         for (int d = 0; d < 3; d++)
+         {
+            const int faceL      = 2*d;
+            const int faceR      = faceL + 1;
+
+//          slab/xy indices for +-1 neighbors; z-dir uses slabs 1/3, x/y-dir uses center slab 2
+            const int slab_L = (d == 2) ? 1 : 2;
+            const int slab_R = (d == 2) ? 3 : 2;
+            const int  xy_L  = (d == 0) ? xy_C - 1     : (d == 1) ? xy_C - NIn   : xy_C;
+            const int  xy_R  = (d == 0) ? xy_C + 1     : (d == 1) ? xy_C + NIn   : xy_C;
+            const int  xy_LL = (d == 0) ? xy_C - 2     : (d == 1) ? xy_C - 2*NIn : -1;
+            const int  xy_RR = (d == 0) ? xy_C + 2     : (d == 1) ? xy_C + 2*NIn : -1;
+
+#           ifdef FLOAT8
+            const real round_err = 1.e-12;
+#           else
+            const real round_err = 1.e-6;
+#           endif
+            const real C_factor  = 1.25;
+
+            for (int v = 0; v < NCOMP_LR; v++)
+            {
+               real fc_L, fc_R;
+
+               if ( LR_Limiter == LR_LIMITER_ATHENA )
+               {
+//                all +-1 and +-2 neighbors from shmem (5-slab window covers k_cc-2..k_cc+2)
+                  const real cc_LL = (d < 2) ? s_PriVar[2    ][v][xy_LL]
+                                             : s_PriVar[0    ][v][xy_C  ];
+                  const real cc_L  = s_PriVar[slab_L][v][xy_L];
+                  const real cc_C  = cc_C_ncomp[v];
+                  const real cc_R  = s_PriVar[slab_R][v][xy_R];
+                  const real cc_RR = (d < 2) ? s_PriVar[2    ][v][xy_RR]
+                                             : s_PriVar[4    ][v][xy_C  ];
+
+                  real tmp, rho, cc_abs_max;
+                  real d_L, d_R, dd_L, dd_C, dd_R;
+                  real dh_LL, dh_L, dh_R, dh_RR, ddh_L, ddh_C, ddh_R;
+
+                  d_L  = cc_C  - cc_L;
+                  d_R  = cc_R  - cc_C;
+                  dd_L = cc_LL - (real)2.*cc_L + cc_C;
+                  dd_C = cc_L  - (real)2.*cc_C + cc_R;
+                  dd_R = cc_C  - (real)2.*cc_R + cc_RR;
+
+                  cc_abs_max = FMAX( FABS(cc_LL), FMAX( FABS(cc_L), FMAX( FABS(cc_C), FMAX( FABS(cc_R), FABS(cc_RR) ) ) ) );
+
+                  fc_L = ( -cc_LL + (real)7.*cc_L + (real)7.*cc_C - cc_R  ) / (real)12.0;
+                  fc_R = ( -cc_L  + (real)7.*cc_C + (real)7.*cc_R - cc_RR ) / (real)12.0;
+
+                  dh_LL = fc_L - cc_L;
+                  dh_L  = cc_C - fc_L;
+                  dh_R  = fc_R - cc_C;
+                  dh_RR = cc_R - fc_R;
+                  ddh_L = cc_L - (real)2.*fc_L + cc_C;
+                  ddh_C = fc_L - (real)2.*cc_C + fc_R;
+                  ddh_R = cc_C - (real)2.*fc_R + cc_R;
+
+                  if ( dh_LL*dh_L < (real)0.0 ) {
+                     if ( SIGN(dd_L) == SIGN(ddh_L)  &&  SIGN(ddh_L) == SIGN(dd_C) )
+                        tmp = SIGN(dd_C)*FMIN( C_factor*FABS(dd_L), FMIN( (real)3.*FABS(ddh_L), C_factor*FABS(dd_C) ) );
+                     else
+                        tmp = (real)0.0;
+                     fc_L  = (real)0.5*(cc_L+cc_C) - tmp/(real)6.0;
+                     dh_L  = cc_C - fc_L;
+                     ddh_C = fc_L - (real)2.*cc_C + fc_R;
+                  }
+
+                  if ( dh_R*dh_RR < (real)0.0 ) {
+                     if ( SIGN(dd_C) == SIGN(ddh_R)  &&  SIGN(ddh_R) == SIGN(dd_R) )
+                        tmp = SIGN(dd_C)*FMIN( C_factor*FABS(dd_C), FMIN( (real)3.*FABS(ddh_R), C_factor*FABS(dd_R) ) );
+                     else
+                        tmp = (real)0.0;
+                     fc_R  = (real)0.5*(cc_C+cc_R) - tmp/(real)6.0;
+                     dh_R  = fc_R - cc_C;
+                     ddh_C = fc_L - (real)2.*cc_C + fc_R;
+                  }
+
+                  if ( SIGN(dd_L) == SIGN(dd_C)  &&  SIGN(dd_C) == SIGN(dd_R)  &&  SIGN(dd_R) == SIGN(ddh_C) )
+                     tmp = SIGN(dd_C)*FMIN( C_factor*FABS(dd_L), FMIN( C_factor*FABS(dd_C), FMIN( C_factor*FABS(dd_R), (real)6.0*FABS(ddh_C) ) ) );
+                  else
+                     tmp = (real)0.0;
+
+                  rho = ( (real)6.*FABS(ddh_C) > round_err*cc_abs_max ) ? tmp/ddh_C/(real)6. : (real)0.0;
+
+                  if ( dh_L*dh_R < (real)0.0  ||  d_L*d_R < (real)0.0 ) {
+                     if ( rho < (real)1.-round_err ) { fc_L = cc_C - rho*dh_L;  fc_R = cc_C + rho*dh_R; }
+                  } else {
+                     if ( FABS(dh_L) >= (real)2.*FABS(dh_R) )   fc_L = cc_C - (real)2.*dh_R;
+                     if ( FABS(dh_R) >= (real)2.*FABS(dh_L) )   fc_R = cc_C + (real)2.*dh_L;
+                  }
+
+               } else { // non-ATHENA: all reads from shmem; slopes computed inline
+                  const real cc_L_val = s_PriVar[slab_L][v][xy_L];
+                  const real cc_R_val = s_PriVar[slab_R][v][xy_R];
+                  const real cc_C_val = cc_C_ncomp[v];
+//                +-2 cell values for slope stencil at C-1 and C+1
+                  const real cc_LL_val = (d == 0) ? s_PriVar[2][v][xy_C - 2    ]
+                                       : (d == 1) ? s_PriVar[2][v][xy_C - 2*NIn]
+                                       :            s_PriVar[0][v][xy_C        ];
+                  const real cc_RR_val = (d == 0) ? s_PriVar[2][v][xy_C + 2    ]
+                                       : (d == 1) ? s_PriVar[2][v][xy_C + 2*NIn]
+                                       :            s_PriVar[4][v][xy_C        ];
+                  const real dcc_L = Hydro_LimitSlope_Scalar( cc_LL_val, cc_L_val, cc_C_val, LR_Limiter, MinMod_Coeff );
+                  const real dcc_C = Hydro_LimitSlope_Scalar( cc_L_val,  cc_C_val, cc_R_val, LR_Limiter, MinMod_Coeff );
+                  const real dcc_R = Hydro_LimitSlope_Scalar( cc_C_val,  cc_R_val, cc_RR_val, LR_Limiter, MinMod_Coeff );
+
+                  fc_L = (real)0.5*( cc_C_val + cc_L_val ) - (real)1.0/(real)6.0*( dcc_C - dcc_L );
+                  fc_R = (real)0.5*( cc_C_val + cc_R_val ) - (real)1.0/(real)6.0*( dcc_R - dcc_C );
+
+                  if ( LR_Limiter == LR_LIMITER_CENTRAL )
+                  {
+                     if ( (cc_C_val-fc_L)*(fc_L-cc_L_val) < (real)0.0 )   fc_L = (real)0.5*(cc_C_val+cc_L_val);
+                     if ( (cc_R_val-fc_R)*(fc_R-cc_C_val) < (real)0.0 )   fc_R = (real)0.5*(cc_C_val+cc_R_val);
+                  }
+
+                  dfc [v] = fc_R - fc_L;
+                  dfc6[v] = (real)6.0*(  cc_C_val - (real)0.5*( fc_L + fc_R )  );
+
+                  if (  ( fc_R - cc_C_val )*( cc_C_val - fc_L ) <= (real)0.0  )
+                  {
+                     fc_L = cc_C_val;
+                     fc_R = cc_C_val;
+                  }
+                  else if ( dfc[v]*dfc6[v] > +dfc[v]*dfc[v] )
+                     fc_L = (real)3.0*cc_C_val - (real)2.0*fc_R;
+                  else if ( dfc[v]*dfc6[v] < -dfc[v]*dfc[v] )
+                     fc_R = (real)3.0*cc_C_val - (real)2.0*fc_L;
+
+                  real Min, Max;
+                  Min  = ( cc_C_val < cc_L_val ) ? cc_C_val : cc_L_val;
+                  Max  = ( cc_C_val > cc_L_val ) ? cc_C_val : cc_L_val;
+                  fc_L = ( fc_L > Min ) ? fc_L : Min;
+                  fc_L = ( fc_L < Max ) ? fc_L : Max;
+
+                  Min  = ( cc_C_val < cc_R_val ) ? cc_C_val : cc_R_val;
+                  Max  = ( cc_C_val > cc_R_val ) ? cc_C_val : cc_R_val;
+                  fc_R = ( fc_R > Min ) ? fc_R : Min;
+                  fc_R = ( fc_R < Max ) ? fc_R : Max;
+               } // if ( LR_Limiter == LR_LIMITER_ATHENA ) ... else ...
+
+               fcPri[faceL][v] = fc_L;
+               fcPri[faceR][v] = fc_R;
+
+            } // for (int v=0; v<NCOMP_LR; v++)
+
+
+//          4. advance by half time-step (CTU)
+            real Coeff_L, Coeff_R;
+            real Correct_L[NCOMP_LR], Correct_R[NCOMP_LR];
+
+            for (int v = 0; v < NCOMP_LR; v++)
+            {
+               dfc [v] = fcPri[faceR][v] - fcPri[faceL][v];
+               dfc6[v] = (real)6.0*(  cc_C_ncomp[v] - (real)0.5*( fcPri[faceL][v] + fcPri[faceR][v] )  );
+            }
+
+            Hydro_Rotate3D( dfc,  d, true, MAG_OFFSET );
+            Hydro_Rotate3D( dfc6, d, true, MAG_OFFSET );
+
+#           if (  ( RSOLVER == HLLE || RSOLVER == HLLC || RSOLVER == HLLD )  &&  defined HLL_NO_REF_STATE  )
+            for (int v = 0; v < NWAVE; v++)
+            {
+               Correct_L[ idx_wave[v] ] = (real)0.0;
+               Correct_R[ idx_wave[v] ] = (real)0.0;
+            }
+
+            for (int Mode = 0; Mode < NWAVE; Mode++)
+            {
+               Coeff_L = (real)0.0;
+               Coeff_R = (real)0.0;
+
+               if ( HLL_Include_All_Waves  ||  EigenVal[d][Mode] <= (real)0.0 )
+               {
+                  const real Coeff_C = -dt_dh2*EigenVal[d][Mode];
+                  const real Coeff_D = real(-4.0/3.0)*SQR(Coeff_C);
+
+                  for (int v = 0; v < NWAVE; v++)
+                     Coeff_L += LEigenVec[Mode][v]*(  Coeff_C*( dfc[ idx_wave[v] ] + dfc6[ idx_wave[v] ] ) +
+                                                      Coeff_D*( dfc6[ idx_wave[v] ]                      )  );
+                  for (int v = 0; v < NWAVE; v++)
+                     Correct_L[ idx_wave[v] ] += Coeff_L*REigenVec[Mode][v];
+               }
+
+               if ( HLL_Include_All_Waves  ||  EigenVal[d][Mode] >= (real)0.0 )
+               {
+                  const real Coeff_A = -dt_dh2*EigenVal[d][Mode];
+                  const real Coeff_B = real(-4.0/3.0)*SQR(Coeff_A);
+
+                  for (int v = 0; v < NWAVE; v++)
+                     Coeff_R += LEigenVec[Mode][v]*(  Coeff_A*( dfc[ idx_wave[v] ] - dfc6[ idx_wave[v] ] ) +
+                                                      Coeff_B*( dfc6[ idx_wave[v] ]                      )  );
+                  for (int v = 0; v < NWAVE; v++)
+                     Correct_R[ idx_wave[v] ] += Coeff_R*REigenVec[Mode][v];
+               }
+            } // for (int Mode=0; Mode<NWAVE; Mode++)
+
+#           else // Roe / exact solver
+            Coeff_L = -dt_dh2*FMIN( EigenVal[d][       0 ], (real)0.0 );
+            Coeff_R = -dt_dh2*FMAX( EigenVal[d][ NWAVE-1 ], (real)0.0 );
+
+            for (int v = 0; v < NWAVE; v++)
+            {
+               Correct_L[ idx_wave[v] ] = Coeff_L*(  dfc[ idx_wave[v] ] + ( (real)1.0 - real(4.0/3.0)*Coeff_L )*dfc6[ idx_wave[v] ]  );
+               Correct_R[ idx_wave[v] ] = Coeff_R*(  dfc[ idx_wave[v] ] - ( (real)1.0 + real(4.0/3.0)*Coeff_R )*dfc6[ idx_wave[v] ]  );
+            }
+
+            for (int Mode = 0; Mode < NWAVE; Mode++)
+            {
+               Coeff_L = (real)0.0;
+               Coeff_R = (real)0.0;
+
+               if ( EigenVal[d][Mode] <= (real)0.0 )
+               {
+                  const real Coeff_C = dt_dh2*( EigenVal[d][0] - EigenVal[d][Mode] );
+                  const real Coeff_D = real(4.0/3.0)*dt_dh2*Coeff_C*( EigenVal[d][0] + EigenVal[d][Mode] );
+
+                  for (int v = 0; v < NWAVE; v++)
+                     Coeff_L += LEigenVec[Mode][v]*(  Coeff_C*( dfc[ idx_wave[v] ] + dfc6[ idx_wave[v] ] ) +
+                                                      Coeff_D*( dfc6[ idx_wave[v] ]                      )  );
+                  for (int v = 0; v < NWAVE; v++)
+                     Correct_L[ idx_wave[v] ] += Coeff_L*REigenVec[Mode][v];
+               }
+
+               if ( EigenVal[d][Mode] >= (real)0.0 )
+               {
+                  const real Coeff_A = dt_dh2*( EigenVal[d][ NWAVE-1 ] - EigenVal[d][Mode] );
+                  const real Coeff_B = real(4.0/3.0)*dt_dh2*Coeff_A*( EigenVal[d][ NWAVE-1 ] + EigenVal[d][Mode] );
+
+                  for (int v = 0; v < NWAVE; v++)
+                     Coeff_R += LEigenVec[Mode][v]*(  Coeff_A*( dfc[ idx_wave[v] ] - dfc6[ idx_wave[v] ] ) +
+                                                      Coeff_B*( dfc6[ idx_wave[v] ]                      )  );
+                  for (int v = 0; v < NWAVE; v++)
+                     Correct_R[ idx_wave[v] ] += Coeff_R*REigenVec[Mode][v];
+               }
+            } // for (int Mode=0; Mode<NWAVE; Mode++)
+
+#           endif // if (  ( RSOLVER == HLLE || RSOLVER == HLLC || RSOLVER == HLLD )  &&  defined HLL_NO_REF_STATE  ) ... else ...
+
+#           if ( NCOMP_PASSIVE > 0 )
+            Coeff_L = -dt_dh2*FMIN( EigenVal[d][1], (real)0.0 );
+            Coeff_R = -dt_dh2*FMAX( EigenVal[d][1], (real)0.0 );
+            for (int v = NCOMP_FLUID; v < NCOMP_TOTAL; v++)
+            {
+               Correct_L[v] = Coeff_L*(  dfc[v] + ( (real)1.0 - real(4.0/3.0)*Coeff_L )*dfc6[v]  );
+               Correct_R[v] = Coeff_R*(  dfc[v] - ( (real)1.0 + real(4.0/3.0)*Coeff_R )*dfc6[v]  );
+            }
+#           endif
+
+            Hydro_Rotate3D( Correct_L, d, false, MAG_OFFSET );
+            Hydro_Rotate3D( Correct_R, d, false, MAG_OFFSET );
+
+            for (int v = 0; v < NCOMP_LR; v++)
+            {
+               fcPri[faceL][v] += Correct_L[v];
+               fcPri[faceR][v] += Correct_R[v];
+            }
+
+            fcPri[faceL][0] = FMAX( fcPri[faceL][0], MinDens );
+            fcPri[faceR][0] = FMAX( fcPri[faceR][0], MinDens );
+            fcPri[faceL][4] = Hydro_CheckMinPres( fcPri[faceL][4], MinPres );
+            fcPri[faceR][4] = Hydro_CheckMinPres( fcPri[faceR][4], MinPres );
+
+#           if ( NCOMP_PASSIVE > 0 )
+            for (int v = NCOMP_FLUID; v < NCOMP_TOTAL; v++)
+               if ( PassiveFloor & BIDX(v) ) {
+               fcPri[faceL][v] = FMAX( fcPri[faceL][v], TINY_NUMBER );
+               fcPri[faceR][v] = FMAX( fcPri[faceR][v], TINY_NUMBER ); }
+#           endif
+
+            Hydro_Pri2Con( fcPri[faceL], fcCon[faceL], FracPassive, NFrac, c_FracIdx,
+                           EoS.DensPres2Eint_FuncPtr, EoS.Temp2HTilde_FuncPtr, EoS.HTilde2Temp_FuncPtr,
+                           EoS.AuxArrayDevPtr_Flt, EoS.AuxArrayDevPtr_Int, EoS.Table, NULL );
+            Hydro_Pri2Con( fcPri[faceR], fcCon[faceR], FracPassive, NFrac, c_FracIdx,
+                           EoS.DensPres2Eint_FuncPtr, EoS.Temp2HTilde_FuncPtr, EoS.HTilde2Temp_FuncPtr,
+                           EoS.AuxArrayDevPtr_Flt, EoS.AuxArrayDevPtr_Int, EoS.Table, NULL );
+
+         } // for (int d=0; d<3; d++)
+
+         for (int f = 0; f < 6; f++)
+         for (int v = 0; v < NCOMP_TOTAL_PLUS_MAG; v++)
+            g_FC_Var_1PG[f][v][idx_fc_out] = fcCon[f][v];
+
+      } // CGPU_LOOP( idx_ij, N_FC_VAR2 )
+      __syncthreads();
+   } // for (int k_fc=0; k_fc<N_FC_VAR; k_fc++)
+}
+#endif // #ifndef MHD
+#endif // __CUDACC__
+
+#ifdef __CUDACC__
 __global__
 void CUFLU_FluidSolver_CTU(
    const real   g_Flu_Array_In [][NCOMP_TOTAL][ CUBE(FLU_NXT) ],
@@ -219,8 +630,12 @@ void CPU_FluidSolver_CTU(
 #  else
    const bool CorrHalfVel          = false;
 #  endif
+#  if !( defined __CUDACC__  &&  !defined MHD )
    const bool CorrHalfVel_No       = false;
+#  endif
+#  if !( defined __CUDACC__  &&  !defined MHD )
    const bool Con2Pri_Yes          = true;
+#  endif
 #  ifdef MHD
    const bool StoreElectric_No     = false;
 #  endif
@@ -248,25 +663,270 @@ void CPU_FluidSolver_CTU(
 //          --> necessary because different patch groups are computed by different OpenMP threads or CUDA blocks in parallel
          real (*const g_FC_Var_1PG   )[NCOMP_TOTAL_PLUS_MAG][ CUBE(N_FC_VAR)    ] = g_FC_Var   [P];
          real (*const g_FC_Flux_1PG  )[NCOMP_TOTAL_PLUS_MAG][ CUBE(N_FC_FLUX)   ] = g_FC_Flux  [P];
+#        if !( defined __CUDACC__  &&  !defined MHD )
          real (*const g_PriVar_1PG   )                      [ CUBE(FLU_NXT)     ] = g_PriVar   [P];
+#        endif
+#        if !( defined __CUDACC__  &&  !defined MHD )
          real (*const g_Slope_PPM_1PG)[NCOMP_LR            ][ CUBE(N_SLOPE_PPM) ] = g_Slope_PPM[P];
+#        endif
 
 #        ifdef MHD
          real (*const g_FC_Mag_Half_1PG)[ FLU_NXT_P1*SQR(FLU_NXT) ] = g_FC_Mag_Half[P];
          real (*const g_EC_Ele_1PG     )[ CUBE(N_EC_ELE)          ] = g_EC_Ele     [P];
          real (*const g_PriVar_Half_1PG)[ CUBE(FLU_NXT) ]           = g_PriVar_1PG;
-#        else
+#        elif !defined __CUDACC__
          real (*const g_FC_Mag_Half_1PG)[ FLU_NXT_P1*SQR(FLU_NXT) ] = NULL;
          real (*const g_EC_Ele_1PG     )[ CUBE(N_EC_ELE)          ] = NULL;
 #        endif
 
 
 //       1. evaluate the face-centered values at the half time-step
+//          GPU non-MHD: CUFLU_DR_FCVar has already filled g_FC_Var; skip here
+//          CPU or GPU+MHD: full inline
+#        if !( defined __CUDACC__  &&  !defined MHD )
          Hydro_DataReconstruction( g_Flu_Array_In[P], g_Mag_Array_In[P], g_PriVar_1PG, g_FC_Var_1PG, g_Slope_PPM_1PG,
                                    NULL, Con2Pri_Yes, LR_Limiter, MinMod_Coeff, dt, dh,
                                    MinDens, MinPres, MinEint, PassiveFloor, FracPassive, NFrac, c_FracIdx,
                                    JeansMinPres, JeansMinPres_Coeff, &EoS );
+#        endif
 
+
+//       2-4. GPU non-MHD: k-slab pipeline — half-step Riemanns into shmem ping-pong buffers,
+//            inline TGrad from shmem; eliminates ~50 MB DRAM roundtrip of g_FC_Flux_1PG[half-step]
+#        if ( defined __CUDACC__  &&  !defined MHD )
+         {
+            const int  N_FC_VAR2  = SQR(N_FC_VAR);
+            const real dt_dh2     = (real)0.5*dt/dh;
+            const int  didx_FC[3] = { 1, N_FC_VAR, N_FC_VAR2 };
+
+//          ping-pong shmem for half-step fluxes; pp = current k-plane, pq = previous
+            __shared__ real s_FluxX[2][NCOMP_TOTAL][SQR(N_FC_VAR)];
+            __shared__ real s_FluxY[2][NCOMP_TOTAL][SQR(N_FC_VAR)];
+            __shared__ real s_FluxZ[2][NCOMP_TOTAL][SQR(N_FC_VAR)];
+
+            for (int k_fc = 0; k_fc < N_FC_VAR; k_fc++)
+            {
+               const int pp = k_fc & 1;
+               const int pq = 1 - pp;
+
+//             step 1: half-step Riemann for d=0 (x), d=1 (y), d=2 (z, skipped at k_fc=0)
+               for (int d_r = 0; d_r < 3; d_r++)
+               {
+                  if ( d_r == 2  &&  k_fc == 0 )   continue;
+
+                  const int faceR    = 2*d_r + 1;    // right face of L cell
+                  const int faceL    = 2*d_r;         // left  face of R cell
+                  const int n_flux_i = (d_r == 0) ? N_FC_VAR-1 : N_FC_VAR;
+                  const int n_flux_j = (d_r == 1) ? N_FC_VAR-1 : N_FC_VAR;
+
+                  CGPU_LOOP( idx, n_flux_i*n_flux_j )
+                  {
+                     const int i_flux = idx % n_flux_i;
+                     const int j_flux = idx / n_flux_i;
+
+                     int idx_Lfc, idx_Rfc;
+                     if ( d_r < 2 ) {
+                        idx_Lfc = IDX321( i_flux, j_flux, k_fc,   N_FC_VAR, N_FC_VAR );
+                        idx_Rfc = idx_Lfc + didx_FC[d_r];
+                     } else {
+                        idx_Lfc = IDX321( i_flux, j_flux, k_fc-1, N_FC_VAR, N_FC_VAR );
+                        idx_Rfc = IDX321( i_flux, j_flux, k_fc,   N_FC_VAR, N_FC_VAR );
+                     }
+
+                     real ConVar_L[NCOMP_TOTAL_PLUS_MAG], ConVar_R[NCOMP_TOTAL_PLUS_MAG], Flux_1F[NCOMP_TOTAL_PLUS_MAG];
+                     for (int v=0; v<NCOMP_TOTAL_PLUS_MAG; v++) {
+                        ConVar_L[v] = g_FC_Var_1PG[faceR][v][idx_Lfc];
+                        ConVar_R[v] = g_FC_Var_1PG[faceL][v][idx_Rfc];
+                     }
+
+#                    if   ( RSOLVER == EXACT )
+                     Hydro_RiemannSolver_Exact( d_r, Flux_1F, ConVar_L, ConVar_R, MinDens, MinPres, PassiveFloor,
+                                                EoS.DensEint2Pres_FuncPtr, EoS.DensPres2CSqr_FuncPtr,
+                                                EoS.AuxArrayDevPtr_Flt, EoS.AuxArrayDevPtr_Int, EoS.Table );
+#                    elif ( RSOLVER == ROE )
+                     Hydro_RiemannSolver_Roe( d_r, Flux_1F, ConVar_L, ConVar_R, MinDens, MinPres, PassiveFloor,
+                                              EoS.DensEint2Pres_FuncPtr, EoS.DensPres2CSqr_FuncPtr,
+                                              EoS.AuxArrayDevPtr_Flt, EoS.AuxArrayDevPtr_Int, EoS.Table );
+#                    elif ( RSOLVER == HLLE )
+                     Hydro_RiemannSolver_HLLE( d_r, Flux_1F, ConVar_L, ConVar_R, MinDens, MinPres, PassiveFloor,
+                                               EoS.DensEint2Pres_FuncPtr, EoS.DensPres2CSqr_FuncPtr,
+                                               EoS.GuessHTilde_FuncPtr, EoS.HTilde2Temp_FuncPtr,
+                                               EoS.AuxArrayDevPtr_Flt, EoS.AuxArrayDevPtr_Int, EoS.Table );
+#                    elif ( RSOLVER == HLLC )
+                     Hydro_RiemannSolver_HLLC( d_r, Flux_1F, ConVar_L, ConVar_R, MinDens, MinPres, PassiveFloor,
+                                               EoS.DensEint2Pres_FuncPtr, EoS.DensPres2CSqr_FuncPtr,
+                                               EoS.GuessHTilde_FuncPtr, EoS.HTilde2Temp_FuncPtr,
+                                               EoS.AuxArrayDevPtr_Flt, EoS.AuxArrayDevPtr_Int, EoS.Table );
+#                    else
+#                    error : unsupported Riemann solver in k-slab path
+#                    endif
+
+#                    if ( RSOLVER_RESCUE != OPTION_NONE )
+                     for (int v=0; v<NCOMP_TOTAL_PLUS_MAG; v++) {
+                        if ( Flux_1F[v] != Flux_1F[v] ) {
+#                          if   ( RSOLVER_RESCUE == EXACT )
+                           Hydro_RiemannSolver_Exact( d_r, Flux_1F, ConVar_L, ConVar_R, MinDens, MinPres, PassiveFloor,
+                                                      EoS.DensEint2Pres_FuncPtr, EoS.DensPres2CSqr_FuncPtr,
+                                                      EoS.AuxArrayDevPtr_Flt, EoS.AuxArrayDevPtr_Int, EoS.Table );
+#                          elif ( RSOLVER_RESCUE == ROE )
+                           Hydro_RiemannSolver_Roe( d_r, Flux_1F, ConVar_L, ConVar_R, MinDens, MinPres, PassiveFloor,
+                                                    EoS.DensEint2Pres_FuncPtr, EoS.DensPres2CSqr_FuncPtr,
+                                                    EoS.AuxArrayDevPtr_Flt, EoS.AuxArrayDevPtr_Int, EoS.Table );
+#                          elif ( RSOLVER_RESCUE == HLLE )
+                           Hydro_RiemannSolver_HLLE( d_r, Flux_1F, ConVar_L, ConVar_R, MinDens, MinPres, PassiveFloor,
+                                                     EoS.DensEint2Pres_FuncPtr, EoS.DensPres2CSqr_FuncPtr,
+                                                     EoS.GuessHTilde_FuncPtr, EoS.HTilde2Temp_FuncPtr,
+                                                     EoS.AuxArrayDevPtr_Flt, EoS.AuxArrayDevPtr_Int, EoS.Table );
+#                          elif ( RSOLVER_RESCUE == HLLC )
+                           Hydro_RiemannSolver_HLLC( d_r, Flux_1F, ConVar_L, ConVar_R, MinDens, MinPres, PassiveFloor,
+                                                     EoS.DensEint2Pres_FuncPtr, EoS.DensPres2CSqr_FuncPtr,
+                                                     EoS.GuessHTilde_FuncPtr, EoS.HTilde2Temp_FuncPtr,
+                                                     EoS.AuxArrayDevPtr_Flt, EoS.AuxArrayDevPtr_Int, EoS.Table );
+#                          endif
+                           break;
+                        }
+                     }
+#                    endif // RSOLVER_RESCUE
+
+                     const int ij = j_flux*N_FC_VAR + i_flux;
+                     for (int v=0; v<NCOMP_TOTAL; v++) {
+                        if      ( d_r == 0 ) s_FluxX[pp][v][ij] = Flux_1F[v];
+                        else if ( d_r == 1 ) s_FluxY[pp][v][ij] = Flux_1F[v];
+                        else                 s_FluxZ[pp][v][ij] = Flux_1F[v];
+                     }
+                  } // CGPU_LOOP Riemann d_r
+               } // for d_r = 0..2
+
+               __syncthreads();
+
+//             step 2: TGrad at k_out = k_fc-1 (deferred by 1 to allow z-flux at k_fc-1/k_fc boundary)
+//             convention: s_FluxX/Y[pq] = x/y-fluxes at k_out; s_FluxZ[pp]/[pq] = z-fluxes at interfaces k_out/k_out+1 and k_out-1/k_out
+               if ( k_fc >= 1 )
+               {
+                  const int k_out = k_fc - 1;
+
+                  for (int d=0; d<3; d++)
+                  {
+                     const int faceL = 2*d;
+                     const int faceR = faceL + 1;
+
+                     int nskip_i, nskip_j, nskip_k;
+                     switch (d) {
+                        case 0:  nskip_i=0; nskip_j=1; nskip_k=1;  break;
+                        case 1:  nskip_i=1; nskip_j=0; nskip_k=1;  break;
+                        default: nskip_i=1; nskip_j=1; nskip_k=0;  break;
+                     }
+
+                     if ( k_out < nskip_k  ||  k_out >= N_FC_VAR - nskip_k )   continue;
+
+                     const int size_i = N_FC_VAR - 2*nskip_i;
+                     const int size_j = N_FC_VAR - 2*nskip_j;
+
+                     CGPU_LOOP( idx_ij, size_i*size_j )
+                     {
+                        const int i_fc   = idx_ij % size_i + nskip_i;
+                        const int j_fc   = idx_ij / size_i + nskip_j;
+                        const int idx_fc = IDX321( i_fc, j_fc, k_out, N_FC_VAR, N_FC_VAR );
+                        const int ij     = j_fc*N_FC_VAR + i_fc;
+
+                        real fc[2][NCOMP_TOTAL_PLUS_MAG];
+                        for (int v=0; v<NCOMP_TOTAL_PLUS_MAG; v++) {
+                           fc[0][v] = g_FC_Var_1PG[faceL][v][idx_fc];
+                           fc[1][v] = g_FC_Var_1PG[faceR][v][idx_fc];
+                        }
+
+                        for (int v=0; v<NCOMP_TOTAL; v++) {
+                           real TGrad1, TGrad2;
+                           switch (d) {
+                           case 0:   // TDir1=y, TDir2=z
+                              TGrad1 = s_FluxY[pq][v][ij]                         - s_FluxY[pq][v][(j_fc-1)*N_FC_VAR+i_fc];
+                              TGrad2 = s_FluxZ[pp][v][ij]                         - s_FluxZ[pq][v][ij];
+                              break;
+                           case 1:   // TDir1=z, TDir2=x
+                              TGrad1 = s_FluxZ[pp][v][ij]                         - s_FluxZ[pq][v][ij];
+                              TGrad2 = s_FluxX[pq][v][ij]                         - s_FluxX[pq][v][j_fc*N_FC_VAR+(i_fc-1)];
+                              break;
+                           default:  // TDir1=x, TDir2=y
+                              TGrad1 = s_FluxX[pq][v][ij]                         - s_FluxX[pq][v][j_fc*N_FC_VAR+(i_fc-1)];
+                              TGrad2 = s_FluxY[pq][v][ij]                         - s_FluxY[pq][v][(j_fc-1)*N_FC_VAR+i_fc];
+                              break;
+                           }
+                           const real Correct = -dt_dh2 * ( TGrad1 + TGrad2 );
+                           fc[0][v] += Correct;
+                           fc[1][v] += Correct;
+                        }
+
+                        for (int f=0; f<2; f++) {
+                           fc[f][0] = FMAX( fc[f][0], MinDens );
+                           fc[f][4] = Hydro_CheckMinEintInEngy( fc[f][0], fc[f][1], fc[f][2], fc[f][3],
+                                                                 fc[f][4], MinEint, PassiveFloor, NULL_REAL );
+#                          if ( NCOMP_PASSIVE > 0 )
+                           for (int v=NCOMP_FLUID; v<NCOMP_TOTAL; v++)
+                              if ( PassiveFloor & BIDX(v) )
+                                 fc[f][v] = FMAX( fc[f][v], TINY_NUMBER );
+#                          endif
+                        }
+
+                        for (int v=0; v<NCOMP_TOTAL_PLUS_MAG; v++) {
+                           g_FC_Var_1PG[faceL][v][idx_fc] = fc[0][v];
+                           g_FC_Var_1PG[faceR][v][idx_fc] = fc[1][v];
+                        }
+                     } // CGPU_LOOP TGrad
+                  } // for d = 0..2
+               } // if k_fc >= 1
+
+               __syncthreads();
+
+            } // for k_fc = 0..N_FC_VAR-1
+
+//          post-loop: TGrad d=2 at k_out = N_FC_VAR-1 (d=0,1 skip due to nskip_k=1)
+            {
+               const int pp_last = (N_FC_VAR-1) & 1;   // = 1 for N_FC_VAR=18
+               const int k_out   = N_FC_VAR - 1;
+
+               CGPU_LOOP( idx_ij, SQR(N_FC_VAR-2) )
+               {
+                  const int i_fc   = idx_ij % (N_FC_VAR-2) + 1;
+                  const int j_fc   = idx_ij / (N_FC_VAR-2) + 1;
+                  const int idx_fc = IDX321( i_fc, j_fc, k_out, N_FC_VAR, N_FC_VAR );
+                  const int ij     = j_fc*N_FC_VAR + i_fc;
+
+                  real fc[2][NCOMP_TOTAL_PLUS_MAG];
+                  for (int v=0; v<NCOMP_TOTAL_PLUS_MAG; v++) {
+                     fc[0][v] = g_FC_Var_1PG[4][v][idx_fc];
+                     fc[1][v] = g_FC_Var_1PG[5][v][idx_fc];
+                  }
+
+                  for (int v=0; v<NCOMP_TOTAL; v++) {
+                     const real TGrad1 = s_FluxX[pp_last][v][ij] - s_FluxX[pp_last][v][j_fc*N_FC_VAR+(i_fc-1)];
+                     const real TGrad2 = s_FluxY[pp_last][v][ij] - s_FluxY[pp_last][v][(j_fc-1)*N_FC_VAR+i_fc];
+                     const real Correct = -dt_dh2 * ( TGrad1 + TGrad2 );
+                     fc[0][v] += Correct;
+                     fc[1][v] += Correct;
+                  }
+
+                  for (int f=0; f<2; f++) {
+                     fc[f][0] = FMAX( fc[f][0], MinDens );
+                     fc[f][4] = Hydro_CheckMinEintInEngy( fc[f][0], fc[f][1], fc[f][2], fc[f][3],
+                                                           fc[f][4], MinEint, PassiveFloor, NULL_REAL );
+#                    if ( NCOMP_PASSIVE > 0 )
+                     for (int v=NCOMP_FLUID; v<NCOMP_TOTAL; v++)
+                        if ( PassiveFloor & BIDX(v) )
+                           fc[f][v] = FMAX( fc[f][v], TINY_NUMBER );
+#                    endif
+                  }
+
+                  for (int v=0; v<NCOMP_TOTAL_PLUS_MAG; v++) {
+                     g_FC_Var_1PG[4][v][idx_fc] = fc[0][v];
+                     g_FC_Var_1PG[5][v][idx_fc] = fc[1][v];
+                  }
+               }
+               __syncthreads();
+            } // post-loop TGrad d=2
+
+         } // k-slab block
+
+#        else // !( defined __CUDACC__  &&  !defined MHD ): CPU or MHD — standard path
 
 //       2. evaluate the face-centered half-step fluxes by solving the Riemann problem
          Hydro_ComputeFlux( g_FC_Var_1PG, g_FC_Flux_1PG, N_HF_FLUX, 0, 0, CorrHalfVel_No,
@@ -290,6 +950,8 @@ void CPU_FluidSolver_CTU(
 //       4. correct the face-centered variables by the transverse flux gradients
          Hydro_TGradientCorrection( g_FC_Var_1PG, g_FC_Flux_1PG, g_Mag_Array_In[P], g_FC_Mag_Half_1PG, g_EC_Ele_1PG, g_PriVar_1PG,
                                     dt, dh, MinDens, MinEint, PassiveFloor );
+
+#        endif // #if ( defined __CUDACC__  &&  !defined MHD )
 
 
 //       5. evaluate the cell-centered primitive variables at the half time-step


### PR DESCRIPTION
# Quick fact

This PR slashes the duration of CTU kernel by 44%.

# Benchmark
- Test problem: default blast wave (non-MHD)
- Model: HYDRO/CTU/PPM/HLLC, single precision
- GPU: NVIDIA GeForce RTX 2080 SUPER (sm_75)

## Nsight compute:

| CUDA kernel | Baseline (1 kernel) | New approach (2 kernels) | Δ |
|---|---|---|---|
| `CUFLU_DR_FCVar` | — | 0.426 ms | — |
| `CUFLU_FluidSolver_CTU` | 1.97 ms  | 0.682 ms | — |
| Total pipeline | 1.97 ms | 1.109 ms | **−44%** |


- Parallelism: 1 MPI rank × 16 OpenMP threads, 1 GPU
- Initialization: restart from `Data_000004` (step 53, ensuring enough kernel launches for `--launch-skip 400`)
- Maximum refinement level: 6

## GAMER's profiler:



|                       | Baseline  | New approach |    Δ     |
|:---------------------:|:---------:|:------------:|:--------:|
|    Overall performance (`Perf_Overall`)     |    1.32e+08       |   1.63e+08           |  **+23.5%**        |
| Accumulated `Flu_Adv` | 1228.11 s |   923.74 s   | **-24%** |
|   Accumulated `dt`    | 230.41 s  |   232.32 s   |   0.8%   |


- Parallelism: 4 MPI ranks × 8 OpenMP threads, 2 nodes × 1 GPU each
- Initialization: fresh start (`OPT__INIT=1`)
- Run length: physics time 0 to 5e-3
- Maximum refinement level: 6

# Validation
* Only HYDRO with single precision is optimized, all others remains unaffected. This is becasue HYDRO with double precision requires at least 94.6 KB shmem, exceeding the 64KB available on sm_75, let alone MHD, which requires more shmem.
* All 8 configurations are bit identical to their respective baselines.

| Model | GPU | sizeof(real) | Baseline total | New total | Δ total    | Baseline Flu_Adv | New Flu_Adv | Δ Flu_Adv  | Bitwise comparison |
| ----- |:---:|:------------:| -------------- | --------- | ---------- | ---------------- | ----------- | ---------- | ------------------ |
| HYDRO |  x  |      4       | 881.6 s        | 869.8 s   | −1.3%      | 844.0 s          | 831.8 s     | −1.4%      | Bit identical      |
| HYDRO |  o  |      4       | 134.8 s        | 111.6 s   | **−17.2%** (including output time) | 96.5 s           | 73.9 s      | **−23.4%** | Bit identical      |
| HYDRO |  x  |      8       | 981.2 s        | 981.2 s   | 0.0%       | 926.4 s          | 926.5 s     | 0.0%       | Bit identical      |
| HYDRO |  o  |      8       | 285.5 s        | 286.7 s   | +0.4%      | 219.6 s          | 222.6 s     | +1.3%      | Bit identical      |
| MHD   |  x  |      4       | 2231.7 s       | 2228.2 s  | −0.2%      | 2176.3 s         | 2176.4 s    | 0.0%       | Bit identical      |
| MHD   |  o  |      4       | 310.4 s        | 311.6 s   | +0.3%      | 255.9 s          | 256.4 s     | +0.2%      | Bit identical      |
| MHD   |  x  |      8       | 2509.8 s       | 2487.5 s  | −0.9%      | 2430.1 s         | 2412.3 s    | −0.7%      | Bit identical      |
| MHD   |  o  |      8       | 759.0 s        | 759.6 s   | +0.1%      | 664.3 s          | 668.3 s     | +0.6%      | Bit identical      |
- Parallelism: 4 MPI ranks × 8 OpenMP threads, 2 nodes × 1 GPU each
- Initialization: fresh start (`OPT__INIT=1`)
- Run length: physics time 0 to 5e-4 (Step:0-11)
- Maximum refinement level: 6


# The bottleneck on baseline
The original `CUFLU_FluidSolver_CTU` is a single kernel handling Con2Pri, PPM slope, face reconstruction, half-step Riemann fluxes, TGrad correction, full-step Riemann fluxes, and conservative update in one thread block. Nsight Compute reveals a bottleneck:
* **~95 MB DRAM roundtrip**
For example, the half-step Riemann solver writes `g_FC_Flux_1PG` to global memory, then immediately reads it back for `Hydro_TGradientCorrection`. Similar goes for `g_PriVar` and `g_Slope_PPM`. These ~95 MB per invocation roundtrip can be largely (all compute capabilities since Fermi) or totally(sm_80, or higher) eliminated by using shmem.
   | Array                   | Dimensions                     | Calculation                  | Per `FLU_GPU_NPGROUP` | Round-trip   |
   | ----------------------- | ------------------------------ | ---------------------------- | --------- | ------------ |
   | `g_Slope_PPM`           | `[3][NCOMP_LR][N_SLOPE_PPM³]`  | 3 × 5 × 20^3 × 4 × 48 / 1024^2 | 22.0 MB  | **43.9 MB** |
   | `g_PriVar`              | `[NCOMP_LR][FLU_NXT³]`         | 5 × 22^3 × 4 × 48 / 1024^2     | 9.7 MB   | **19.5 MB** |
   | `g_FC_Flux` | `[3][NCOMP_TOTAL][N_FC_FLUX³]` | 3 × 5 × 18^3 × 4 × 48 / 1024^2 | 16.0 MB  | **32.0 MB** |
   | **Total eliminated**    |                                |                              |           | **~95 MB**  |
   | `g_FC_Var` (remaining)  | `[6][NCOMP_LR][N_FC_VAR³]`     | 6 × 5 × 18^3 × 4 × 48 / 1024^2 | 32.0 MB  | one-way      |



# The Optimized Pipeline

For this PR (works for all CC since Fermi), I split a sinle kernel into two: `CUFLU_DR_FCVar` (Con2Pri+PPM→`g_FC_Var`) and `CUFLU_FluidSolver_CTU` (`g_FC_Var`→Riemann+TGrad+update), and eliminates DRAM roundtrips as follows:
* **Caculated PPM slope on the fly**
* **Replaced `g_PriVar` with `s_PriVar`, a 5-slot ring buffer on shmem**
The baseline stores primitive variables in `g_PriVar` — a 43.9 MiB DRAM buffer filled by Con2Pri and read back by the reconstruction loop. The replacement is a 5-slot `s_PriVar` ring buffer in shared memory. The reconstruction loop iterates over 18 k-planes; each iteration needs 5 consecutive k-slabs of primitive variables. A naive per-iteration approach would call Con2Pri 18 × 5 = 90 times and read 90 × FLU_NXT^2 cells from `g_Flu_Array_In`. The ring buffer reuses the 4 slabs carried over from the previous step and loads only the one new slab at the leading edge, reducing total slab loads to 22 (4.1×). Before the loop, a one-time prologue fills all 5 slots. The 5 logical roles (k−2 … k+2) map to physical slots by `rs_i = (base + i) % 5`. After face values are computed, the oldest slot is overwritten and `base` advances by 1.
* **Replaced `g_FC_Flux_1PG` with `s_FluxX/Y/Z` on shmem**
For each of the 18 k-planes, the half-step Riemann solver computes x/y/z fluxes and writes them to `g_FC_Flux_1PG` (~16 MB). The TGrad correction then immediately reads them back — a ~32 MB DRAM round-trip per kernel call.
This PR processes one k-plane at a time using two ping-pong shared-memory buffers `s_FluxX/Y/Z[2][NCOMP_TOTAL][18^2]` (38.9 KB total). For plane `k`, fluxes go into slot `pp = k & 1`. TGradient for plane `k−1` reads from the slot just written (`pp`, for the z-flux) and the previous slot `pq` (for x/y fluxes already stored from the prior iteration). The 18-plane round-trip to DRAM is entirely eliminated.

All compute capabilities (CC) from Fermi can benefit from this PR. For GPUs with the CC newer than sm_75, the larger shared memory may even allow us to fuse the currently split kernels and eliminate g_FC_Var entirely. If it works, it may produce a better performance than this PR.
To keep this PR simple, I'd prefer to leave that optimization for the next PR.