### PR TITLE
Prevent the misuse of `amr->patch[Sg=1][lv][PID]->Edge`

### DIFF
--- a/include/AMR.h
+++ b/include/AMR.h
@@ -105,6 +105,7 @@ struct AMR_t
    int    NPatchComma [NLEVEL][28];
    double dh          [NLEVEL];
    int    ResPower2   [NLEVEL];
+   double PosUndef    [3] = { NAN, NAN, NAN };
    double BoxEdgeL    [3];
    double BoxEdgeR    [3];
    double BoxCenter   [3];
@@ -273,7 +274,7 @@ struct AMR_t
          patch[0][lv][NewPID] = new patch_t( scale_x, scale_y, scale_z, FaPID, FluData, MagData, PotData, FluData, lv,
                                              BoxScale, BoxEdgeL, dh[TOP_LEVEL] );
          patch[1][lv][NewPID] = new patch_t(       0,       0,       0,    -1, FluData, MagData, PotData,   false, lv,
-                                             BoxScale, BoxEdgeL, dh[TOP_LEVEL] );
+                                             BoxScale, PosUndef, dh[TOP_LEVEL] );   // the patch edge of patch[1] should not be used
       }
 
 //    reactivate inactive patches
@@ -296,7 +297,7 @@ struct AMR_t
          patch[0][lv][NewPID]->Activate( scale_x, scale_y, scale_z, FaPID, FluData, MagData, PotData, FluData, lv,
                                          BoxScale, BoxEdgeL, dh[TOP_LEVEL], InitPtrAsNull_No );
          patch[1][lv][NewPID]->Activate(       0,       0,       0,    -1, FluData, MagData, PotData,   false, lv,
-                                         BoxScale, BoxEdgeL, dh[TOP_LEVEL], InitPtrAsNull_No );
+                                         BoxScale, PosUndef, dh[TOP_LEVEL], InitPtrAsNull_No );   // the patch edge of patch[1] should not be used
       } // if ( patch[0][lv][NewPID] == NULL ) ... else ...
 
       num[lv] ++;


### PR DESCRIPTION
## Motivation
When we need the coordinates of a cell or a patch in the calculation, we usually use `amr->patch[0][lv][PID]->EdgeL[0/1/2]` to get the left edge of a given patch.
During development, one may accidentally use `amr->patch[1][lv][PID]->EdgeL[0/1/2]`, especially when `FluSg = 1` in the context. But `amr->patch[1][lv][PID]->EdgeL[0/1/2]` does not store the correct patch edges and should not be used anyway.
What is worse is that `amr->patch[1][lv][PID]->EdgeL[0/1/2]` is currently initialized to `0.0`. It may still lead to cell coordinates with positive values from `EdgeL+(i+0.5)*dh`. There is no error, and the coordinates may look normal at first glance; thus, the misuse is hard to identify during debugging.

## Changes
Provide `NaN` for `BoxEdgeL` when activating patches with `Sg=1`, so the patch edges will also be stored as `NaN`.
We hope this helps developers find earlier that the coordinates are problematic when `amr->patch[1][lv][PID]->EdgeL[0/1/2]` is used.

(An error returned when misused would be better, but currently I am not sure how; Any suggestion will be appreciated)

## Checks
One can print `amr->patch[1][lv][PID]->EdgeL[0]` in, for example, the `for (int PID=PID0; PID<PID0+8; PID++)` loop inside `Aux_Check_Conservation()`,  `src/Auxiliary/Aux_Check_Conservation.cpp`. It should become `nan`.