### PR TITLE
Set `Grackle_tempFloor_User_Ptr` to `NULL` by default and add missing pointers in the template

### DIFF
--- a/src/Grackle/Grackle_Prepare.cpp
+++ b/src/Grackle/Grackle_Prepare.cpp
@@ -30,13 +30,13 @@ extern int CheIdx_tempFloor;
 // declare as static so that other functions cannot invoke it directly and must use the function pointer
 static real_che Grackle_vHeatingRate_User_Template( const double x, const double y, const double z, const double Time, const double n_H );
 static real_che Grackle_sHeatingRate_User_Template( const double x, const double y, const double z, const double Time );
-static real_che Grackle_tempFloor_Default( const double x, const double y, const double z, const double Time, const real_che Dens_Gas, const real_che sEint_Gas );
+static real_che Grackle_tempFloor_User_Template( const double x, const double y, const double z, const double Time, const real_che Dens_Gas, const real_che sEint_Gas );
 
 
 // these function pointers must be set by a test problem initializer
 real_che (*Grackle_vHeatingRate_User_Ptr)( const double x, const double y, const double z, const double Time, const double n_H ) = NULL;
 real_che (*Grackle_sHeatingRate_User_Ptr)( const double x, const double y, const double z, const double Time )                   = NULL;
-real_che (*Grackle_tempFloor_User_Ptr)( const double x, const double y, const double z, const double Time, const real_che Dens_Gas, const real_che sEint_Gas ) = Grackle_tempFloor_Default;
+real_che (*Grackle_tempFloor_User_Ptr)( const double x, const double y, const double z, const double Time, const real_che Dens_Gas, const real_che sEint_Gas ) = NULL;
 
 
 
@@ -470,8 +470,8 @@ static real_che Grackle_sHeatingRate_User_Template( const double x, const double
 
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  Grackle_tempFloor_Default
-// Description :  Default function to set Grackle's temperature floor
+// Function    :  Grackle_tempFloor_User_Template
+// Description :  Function template to set Grackle's temperature floor
 //
 // Note        :  1. Invoked by Grackle_Prepare() using the function pointer
 //                   "Grackle_tempFloor_User_Ptr", which can be reset by a test problem initializer
@@ -486,13 +486,13 @@ static real_che Grackle_sHeatingRate_User_Template( const double x, const double
 //
 // Return      :  temperature_floor
 //-------------------------------------------------------------------------------------------------------
-static real_che Grackle_tempFloor_Default( const double x, const double y, const double z, const double Time, const real_che Dens_Gas, const real_che sEint_Gas )
+static real_che Grackle_tempFloor_User_Template( const double x, const double y, const double z, const double Time, const real_che Dens_Gas, const real_che sEint_Gas )
 {
    const real_che temperature_floor = 0.0;
 
    return temperature_floor;
 
-} // FUNCTION : Grackle_tempFloor_Default
+} // FUNCTION : Grackle_tempFloor_User_Template
 
 
 

--- a/src/TestProblem/Template/Init_TestProb_Template.cpp
+++ b/src/TestProblem/Template/Init_TestProb_Template.cpp
@@ -324,7 +324,11 @@ void Init_TestProb_Template()
    BC_User_Ptr                       = NULL; // option: OPT__BC_FLU_*=4;              example: TestProblem/ELBDM/ExtPot/Init_TestProb_ELBDM_ExtPot.cpp --> BC()
 #  ifdef MHD
    BC_BField_User_Ptr                = NULL; // option: OPT__BC_FLU_*=4;
+   MHD_ResetByUser_BField_Ptr        = NULL; // option: OPT__RESET_FLUID;             example: Model_Hydro/MHD_ResetByUser.cpp
+   MHD_ResetByUser_VecPot_Ptr        = NULL; // option: OPT__RESET_FLUID;             example: Model_Hydro/MHD_ResetByUser.cpp
 #  endif
+// comment out Flu_ResetByUser_API_Ptr to use the default
+// Flu_ResetByUser_API_Ptr           = NULL; // option: OPT__RESET_FLUID;             example: Fluid/Flu_ResetByUser.cpp
    Flu_ResetByUser_Func_Ptr          = NULL; // option: OPT__RESET_FLUID;             example: Fluid/Flu_ResetByUser.cpp
    Init_DerivedField_User_Ptr        = NULL; // option: OPT__OUTPUT_USER_FIELD;       example: Fluid/Flu_DerivedField_User.cpp
    Output_User_Ptr                   = NULL; // option: OPT__OUTPUT_USER;             example: TestProblem/Hydro/AcousticWave/Init_TestProb_Hydro_AcousticWave.cpp --> OutputError()
@@ -349,6 +353,11 @@ void Init_TestProb_Template()
 #  if ( EOS == EOS_USER )
    EoS_Init_Ptr                      = NULL; // option: EOS in the Makefile;          example: EoS/User_Template/CPU_EoS_User_Template.cpp
    EoS_End_Ptr                       = NULL;
+#  endif
+#  ifdef SUPPORT_GRACKLE
+   Grackle_vHeatingRate_User_Ptr     = NULL; // option: GRACKLE_USE_V_HEATING_RATE;   example: Grackle/Grackle_Prepare.cpp
+   Grackle_sHeatingRate_User_Ptr     = NULL; // option: GRACKLE_USE_S_HEATING_RATE;   example: Grackle/Grackle_Prepare.cpp
+   Grackle_tempFloor_User_Ptr        = NULL; // option: GRACKLE_USE_TEMP_FLOOR=2;     example: Grackle/Grackle_Prepare.cpp
 #  endif
 #  endif // #if ( MODEL == HYDRO )
    Src_Init_User_Ptr                 = NULL; // option: SRC_USER;                     example: SourceTerms/User_Template/CPU_Src_User_Template.cpp


### PR DESCRIPTION
## Goal
When `GRACKLE_USE_TEMP_FLOOR` is set to `2` but the user-defined function is not linked to the function pointer successfully, the simulation can still run but simply uses the default temperature floor function, which has no effect. This may confuse the users.
This PR is to prevent the default temperature floor function from being used unnoticed.

## Changes
- Initialize `Grackle_tempFloor_User_Ptr` to `NULL` by default, so users must set its function pointer in the test problem if `GRACKLE_USE_TEMP_FLOOR == 2`.
- Add some missing user function pointers in the test problem template.